### PR TITLE
Only mark component types as used, not prop names.

### DIFF
--- a/lib/rules/jsx-uses-vars.js
+++ b/lib/rules/jsx-uses-vars.js
@@ -20,8 +20,8 @@ module.exports = function(context) {
       variableUtil.markVariableAsUsed(context, node.expression.name);
     },
 
-    JSXIdentifier: function(node) {
-      variableUtil.markVariableAsUsed(context, node.name);
+    JSXOpeningElement: function(node) {
+      variableUtil.markVariableAsUsed(context, node.name.name);
     }
 
   };

--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -65,7 +65,18 @@ eslintTester.addRuleTest('node_modules/eslint/lib/rules/no-unused-vars', {
   invalid: [
     {
       code: '/*eslint jsx-uses-vars:1*/ var App;',
-      errors: [{message: 'App is defined but never used'}], ecmaFeatures: {jsx: true}
+      errors: [{message: 'App is defined but never used'}],
+      ecmaFeatures: {jsx: true}
+    }, {
+      code: '\
+        /*eslint jsx-uses-vars:1*/\
+        var App;\
+        var unused;\
+        React.render(<App unused=""/>);',
+      errors: [{message: 'unused is defined but never used'}],
+      ecmaFeatures: {
+        jsx: true
+      }
     }
   ]
 });


### PR DESCRIPTION
Previously, all JSX identifiers were marked as "used", even for prop names. This is an issue in cases where component props happened by chance to have the same name as a local variable, like this:

        var App;
        var foo;
        React.render(<App foo="bar"/>);

Here, the "foo" prop prevents the `foo` variable from being marked as unused and ESLint gives no warnings for the `no-unused-vars` rule, even though `foo` is not actually referenced anywhere.

This change updates the `jsx-uses-vars` rule to only mark variables as used if they occur in a `JSXOpeningElement` node (thus excluding prop names, as they exist in `JSXAttribute` nodes instead).