### PR TITLE
[fixed] Add mandatory eslint package as peerDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "istanbul": "0.3.13",
     "mocha": "2.2.4"
   },
+  "peerDependencies": {
+    "eslint": ">=0.8.0"
+  },
   "keywords": [
     "eslint-plugin",
     "eslintplugin",


### PR DESCRIPTION
From http://eslint.org/docs/developer-guide/working-with-plugins.html
`To make clear that the plugin requires ESLint to work correctly
you have to declare ESLint as a peerDependency in your package.json`

Just some examples:
https://github.com/theodoreb/eslint-plugin-drupal/blob/v0.3.1/package.json#L22-24
https://github.com/Gillespie59/eslint-plugin-angular/blob/0.0.7/package.json#L30-32
https://github.com/ilyavolodin/eslint-plugin-backbone/blob/v1.0.2/package.json#L19-21
https://github.com/tlvince/eslint-plugin-jasmine/blob/v1.0.0-rc.2/package.json#L6-8