### PR TITLE
Make wrap-multilines more granular

### DIFF
--- a/docs/rules/wrap-multilines.md
+++ b/docs/rules/wrap-multilines.md
@@ -1,6 +1,6 @@
-# Prevent missing parentheses around multilines JSX (wrap-multilines)
+# Prevent missing parentheses around multiline JSX (wrap-multilines)
 
-Wrapping multilines JSX in parentheses can improve readability and/or convenience.
+Wrapping multiline JSX in parentheses can improve readability and/or convenience. It optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, `"declaration"`, `"assignment"`, and `"return"` syntax is checked, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior (become enabled).
 
 ## Rule Details
 
@@ -30,4 +30,15 @@ var Hello = React.createClass({
     );
   }
 });
+
+// When [1, {declaration: false}]
+var hello;
+hello = <div>
+  <p>Hello</p>
+</div>
+
+// When [1, {declaration: true, assignment: false, return: true}]
+var world = <div>
+  <p>World</p>
+</div>
 ```

--- a/lib/rules/wrap-multilines.js
+++ b/lib/rules/wrap-multilines.js
@@ -5,6 +5,16 @@
 'use strict';
 
 // ------------------------------------------------------------------------------
+// Constants
+// ------------------------------------------------------------------------------
+
+var DEFAULTS = {
+  declaration: true,
+  assignment: true,
+  return: true
+};
+
+// ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
@@ -33,6 +43,14 @@ module.exports = function(context) {
     }
   }
 
+  function isEnabled(type) {
+    var userOptions = context.options[0] || {};
+    if (({}).hasOwnProperty.call(userOptions, type)) {
+      return userOptions[type];
+    }
+    return DEFAULTS[type];
+  }
+
   // --------------------------------------------------------------------------
   // Public
   // --------------------------------------------------------------------------
@@ -40,16 +58,31 @@ module.exports = function(context) {
   return {
 
     VariableDeclarator: function(node) {
-      check(node.init);
+      if (isEnabled('declaration')) {
+        check(node.init);
+      }
     },
 
     AssignmentExpression: function(node) {
-      check(node.right);
+      if (isEnabled('assignment')) {
+        check(node.right);
+      }
     },
 
     ReturnStatement: function(node) {
-      check(node.argument);
+      if (isEnabled('return')) {
+        check(node.argument);
+      }
     }
   };
 
 };
+
+module.exports.schema = [{
+  type: 'object',
+  properties: {
+    declaration: {type: 'boolean'},
+    assignment: {type: 'boolean'},
+    return: {type: 'boolean'}
+  }
+}];

--- a/tests/lib/rules/wrap-multilines.js
+++ b/tests/lib/rules/wrap-multilines.js
@@ -12,6 +12,67 @@ var eslint = require('eslint').linter;
 var ESLintTester = require('eslint-tester');
 
 // ------------------------------------------------------------------------------
+// Code Snippets
+// ------------------------------------------------------------------------------
+
+var RETURN_SINGLE_LINE = '\
+  var Hello = React.createClass({\
+    render: function() {\
+      return <p>Hello {this.props.name}</p>;\
+    }\
+  });';
+
+var RETURN_PAREN = '\
+  var Hello = React.createClass({\
+    render: function() {\
+      return (\n\
+        <div>\n\
+          <p>Hello {this.props.name}</p>\n\
+        </div>\n\
+      );\
+    }\
+  });';
+
+var RETURN_NO_PAREN = '\
+  var Hello = React.createClass({\
+    render: function() {\
+      return <div>\n\
+        <p>Hello {this.props.name}</p>\n\
+      </div>;\
+    }\
+  });';
+
+var DECLARATION_SINGLE_LINE = 'var hello = <p>Hello</p>;';
+
+var DECLARATION_PAREN = '\
+  var hello = (\n\
+    <div>\n\
+      <p>Hello</p>\n\
+    </div>\n\
+  );';
+
+var DECLARATION_NO_PAREN = '\
+  var hello = <div>\n\
+    <p>Hello</p>\n\
+  </div>;';
+
+var ASSIGNMENT_SINGLE_LINE = 'var hello; hello = <p>Hello</p>;';
+
+var ASSIGNMENT_PAREN = '\
+  var hello;\
+  hello = (\n\
+    <div>\n\
+      <p>Hello</p>\n\
+    </div>\n\
+  );';
+
+var ASSIGNMENT_NO_PAREN = '\
+  var hello;\
+  hello = <div>\n\
+    <p>Hello</p>\n\
+  </div>;';
+
+// ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
 
@@ -20,97 +81,67 @@ eslintTester.addRuleTest('lib/rules/wrap-multilines', {
 
     valid: [
         {
-            code: '\
-              var Hello = React.createClass({\
-                render: function() {\
-                  return <p>Hello {this.props.name}</p>;\
-                }\
-              });',
-            ecmaFeatures: {
-              jsx: true
-            }
+            code: RETURN_SINGLE_LINE,
+            ecmaFeatures: {jsx: true}
         }, {
-            code: '\
-              var Hello = React.createClass({\
-                render: function() {\
-                  return (\n\
-                    <div>\n\
-                      <p>Hello {this.props.name}</p>\n\
-                    </div>\n\
-                  );\
-                }\
-              });',
-            ecmaFeatures: {
-              jsx: true
-            }
+            code: RETURN_PAREN,
+            ecmaFeatures: {jsx: true}
         }, {
-            code: 'var hello = <p>Hello</p>;',
-            ecmaFeatures: {
-              jsx: true
-            }
+            code: RETURN_NO_PAREN,
+            args: [1, {return: false}],
+            ecmaFeatures: {jsx: true}
         }, {
-            code: '\
-              var hello = (\n\
-                <div>\n\
-                  <p>Hello</p>\n\
-                </div>\n\
-              );',
-            ecmaFeatures: {
-              jsx: true
-            }
+            code: DECLARATION_SINGLE_LINE,
+            ecmaFeatures: {jsx: true}
         }, {
-            code: '\
-              var hello;\
-              hello = (\n\
-                <div>\n\
-                  <p>Hello</p>\n\
-                </div>\n\
-              );',
-            ecmaFeatures: {
-              jsx: true
-            }
+            code: DECLARATION_PAREN,
+            ecmaFeatures: {jsx: true}
+        }, {
+            code: DECLARATION_NO_PAREN,
+            args: [1, {declaration: false}],
+            ecmaFeatures: {jsx: true}
+        }, {
+            code: ASSIGNMENT_SINGLE_LINE,
+            args: [1, {declaration: false}],
+            ecmaFeatures: {jsx: true}
+        }, {
+            code: ASSIGNMENT_PAREN,
+            ecmaFeatures: {jsx: true}
+        }, {
+            code: ASSIGNMENT_NO_PAREN,
+            args: [1, {assignment: false}],
+            ecmaFeatures: {jsx: true}
         }
     ],
 
     invalid: [
         {
-            code: '\
-              var Hello = React.createClass({\
-                render: function() {\
-                  return <div>\n\
-                    <p>Hello {this.props.name}</p>\n\
-                  </div>;\
-                }\
-              });',
-            ecmaFeatures: {
-              jsx: true
-            },
-            errors: [{
-                message: 'Missing parentheses around multilines JSX'
-            }]
+            code: RETURN_NO_PAREN,
+            ecmaFeatures: {jsx: true},
+            errors: [{message: 'Missing parentheses around multilines JSX'}]
         }, {
-            code: '\
-              var hello = <div>\n\
-                <p>Hello</p>\n\
-              </div>;',
-            ecmaFeatures: {
-              jsx: true
-            },
-            errors: [{
-                message: 'Missing parentheses around multilines JSX'
-            }]
+            code: RETURN_NO_PAREN,
+            ecmaFeatures: {jsx: true},
+            args: [1, {return: true}],
+            errors: [{message: 'Missing parentheses around multilines JSX'}]
         }, {
-            code: '\
-              var hello;\
-              hello = <div>\n\
-                <p>Hello</p>\n\
-              </div>;',
-            ecmaFeatures: {
-              jsx: true
-            },
-            errors: [{
-                message: 'Missing parentheses around multilines JSX'
-            }]
+            code: DECLARATION_NO_PAREN,
+            ecmaFeatures: {jsx: true},
+            errors: [{message: 'Missing parentheses around multilines JSX'}]
+        }, {
+            code: DECLARATION_NO_PAREN,
+            ecmaFeatures: {jsx: true},
+            args: [1, {declaration: true}],
+            errors: [{message: 'Missing parentheses around multilines JSX'}]
+        }, {
+            code: ASSIGNMENT_NO_PAREN,
+            ecmaFeatures: {jsx: true},
+            errors: [{message: 'Missing parentheses around multilines JSX'}]
+        }, {
+            code: ASSIGNMENT_NO_PAREN,
+            ecmaFeatures: {jsx: true},
+            args: [1, {assignment: true}],
+            errors: [{message: 'Missing parentheses around multilines JSX'}]
         }
     ]
 });


### PR DESCRIPTION
This adds an option for enabling/disabling wrap-multilines in the context of the enclosing expression. In facebook/react, [we only care about jsx expressions in return statements](https://github.com/facebook/react/pull/4007#discussion_r31554866)