### PR TITLE
check jsxPragma in eslintrc settings

### DIFF
--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -168,7 +168,7 @@ module.exports = function(context) {
         markDisplayNameAsDeclared(node);
       }
 
-      if (componentUtil.isComponentDefinition(node)) {
+      if (componentUtil.isComponentDefinition(context, node)) {
         componentList.set(context, node, {
           isReactComponent: true
         });

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -557,7 +557,7 @@ module.exports = function(context) {
         markPropTypesAsDeclared(node, property.value);
       });
 
-      if (componentUtil.isComponentDefinition(node)) {
+      if (componentUtil.isComponentDefinition(context, node)) {
         componentList.set(context, node, {
           isReactComponent: true
         });

--- a/lib/util/component.js
+++ b/lib/util/component.js
@@ -41,7 +41,8 @@ function isReactComponent(context, node) {
  * @param {ASTNode} node The AST node being checked.
  * @returns {Boolean} True the node is a component definition, false if not.
  */
-function isComponentDefinition(node) {
+function isComponentDefinition(context, node) {
+  var jsxPragma = context.settings.jsxPragma || 'React';
   var isES6Component = node.type === 'ClassDeclaration';
   var isES5Component = Boolean(
     node.type === 'ObjectExpression' &&
@@ -49,7 +50,7 @@ function isComponentDefinition(node) {
     node.parent.callee &&
     node.parent.callee.object &&
     node.parent.callee.property &&
-    node.parent.callee.object.name === 'React' &&
+    node.parent.callee.object.name === jsxPragma &&
     node.parent.callee.property.name === 'createClass'
   );
   return isES5Component || isES6Component;
@@ -68,7 +69,7 @@ function getNode(context, node) {
   ancestors.unshift(node);
 
   for (var i = 0, j = ancestors.length; i < j; i++) {
-    if (isComponentDefinition(ancestors[i])) {
+    if (isComponentDefinition(context, ancestors[i])) {
       componentNode = ancestors[i];
       break;
     }


### PR DESCRIPTION
I'm using a wrapper around React called 'dom', and all of the react plugin linting trips up because it can't find the word 'React'. By setting a jsxPragma for your whole project, in the eslintrc settings, the linter becomes more flexible. 

The settings object gets passed into the utilities already, so I merely added a flexbilble jsxPragma setting in `isComponentDefinition`. It defaults to 'React' if there is no settings.jsxPragma .

- adding a JSX pragma config for every rule in react plugin is not ideal
- allow the settings config in eslintrc to define the jsxPragma.