### PR TITLE
Fix license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,10 +39,5 @@
     "eslint",
     "react"
   ],
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.github.com/yannickcr/eslint-plugin-react/master/LICENSE"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
So `npm` stops complaining: `npm WARN package.json eslint-plugin-react@2.3.0 No license field.`. See https://docs.npmjs.com/files/package.json#license.