### PR TITLE
`jsx-sort-prop-types` support for keys as string

### DIFF
--- a/lib/rules/jsx-sort-prop-types.js
+++ b/lib/rules/jsx-sort-prop-types.js
@@ -35,6 +35,10 @@ module.exports = function(context) {
     );
   }
 
+  function getKey(node) {
+    return node.key.type === 'Identifier' ? node.key.name : node.key.value;
+  }
+
   /**
    * Checks if propTypes declarations are sorted
    * @param {Array} declarations The array of AST nodes being checked.
@@ -42,8 +46,8 @@ module.exports = function(context) {
    */
   function checkSorted(declarations) {
     declarations.reduce(function(prev, curr) {
-      var prevPropName = prev.key.name;
-      var currenPropName = curr.key.name;
+      var prevPropName = getKey(prev);
+      var currenPropName = getKey(curr);
 
       if (ignoreCase) {
         prevPropName = prevPropName.toLowerCase();

--- a/tests/lib/rules/jsx-sort-prop-types.js
+++ b/tests/lib/rules/jsx-sort-prop-types.js
@@ -161,6 +161,21 @@ eslintTester.addRuleTest('lib/rules/jsx-sort-prop-types', {
         classes: true,
         jsx: true
       }
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    return <div>Hello</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  "aria-controls": React.PropTypes.string',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      args: [1, {
+        ignoreCase: true
+      }]
     }
   ],
 


### PR DESCRIPTION
While investigating another bug, I stumbled onto this, which was easier to fix, so here it is.
Added support for prop type identified by strings in rule `jsx-sort-prop-types`