### PR TITLE
Reproduce error using ES6 imports

### DIFF
--- a/tests/lib/rules/react-in-jsx-scope.js
+++ b/tests/lib/rules/react-in-jsx-scope.js
@@ -26,7 +26,20 @@ eslintTester.addRuleTest('lib/rules/react-in-jsx-scope', {
         {code: 'var React, App, a=1; function elem() { return <App attr={a} />; }', ecmaFeatures: {jsx: true}},
         {code: 'var React, App; <App />;', args: [1, {vars: 'all'}], ecmaFeatures: {globalReturn: true, jsx: true}},
         {code: '/** @jsx Foo */ var Foo, App; <App />;', args: [1, {vars: 'all'}], ecmaFeatures: {jsx: true}},
-        {code: '/** @jsx Foo.Bar */ var Foo, App; <App />;', args: [1, {vars: 'all'}], ecmaFeatures: {jsx: true}}
+        {code: '/** @jsx Foo.Bar */ var Foo, App; <App />;', args: [1, {vars: 'all'}], ecmaFeatures: {jsx: true}},
+        {code: [
+            'import React from \'react/addons\';',
+            'const Button = React.createClass({',
+            '  render() {',
+            '    return (',
+            '      <button {...this.props}>{this.props.children}</button>',
+            '    )',
+            '  }',
+            '});',
+            'export default Button;'
+          ].join('\n'),
+          ecmaFeatures: {blockBindings: true, objectLiteralShorthandMethods: true, modules: true, jsx: true}
+        }
     ],
     invalid: [
         {code: 'var App, a = <App />;',


### PR DESCRIPTION
This is to reproduce the error described here https://github.com/yannickcr/eslint-plugin-react/issues/58, which fails with:

```bash
  152 passing (174ms)
  1 failing

  1) react-in-jsx-scope import React from 'react/addons';
const Button = React.createClass({
  render() {
    return (
      <button {...this.props}>{this.props.children}</button>
    )
  }
});
export default Button;:
     AssertionError: Should have no errors but had 1: [ { ruleId: 'react-in-jsx-scope',
    severity: 1,
    message: '\'React\' must be in scope when using JSX',
    line: 5,
    column: 6,
    nodeType: 'JSXOpeningElement',
    source: '      <button {...this.props}>{this.props.children}</button>' } ]: expected 1 to equal 0
```