### PR TITLE
Enable jsx-uses-vars rule to WARN by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
     'no-did-mount-set-state': 0,
     'no-did-update-set-state': 0,
     'react-in-jsx-scope': 0,
-    'jsx-uses-vars': 0,
+    'jsx-uses-vars': 1,
     'jsx-no-undef': 0,
     'jsx-quotes': 0,
     'no-unknown-property': 0,

--- a/tests/index.js
+++ b/tests/index.js
@@ -12,6 +12,10 @@ var rules = fs.readdirSync(path.resolve(__dirname, '../lib/rules/'))
     return path.basename(f, '.js');
   });
 
+var defaultSettings = {
+  'jsx-uses-vars': 1
+};
+
 describe('all rule files should be exported by the plugin', function() {
   rules.forEach(function(ruleName) {
     it('should export ' + ruleName, function() {
@@ -20,11 +24,22 @@ describe('all rule files should be exported by the plugin', function() {
         require(path.join('../lib/rules', ruleName))
       );
     });
-    it('should configure ' + ruleName + ' off by default', function() {
-      assert.equal(
-        plugin.rulesConfig[ruleName],
-        0
-      );
-    });
+
+    if (defaultSettings.hasOwnProperty(ruleName)) {
+      var val = defaultSettings[ruleName];
+      it('should configure ' + ruleName + ' to ' + val + ' by default', function() {
+        assert.equal(
+          plugin.rulesConfig[ruleName],
+          val
+        );
+      });
+    } else {
+      it('should configure ' + ruleName + ' off by default', function() {
+        assert.equal(
+          plugin.rulesConfig[ruleName],
+          0
+        );
+      });
+    }
   });
 });


### PR DESCRIPTION
From original issue: "just wondering why jsx-uses-vars wouldn't be turned on by default (maybe to 'warn')? I guess the real question is: what's the use case for not wanting to mark them used?"

Fixes #49