### PR TITLE
Sort rules alphabetically in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,32 +42,32 @@ Finally, enable all of the rules that you would like to use.
 ```json
 {
   "rules": {
-    "react/no-multi-comp": 1,
-    "react/prop-types": 1,
     "react/display-name": 1,
-    "react/wrap-multilines": 1,
-    "react/self-closing-comp": 1,
-    "react/no-did-mount-set-state": 1,
-    "react/no-did-update-set-state": 1,
     "react/jsx-uses-react": 1,
     "react/jsx-uses-vars": 1,
-    "react/react-in-jsx-scope": 1
+    "react/no-did-mount-set-state": 1,
+    "react/no-did-update-set-state": 1,
+    "react/no-multi-comp": 1,
+    "react/prop-types": 1,
+    "react/react-in-jsx-scope": 1,
+    "react/self-closing-comp": 1,
+    "react/wrap-multilines": 1
   }
 }
 ```
 
 # List of supported rules
 
-* [no-multi-comp](docs/rules/no-multi-comp.md): Prevent multiple component definition per file
-* [prop-types](docs/rules/prop-types.md): Prevent missing props validation in a React component definition
 * [display-name](docs/rules/display-name.md): Prevent missing displayName in a React component definition
-* [wrap-multilines](docs/rules/wrap-multilines.md): Prevent missing parentheses around multilines JSX
-* [self-closing-comp](docs/rules/self-closing-comp.md): Prevent extra closing tags for components without children
-* [no-did-mount-set-state](docs/rules/no-did-mount-set-state.md): Prevent usage of setState in componentDidMount
-* [no-did-update-set-state](docs/rules/no-did-update-set-state.md): Prevent usage of setState in componentDidUpdate
 * [jsx-uses-react](docs/rules/jsx-uses-react.md): Prevent React to be incorrectly marked as unused
 * [jsx-uses-vars](docs/rules/jsx-uses-vars.md): Prevent variables used in JSX to be incorrectly marked as unused
+* [no-did-mount-set-state](docs/rules/no-did-mount-set-state.md): Prevent usage of setState in componentDidMount
+* [no-did-update-set-state](docs/rules/no-did-update-set-state.md): Prevent usage of setState in componentDidUpdate
+* [no-multi-comp](docs/rules/no-multi-comp.md): Prevent multiple component definition per file
+* [prop-types](docs/rules/prop-types.md): Prevent missing props validation in a React component definition
 * [react-in-jsx-scope](docs/rules/react-in-jsx-scope.md): Prevent missing React when using JSX
+* [self-closing-comp](docs/rules/self-closing-comp.md): Prevent extra closing tags for components without children
+* [wrap-multilines](docs/rules/wrap-multilines.md): Prevent missing parentheses around multilines JSX
 
 ## To Do
 


### PR DESCRIPTION
Sorting these alphabetically makes it easier to find what you are
looking for, and provides a simple and clear order for new items to be
added to the list.