### PR TITLE
Allow this.getState references (not calls) in lifecycle methods.

### DIFF
--- a/lib/rules/no-did-mount-set-state.js
+++ b/lib/rules/no-did-mount-set-state.js
@@ -16,16 +16,20 @@ module.exports = function(context) {
 
   return {
 
-    'MemberExpression': function(node) {
-      if (node.object.type !== 'ThisExpression' || node.property.name !== 'setState') {
+    'CallExpression': function(node) {
+      var callee = node.callee;
+      if (callee.type !== 'MemberExpression') {
         return;
       }
-      var ancestors = context.getAncestors(node);
+      if (callee.object.type !== 'ThisExpression' || callee.property.name !== 'setState') {
+        return;
+      }
+      var ancestors = context.getAncestors(callee);
       for (var i = 0, j = ancestors.length; i < j; i++) {
         if (ancestors[i].type !== 'Property' || ancestors[i].key.name !== 'componentDidMount') {
           continue;
         }
-        context.report(node, 'Do not use setState in componentDidMount');
+        context.report(callee, 'Do not use setState in componentDidMount');
       }
     }
   };

--- a/lib/rules/no-did-update-set-state.js
+++ b/lib/rules/no-did-update-set-state.js
@@ -16,16 +16,20 @@ module.exports = function(context) {
 
   return {
 
-    'MemberExpression': function(node) {
-      if (node.object.type !== 'ThisExpression' || node.property.name !== 'setState') {
+    'CallExpression': function(node) {
+      var callee = node.callee;
+      if (callee.type !== 'MemberExpression') {
         return;
       }
-      var ancestors = context.getAncestors(node);
+      if (callee.object.type !== 'ThisExpression' || callee.property.name !== 'setState') {
+        return;
+      }
+      var ancestors = context.getAncestors(callee);
       for (var i = 0, j = ancestors.length; i < j; i++) {
         if (ancestors[i].type !== 'Property' || ancestors[i].key.name !== 'componentDidUpdate') {
           continue;
         }
-        context.report(node, 'Do not use setState in componentDidUpdate');
+        context.report(callee, 'Do not use setState in componentDidUpdate');
       }
     }
   };

--- a/tests/lib/rules/no-did-mount-set-state.js
+++ b/tests/lib/rules/no-did-mount-set-state.js
@@ -40,6 +40,19 @@ eslintTester.addRuleTest('lib/rules/no-did-mount-set-state', {
             ecmaFeatures: {
               jsx: true
             }
+        }, {
+            code: '\
+              var Hello = React.createClass({\
+                componentDidMount: function() {\
+                  this.someHandler = this.setState;\
+                },\
+                render: function() {\
+                  return <div>Hello {this.props.name}</div>;\
+                }\
+              });',
+            ecmaFeatures: {
+              jsx: true
+            }
         }
     ],
 

--- a/tests/lib/rules/no-did-mount-set-state.js
+++ b/tests/lib/rules/no-did-mount-set-state.js
@@ -44,6 +44,7 @@ eslintTester.addRuleTest('lib/rules/no-did-mount-set-state', {
             code: '\
               var Hello = React.createClass({\
                 componentDidMount: function() {\
+                  someNonMemberFunction(arg);\
                   this.someHandler = this.setState;\
                 },\
                 render: function() {\

--- a/tests/lib/rules/no-did-update-set-state.js
+++ b/tests/lib/rules/no-did-update-set-state.js
@@ -44,6 +44,7 @@ eslintTester.addRuleTest('lib/rules/no-did-update-set-state', {
             code: '\
               var Hello = React.createClass({\
                 componentDidUpdate: function() {\
+                  someNonMemberFunction(arg);\
                   this.someHandler = this.setState;\
                 },\
                 render: function() {\

--- a/tests/lib/rules/no-did-update-set-state.js
+++ b/tests/lib/rules/no-did-update-set-state.js
@@ -40,6 +40,19 @@ eslintTester.addRuleTest('lib/rules/no-did-update-set-state', {
             ecmaFeatures: {
               jsx: true
             }
+        }, {
+            code: '\
+              var Hello = React.createClass({\
+                componentDidUpdate: function() {\
+                  this.someHandler = this.setState;\
+                },\
+                render: function() {\
+                  return <div>Hello {this.props.name}</div>;\
+                }\
+              });',
+            ecmaFeatures: {
+              jsx: true
+            }
         }
     ],
 


### PR DESCRIPTION
I think this should not be considered an error/warning by this rule: (my actual code follows)
```	
componentDidMount() {
	this.handleStoreEvent = _.compose(this.setState, getStoreState).bind(this);
	dependencies.add(this.handleStoreEvent);
},
```
While I don't know that this is great code per se, it is essentially binding `setState` to a list of Flux stores via a helper (`dependencies`). This seems to me like a valid use of `setState` within `componentDidMount`.

I refactored both rules pertaining to `setState` to respond to `CallExpression` nodes instead of `MemberExpression`, and it returns if the `callee` is not a `MemberExpression`. The original logic follows thereafter.

I can imagine also potentially making this reduction in strength an option, but I believe the behavior here captures the spirit of the rule, and thus an option should not be necessary. 

Submitted for your consideration. 👍