### PR TITLE
Fix/type of child types

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -276,8 +276,9 @@ module.exports = function(context) {
                 unionTypeDefinition.children = true;
                 return unionTypeDefinition;
               }
-              unionTypeDefinition.children.push(type);
             }
+
+            unionTypeDefinition.children.push(type);
           }
           if (unionTypeDefinition.length === 0) {
             // no complex type found, simply accept everything

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -355,6 +355,25 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
       code: [
         'class Hello extends React.Component {',
         '  render() {',
+        '    this.props.a.length;',
+        '    return <div>Hello</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  a: React.PropTypes.oneOfType([',
+        '    React.PropTypes.array,',
+        '    React.PropTypes.string',
+        '  ])',
+        '};'
+      ].join('\n'),
+      ecmaFeatures: {
+        classes: true,
+        jsx: true
+      }
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
         '    this.props.a.c;',
         '    this.props.a[2] === true;',
         '    this.props.a.e[2];',


### PR DESCRIPTION
Should complete #148 
Failure case:

eslintrc
``` json
"react/prop-types": [ 2 ],
```

sample.jsx
``` javascript
{
  propTypes : {
    testType : React.PropTypes.oneOfType([
      React.PropTypes.string,
      React.PropTypes.array,
    ]),
  },

  getInitialState() {
    console.log(this.props.testType.length);
    return {};
  }
}
```

Fails on `length`