### PR TITLE
adding support for setting the jsx pragma value via config

### DIFF
--- a/docs/rules/jsx-uses-react.md
+++ b/docs/rules/jsx-uses-react.md
@@ -7,6 +7,7 @@ If you are using the @jsx pragma this rule will mark the designated variable and
 
 This rule has no effect if the `no-unused-vars` rule is not enabled.
 
+
 ## Rule Details
 
 The following patterns are considered warnings:
@@ -38,6 +39,27 @@ var Foo = require('foo');
 
 var Hello = <div>Hello {this.props.name}</div>;
 ```
+
+
+## Rule Options
+
+```js
+...
+"jsx-uses-react": [<enabled>, { "pragma": <string> }]
+...
+```
+
+### `pragma`
+
+As an alternative to specifying the above pragma in each source file, you can specify
+this configuration option:
+
+```js
+var Foo = require('Foo');
+
+var Hello = <div>Hello {this.props.name}</div>;
+```
+
 
 ## When Not To Use It
 

--- a/lib/rules/jsx-uses-react.js
+++ b/lib/rules/jsx-uses-react.js
@@ -14,7 +14,8 @@ var JSX_ANNOTATION_REGEX = /^\*\s*@jsx\s+([^\s]+)/;
 
 module.exports = function(context) {
 
-  var id = 'React';
+  var config = context.options[0] || {};
+  var id = config.pragma || 'React';
 
   // --------------------------------------------------------------------------
   // Public

--- a/tests/lib/rules/jsx-uses-react.js
+++ b/tests/lib/rules/jsx-uses-react.js
@@ -22,7 +22,8 @@ eslintTester.addRuleTest('node_modules/eslint/lib/rules/no-unused-vars', {
     valid: [
         {code: '/*eslint jsx-uses-react:1*/ var React; <div />;', ecmaFeatures: {jsx: true}},
         {code: '/*eslint jsx-uses-react:1*/ var React; (function () { <div /> })();', ecmaFeatures: {jsx: true}},
-        {code: '/*eslint jsx-uses-react:1*/ /** @jsx Foo */ var Foo; <div />;', ecmaFeatures: {jsx: true}}
+        {code: '/*eslint jsx-uses-react:1*/ /** @jsx Foo */ var Foo; <div />;', ecmaFeatures: {jsx: true}},
+        {code: '/*eslint jsx-uses-react:[1,{"pragma":"Foo"}]*/ var Foo; <div />;', ecmaFeatures: {jsx: true}}
     ],
     invalid: [
         {code: '/*eslint jsx-uses-react:1*/ var React;',


### PR DESCRIPTION
This fixes #80 

Instead of taking the approach mentioned there, this turned out to be far less complicated, it basically adds a second config option to the `react/jsx-uses-react` rule:

```js
[ 2, 'dom' ]
```

This causes `dom` to be used in place of `React` as the used variable. I've also included a test and updated the docs for the aforementioned rule.

Let me know if there's anything else we need to do to get this merged! :D