### PR TITLE
Changed ignore check to use correct key name

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -487,7 +487,7 @@ module.exports = function(context) {
     for (var i = 0, j = component.usedPropTypes.length; i < j; i++) {
       allNames = component.usedPropTypes[i].allNames;
       if (
-        isIgnored(allNames[0]) ||
+        isIgnored(allNames[allNames.length - 1]) ||
         isDeclaredInComponent(component, allNames)
       ) {
         continue;


### PR DESCRIPTION
Use case of failure:

eslintrc: 
```
"react/prop-types": [ 2, { ignore : [ 'get' ]} ],
```
test.js:
``` javascript
propTypes : {
  user : React.PropTypes.shape({
    id : React.PropTypes.node.isRequired,
  }).isRequired,
},

getInitialState() {
  console.log(this.props.user.get('foo'));
  return {};
}
```

despite `get` being an ignored attribute, it throws an error.