### PR TITLE
Changed oneOfType to actually keep the child types

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -276,8 +276,9 @@ module.exports = function(context) {
                 unionTypeDefinition.children = true;
                 return unionTypeDefinition;
               }
-              unionTypeDefinition.children.push(type);
             }
+
+            unionTypeDefinition.children.push(type);
           }
           if (unionTypeDefinition.length === 0) {
             // no complex type found, simply accept everything


### PR DESCRIPTION
Should complete #148 
Failure case:

eslintrc
``` json
"react/prop-types": [ 2 ],
```

sample.jsx
``` javascript
{
  propTypes : {
    testType : React.PropTypes.oneOfType([
      React.PropTypes.string,
      React.PropTypes.array,
    ]),
  },

  getInitialState() {
    console.log(this.props.testType.length);
    return {};
  }
}
```

Fails on `length`