### PR TITLE
Fix prop-types to check for computed prop names.

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -129,7 +129,7 @@ module.exports = function(context) {
   function markPropTypesAsUsed(node) {
     var component = getComponent(node);
     var type;
-    if (node.parent.property && node.parent.property.name) {
+    if (node.parent.property && node.parent.property.name && !node.parent.computed) {
       type = 'direct';
     } else if (
       node.parent.parent.declarations &&

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -84,6 +84,18 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
     }, {
       code: [
         'var Hello = React.createClass({',
+        '  render: function() {',
+        '    var propName = "foo";',
+        '    return <div>Hello World {this.props[propName]}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      ecmaFeatures: {
+        jsx: true
+      }
+    }, {
+      code: [
+        'var Hello = React.createClass({',
         '  propTypes: externalPropTypes,',
         '  render: function() {',
         '    return <div>Hello {this.props.name}</div>;',


### PR DESCRIPTION
Previously, accessing props dynamically with an expression like `this.props[propName]` would result in a linting error like:
> 'propName' is missing in props validation

However "propName" is simply the name of a variable, not the actual property name. Since there's no easy way to resolve the real property name for dynamic accesses like this, this modification simply ignores such cases.