### PR TITLE
`prop-types` computed string format

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -144,13 +144,13 @@ module.exports = function(context) {
   /**
    * Checks if the prop is declared
    * @param {Object} component The component to process
-   * @param {String} name Dot separated name of the prop to check.
+   * @param {String[]} names List of names of the prop to check.
    * @returns {Boolean} True if the prop is declared, false if not.
    */
-  function isDeclaredInComponent(component, name) {
+  function isDeclaredInComponent(component, names) {
     return _isDeclaredInComponent(
       component.declaredPropTypes || {},
-      name.split('.')
+      names
     );
   }
 
@@ -164,14 +164,14 @@ module.exports = function(context) {
     return tokens.length && tokens[0].value === '...';
   }
 
+  /**
+   * Retrieve the name of a key node
+   * @param {ASTNode} node The AST node with the key.
+   * @return {string} the name of the key
+   */
   function getKeyValue(node) {
     var key = node.key;
-    if (key) {
-      if (key.type === 'Identifier') {
-        return key.name;
-      }
-      return key.value;
-    }
+    return key.type === 'Identifier' ? key.name : key.value;
   }
 
   /**
@@ -322,21 +322,50 @@ module.exports = function(context) {
   }
 
   /**
+   * Retrieve the name of a property node
+   * @param {ASTNode} node The AST node with the property.
+   * @return {string} the name of the property or undefined if not found
+   */
+  function getPropertyName(node) {
+    var property = node.property;
+    if (property) {
+      switch (property.type) {
+        case 'Identifier':
+          if (node.computed) {
+            return '__COMPUTED_PROP__';
+          }
+          return property.name;
+        case 'Literal':
+          // Accept computed properties that are literal strings
+          if (typeof property.value === 'string') {
+            return property.value;
+          }
+          // falls through
+        default:
+          if (node.computed) {
+            return '__COMPUTED_PROP__';
+          }
+          break;
+      }
+    }
+  }
+
+  /**
    * Mark a prop type as used
    * @param {ASTNode} node The AST node being marked.
    */
-  function markPropTypesAsUsed(node, parentName) {
+  function markPropTypesAsUsed(node, parentNames) {
+    parentNames = parentNames || [];
     var type;
-    var name = node.parent.computed ?
-      '__COMPUTED_PROP__'
-      : node.parent.property && node.parent.property.name;
-    var fullName = parentName ? parentName + '.' + name : name;
-
-    if (node.parent.type === 'MemberExpression') {
-      markPropTypesAsUsed(node.parent, fullName);
-    }
-    if (name && !node.parent.computed) {
-      type = 'direct';
+    var name = getPropertyName(node.parent);
+    var allNames;
+    if (name) {
+      allNames = parentNames.concat(name);
+      if (node.parent.type === 'MemberExpression') {
+        markPropTypesAsUsed(node.parent, allNames);
+      }
+      // Do not mark computed props as used.
+      type = name !== '__COMPUTED_PROP__' ? 'direct' : null;
     } else if (
       node.parent.parent.declarations &&
       node.parent.parent.declarations[0].id.properties &&
@@ -354,7 +383,8 @@ module.exports = function(context) {
           break;
         }
         usedPropTypes.push({
-          name: fullName,
+          name: name,
+          allNames: allNames,
           node: node.parent.property
         });
         break;
@@ -368,6 +398,7 @@ module.exports = function(context) {
           if (propName) {
             usedPropTypes.push({
               name: propName,
+              allNames: [propName],
               node: properties[i]
             });
           }
@@ -441,19 +472,20 @@ module.exports = function(context) {
    * @param {Object} component The component to process
    */
   function reportUndeclaredPropTypes(component) {
-    var name;
+    var allNames, name;
     for (var i = 0, j = component.usedPropTypes.length; i < j; i++) {
       name = component.usedPropTypes[i].name;
+      allNames = component.usedPropTypes[i].allNames;
       if (
-        isIgnored(name.split('.').pop()) ||
-        isDeclaredInComponent(component, name)
+        isIgnored(name) ||
+        isDeclaredInComponent(component, allNames)
       ) {
         continue;
       }
       context.report(
         component.usedPropTypes[i].node,
         component.name === componentUtil.DEFAULT_COMPONENT_NAME ? MISSING_MESSAGE : MISSING_MESSAGE_NAMED_COMP, {
-          name: name.replace(/\.__COMPUTED_PROP__/g, '[]'),
+          name: allNames.join('.').replace(/\.__COMPUTED_PROP__/g, '[]'),
           component: component.name
         }
       );

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -432,6 +432,56 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
         '};'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    this.props["some.value"];',
+        '    return <div>Hello</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  "some.value": React.PropTypes.string',
+        '};'
+      ].join('\n'),
+      ecmaFeatures: {
+        classes: true,
+        jsx: true
+      }
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    this.props["arr"][1];',
+        '    return <div>Hello</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  "arr": React.PropTypes.array',
+        '};'
+      ].join('\n'),
+      ecmaFeatures: {
+        classes: true,
+        jsx: true
+      }
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    this.props["arr"][1]["some.value"];',
+        '    return <div>Hello</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  "arr": React.PropTypes.arrayOf(',
+        '    React.PropTypes.shape({"some.value": React.PropTypes.string})',
+        '  )',
+        '};'
+      ].join('\n'),
+      ecmaFeatures: {
+        classes: true,
+        jsx: true
+      }
     }
   ],
 
@@ -771,6 +821,63 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
       parser: 'babel-eslint',
       errors: [
         {message: '\'propX\' is missing in props validation for Hello'}
+      ]
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    this.props["some.value"];',
+        '    return <div>Hello</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '};'
+      ].join('\n'),
+      ecmaFeatures: {
+        classes: true,
+        jsx: true
+      },
+      errors: [
+        {message: '\'some.value\' is missing in props validation for Hello'}
+      ]
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    this.props["arr"][1];',
+        '    return <div>Hello</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '};'
+      ].join('\n'),
+      ecmaFeatures: {
+        classes: true,
+        jsx: true
+      },
+      errors: [
+        {message: '\'arr\' is missing in props validation for Hello'}
+      ]
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    this.props["arr"][1]["some.value"];',
+        '    return <div>Hello</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  "arr": React.PropTypes.arrayOf(',
+        '    React.PropTypes.shape({})',
+        '  )',
+        '};'
+      ].join('\n'),
+      ecmaFeatures: {
+        classes: true,
+        jsx: true
+      },
+      errors: [
+        {message: '\'arr[].some.value\' is missing in props validation for Hello'}
       ]
     }
   ]


### PR DESCRIPTION
Following discussion at https://github.com/yannickcr/eslint-plugin-react/pull/124#discussion_r32871420
Added support for prop-types check of type `this.props['this-format']`.
Used list of nested names instead of dot-separated names to avoid conflict with properties like `this.props['this.format']`
