### PR TITLE
Fix/ignore child

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -93,14 +93,11 @@ module.exports = function(context) {
    * @returns {Boolean} True if the prop is declared, false if not.
    */
   function _isDeclaredInComponent(declaredPropTypes, keyList) {
-    var isDeclaredInComponentFlag = true;
-    var isFinalKey = false;
+    var isFinalKeyAndAcceptedProperty = true;
     for (var i = 0, j = keyList.length; i < j; i++) {
       var key = keyList[i];
-      isFinalKey = (i === j - 1);
       if (isIgnored(key)) {
-        isDeclaredInComponentFlag = true;
-        break;
+        return true;
       }
       var propType = (
         // Check if this key is declared
@@ -111,19 +108,18 @@ module.exports = function(context) {
 
       if (!propType) {
         // If it's a computed property, we can't make any further analysis, but is valid
-        isDeclaredInComponentFlag = (key === '__COMPUTED_PROP__');
-        break;
+        return key === '__COMPUTED_PROP__';
       }
       if (propType === true) {
-        isDeclaredInComponentFlag = true;
-        break;
+        return true;
       }
       // Consider every children as declared
       if (propType.children === true) {
         return true;
       }
       if (propType.acceptedProperties) {
-        isDeclaredInComponentFlag = (key in propType.acceptedProperties);
+        isFinalKeyAndAcceptedProperty = (key in propType.acceptedProperties) &&
+          (i === j - 1);
       }
       if (propType.type === 'union') {
         // If we fall in this case, we know there is at least one complex type in the union
@@ -134,7 +130,6 @@ module.exports = function(context) {
         // non trivial, check all of them
         var unionTypes = propType.children;
         var unionPropType = {};
-        var unionBreakFlag = false; // Break outer loop
         for (var k = 0, z = unionTypes.length; k < z; k++) {
           unionPropType[key] = unionTypes[k];
           var isValid = _isDeclaredInComponent(
@@ -142,13 +137,8 @@ module.exports = function(context) {
             keyList.slice(i)
           );
           if (isValid) {
-            isDeclaredInComponentFlag = true;
-            unionBreakFlag = true;
-            break;
+            return true;
           }
-        }
-        if (unionBreakFlag) {
-          break;
         }
 
         // every possible union were invalid
@@ -157,8 +147,8 @@ module.exports = function(context) {
       declaredPropTypes = propType.children;
     }
 
-    if (isFinalKey) {
-      return isDeclaredInComponentFlag;
+    if (!isFinalKeyAndAcceptedProperty) {
+      return false;
     }
 
     return true;

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -95,6 +95,9 @@ module.exports = function(context) {
   function _isDeclaredInComponent(declaredPropTypes, keyList) {
     for (var i = 0, j = keyList.length; i < j; i++) {
       var key = keyList[i];
+      if (isIgnored(key)) {
+        return true;
+      }
       var propType = (
         // Check if this key is declared
         declaredPropTypes[key] ||
@@ -487,10 +490,7 @@ module.exports = function(context) {
     var allNames;
     for (var i = 0, j = component.usedPropTypes.length; i < j; i++) {
       allNames = component.usedPropTypes[i].allNames;
-      if (
-        isIgnored(allNames[0]) ||
-        isDeclaredInComponent(component, allNames)
-      ) {
+      if (isDeclaredInComponent(component, allNames)) {
         continue;
       }
       context.report(

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -94,8 +94,10 @@ module.exports = function(context) {
    */
   function _isDeclaredInComponent(declaredPropTypes, keyList) {
     var isDeclaredInComponentFlag = true;
+    var isFinalKey = false;
     for (var i = 0, j = keyList.length; i < j; i++) {
       var key = keyList[i];
+      isFinalKey = (i === j - 1);
       if (isIgnored(key)) {
         isDeclaredInComponentFlag = true;
         break;
@@ -155,7 +157,7 @@ module.exports = function(context) {
       declaredPropTypes = propType.children;
     }
 
-    if (i === j - 1) {
+    if (isFinalKey) {
       return isDeclaredInComponentFlag;
     }
 

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -93,10 +93,12 @@ module.exports = function(context) {
    * @returns {Boolean} True if the prop is declared, false if not.
    */
   function _isDeclaredInComponent(declaredPropTypes, keyList) {
+    var isDeclaredInComponentFlag = true;
     for (var i = 0, j = keyList.length; i < j; i++) {
       var key = keyList[i];
       if (isIgnored(key)) {
-        return true;
+        isDeclaredInComponentFlag = true;
+        break;
       }
       var propType = (
         // Check if this key is declared
@@ -107,17 +109,19 @@ module.exports = function(context) {
 
       if (!propType) {
         // If it's a computed property, we can't make any further analysis, but is valid
-        return key === '__COMPUTED_PROP__';
+        isDeclaredInComponentFlag = (key === '__COMPUTED_PROP__');
+        break;
       }
       if (propType === true) {
-        return true;
+        isDeclaredInComponentFlag = true;
+        break;
       }
       // Consider every children as declared
       if (propType.children === true) {
         return true;
       }
       if (propType.acceptedProperties) {
-        return key in propType.acceptedProperties;
+        isDeclaredInComponentFlag = (key in propType.acceptedProperties);
       }
       if (propType.type === 'union') {
         // If we fall in this case, we know there is at least one complex type in the union
@@ -128,6 +132,7 @@ module.exports = function(context) {
         // non trivial, check all of them
         var unionTypes = propType.children;
         var unionPropType = {};
+        var unionBreakFlag = false; // Break outer loop
         for (var k = 0, z = unionTypes.length; k < z; k++) {
           unionPropType[key] = unionTypes[k];
           var isValid = _isDeclaredInComponent(
@@ -135,8 +140,13 @@ module.exports = function(context) {
             keyList.slice(i)
           );
           if (isValid) {
-            return true;
+            isDeclaredInComponentFlag = true;
+            unionBreakFlag = true;
+            break;
           }
+        }
+        if (unionBreakFlag) {
+          break;
         }
 
         // every possible union were invalid
@@ -144,6 +154,11 @@ module.exports = function(context) {
       }
       declaredPropTypes = propType.children;
     }
+
+    if (i === j - 1) {
+      return isDeclaredInComponentFlag;
+    }
+
     return true;
   }
 

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -535,6 +535,49 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
       code: [
         'class Hello extends React.Component {',
         '  render() {',
+        '    return <div>{this.props.name.get.foo}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  name: PropTypes.shape({',
+        '    foo: PropTypes.node,',
+        '  }),',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      args: [1, {ignore: ['get']}]
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    return <div>{this.props.name.foo.get()}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  name: PropTypes.shape({',
+        '    foo: PropTypes.node,',
+        '  }),',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      args: [1, {ignore: ['get']}]
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    return <div>{this.props.name.get()}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  name: PropTypes.object,',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      args: [1, {ignore: ['get']}]
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
         '    return <div>{this.props.name.firstname}</div>;',
         '  }',
         '}'
@@ -602,6 +645,27 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
         message: '\'name\' is missing in props validation',
         line: 3,
         column: 54,
+        type: 'Identifier'
+      }]
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    return <div>{this.props.firstname.foo.name}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  firstname : PropTypes.shape({',
+        '    bar: PropTypes.node,',
+        '  }),',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      args: [1, {ignore: ['name']}],
+      errors: [{
+        message: '\'firstname.foo\' is missing in props validation for Hello',
+        line: 3,
+        column: 39,
         type: 'Identifier'
       }]
     }, {

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -667,6 +667,11 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
         line: 3,
         column: 39,
         type: 'Identifier'
+      }, {
+        message: '\'firstname.foo.name\' is missing in props validation for Hello',
+        line: 3,
+        column: 43,
+        type: 'Identifier'
       }]
     }, {
       code: [


### PR DESCRIPTION
This fixes a couple cases where I was having problems with shape and ignore.

Use case of failure:

eslintrc: 
```
"react/prop-types": [ 2, { ignore : [ 'get' ]} ],
```
test.js:
``` javascript
propTypes : {
  user : React.PropTypes.shape({
    id : React.PropTypes.node.isRequired,
  }).isRequired,
},

getInitialState() {
  console.log(this.props.user.get('foo'));
  return {};
}
```

despite `get` being an ignored attribute, it used to throw an error.