### PR TITLE
fix detection of missing displayName and propTypes when ecmaFeatures.jsx is false

### DIFF
--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -117,6 +117,12 @@ module.exports = function(context) {
         }
         markDisplayNameAsDeclared(node);
       });
+
+      if (componentUtil.isComponentDefinition(node)) {
+        componentList.set(context, node, {
+          isReactComponent: true
+        });
+      }
     },
 
     'Program:exit': function() {

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -509,6 +509,12 @@ module.exports = function(context) {
         }
         markPropTypesAsDeclared(node, property.value);
       });
+
+      if (componentUtil.isComponentDefinition(node)) {
+        componentList.set(context, node, {
+          isReactComponent: true
+        });
+      }
     },
 
     'Program:exit': function() {

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -92,6 +92,20 @@ eslintTester.addRuleTest('lib/rules/display-name', {
     code: [
       'var Hello = React.createClass({',
       '  render: function() {',
+      '    return React.createElement("div", {}, "text content");',
+      '  }',
+      '});'
+    ].join('\n'),
+    ecmaFeatures: {
+      jsx: false
+    },
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: [
+      'var Hello = React.createClass({',
+      '  render: function() {',
       '    return <div>Hello {this.props.name}</div>;',
       '  }',
       '});'

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -423,6 +423,23 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
       code: [
         'var Hello = React.createClass({',
         '  render: function() {',
+        '    return React.createElement("div", {}, this.props.name);',
+        '  }',
+        '});'
+      ].join('\n'),
+      ecmaFeatures: {
+        jsx: false
+      },
+      errors: [{
+        message: '\'name\' is missing in props validation',
+        line: 3,
+        column: 53,
+        type: 'Identifier'
+      }]
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  render: function() {',
         '    return <div>Hello {this.props.name}</div>;',
         '  }',
         '});'


### PR DESCRIPTION
This PR introduces a small tweak in the ```react/display-name``` and ```react/prop-types``` custom eslint rules which adds to the detected React components any class created using the ```React.createClass``` helper when there isn't any jsx syntax in the render method.

Adding the above components definition object expressions to the component list is enough to detect missing ```displayName``` and ```propTypes``` properties as expected.