### PR TITLE
Bump eslint version 0.15.0 -> 0.16.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,7 @@
         "node": true
     },
     ecmaFeatures: {
+        globalReturn: false,
         jsx: true
     },
     "globals": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "bugs": "https://github.com/yannickcr/eslint-plugin-react/issues",
   "devDependencies": {
     "coveralls": "2.11.2",
-    "eslint": "0.15.0",
+    "eslint": "0.16.0",
     "eslint-tester": "0.6.0",
     "istanbul": "0.3.6",
     "mocha": "2.1.0"


### PR DESCRIPTION
This new version of eslint contains many improvements, including better
support for ES6 features. The full changelog can be found at:

  https://github.com/eslint/eslint/blob/master/CHANGELOG.md

With this change, I ran into an issue that was causing the tests to
pass. Lots of errors like:

> 10:12  error  "fs" used outside of binding context  block-scoped-var

It appears that this is an open issue with 0.16.0 that can be worked
around by setting `globalReturn` to `false` in the `.eslintrc` file.
More information:

  https://github.com/eslint/eslint/issues/1969