### PR TITLE
fix describing comment for hasSpreadOperator() method

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -82,10 +82,9 @@ module.exports = function(context) {
   }
 
   /**
-   * Checks if the prop is declared
-   * @param {String} name Name of the prop to check.
-   * @param {Object} component The component to process
-   * @returns {Boolean} True if the prop is declared, false if not.
+   * Checks if the prop has spread operator.
+   * @param {ASTNode} node The AST node being marked.
+   * @returns {Boolean} True if the prop has spread operator, false if not.
    */
   function hasSpreadOperator(node) {
     var tokens = context.getTokens(node);


### PR DESCRIPTION
It seems it had been copy-pasted and then forgot.