### PR TITLE
Added `allowMultiline` property to the `jsx-curly-spacing` rule

### DIFF
--- a/docs/rules/jsx-curly-spacing.md
+++ b/docs/rules/jsx-curly-spacing.md
@@ -29,9 +29,6 @@ When `"never"` is set, the following patterns are considered warnings:
 <Hello name={ firstname } />;
 <Hello name={ firstname} />;
 <Hello name={firstname } />;
-<Hello name={
-  firstname
-} />;
 ```
 
 The following patterns are not warnings:
@@ -39,6 +36,9 @@ The following patterns are not warnings:
 ```js
 <Hello name={firstname} />;
 <Hello name={{ firstname: 'John', lastname: 'Doe' }} />;
+<Hello name={
+  firstname
+} />;
 ```
 
 #### always
@@ -60,6 +60,51 @@ The following patterns are not warnings:
   firstname
 } />;
 ```
+
+#### Braces spanning multiple lines
+
+By default, braces spanning multiple lines are allowed with either setting. If you want to disallow them you can specify an additional `allowMultiline` property with the value `false`:
+
+```json
+"jsx-curly-spacing": [2, "never", {"allowMultiline": false}]
+```
+
+When `"never"` is used and `allowMultiline` is `false`, the following patterns are considered warnings:
+
+```js
+<Hello name={ firstname } />;
+<Hello name={ firstname} />;
+<Hello name={firstname } />;
+<Hello name={
+  firstname
+} />;
+```
+
+The following patterns are not warnings:
+
+```js
+<Hello name={firstname} />;
+<Hello name={{ firstname: 'John', lastname: 'Doe' }} />;
+```
+
+When `"always"` is used and `allowMultiline` is `false`, the following patterns are considered warnings:
+
+```js
+<Hello name={firstname} />;
+<Hello name={ firstname} />;
+<Hello name={firstname } />;
+<Hello name={
+  firstname
+} />;
+```
+
+The following patterns are not warnings:
+
+```js
+<Hello name={ firstname } />;
+<Hello name={ {firstname: 'John', lastname: 'Doe'} } />;
+```
+
 
 ## When Not To Use It
 

--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -10,19 +10,52 @@
 
 module.exports = function(context) {
   var spaced = context.options[0] === 'always';
+  var multiline = context.options[1] ? context.options[1].allowMultiline : true;
 
   // --------------------------------------------------------------------------
   // Helpers
   // --------------------------------------------------------------------------
 
   /**
-   * Determines whether two adjacent tokens are have whitespace between them.
+   * Determines whether two adjacent tokens have a newline between them.
+   * @param {Object} left - The left token object.
+   * @param {Object} right - The right token object.
+   * @returns {boolean} Whether or not there is a newline between the tokens.
+   */
+  function isMultiline(left, right) {
+    return left.loc.start.line !== right.loc.start.line;
+  }
+
+  /**
+   * Determines whether two adjacent tokens have whitespace between them.
    * @param {Object} left - The left token object.
    * @param {Object} right - The right token object.
    * @returns {boolean} Whether or not there is space between the tokens.
    */
   function isSpaced(left, right) {
     return left.range[1] < right.range[0];
+  }
+
+  /**
+  * Reports that there shouldn't be a newline after the first token
+  * @param {ASTNode} node - The node to report in the event of an error.
+  * @param {Token} token - The token to use for the report.
+  * @returns {void}
+  */
+  function reportNoBeginningNewline(node, token) {
+    context.report(node, token.loc.start,
+      'There should be no newline after \'' + token.value + '\'');
+  }
+
+  /**
+  * Reports that there shouldn't be a newline before the last token
+  * @param {ASTNode} node - The node to report in the event of an error.
+  * @param {Token} token - The token to use for the report.
+  * @returns {void}
+  */
+  function reportNoEndingNewline(node, token) {
+    context.report(node, token.loc.start,
+      'There should be no newline before \'' + token.value + '\'');
   }
 
   /**
@@ -79,16 +112,28 @@ module.exports = function(context) {
    * @returns {void}
    */
   function validateBraceSpacing(node, first, second, penultimate, last) {
-    if (spaced && !isSpaced(first, second)) {
-      reportRequiredBeginningSpace(node, first);
+    if (spaced) {
+      if (!isSpaced(first, second)) {
+        reportRequiredBeginningSpace(node, first);
+      } else if (!multiline && isMultiline(first, second)) {
+        reportNoBeginningNewline(node, first);
+      }
+
+      if (!isSpaced(penultimate, last)) {
+        reportRequiredEndingSpace(node, last);
+      } else if (!multiline && isMultiline(penultimate, last)) {
+        reportNoEndingNewline(node, last);
+      }
+
+      return;
     }
-    if (!spaced && isSpaced(first, second)) {
+
+    // "never" setting if we get here.
+    if (isSpaced(first, second) && !(multiline && isMultiline(first, second))) {
       reportNoBeginningSpace(node, first);
     }
-    if (spaced && !isSpaced(penultimate, last)) {
-      reportRequiredEndingSpace(node, last);
-    }
-    if (!spaced && isSpaced(penultimate, last)) {
+
+    if (isSpaced(penultimate, last) && !(multiline && isMultiline(penultimate, last))) {
       reportNoEndingSpace(node, last);
     }
   }
@@ -111,4 +156,12 @@ module.exports = function(context) {
 
 module.exports.schema = [{
   enum: ['always', 'never']
+}, {
+  type: 'object',
+  properties: {
+    allowMultiline: {
+      type: 'boolean'
+    }
+  },
+  additionalProperties: false
 }];

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -30,6 +30,10 @@ eslintTester.addRuleTest('lib/rules/jsx-curly-spacing', {
     args: [1, 'always'],
     ecmaFeatures: {jsx: true}
   }, {
+    code: '<App foo={ bar } />;',
+    args: [1, 'always', {allowMultiline: false}],
+    ecmaFeatures: {jsx: true}
+  }, {
     code: '<App foo={{ bar:baz }} />;',
     args: [1, 'never'],
     ecmaFeatures: {jsx: true}
@@ -45,11 +49,36 @@ eslintTester.addRuleTest('lib/rules/jsx-curly-spacing', {
     ].join('\n'),
     args: [1, 'always'],
     ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      '<App foo={',
+      'bar',
+      '} />;'
+    ].join('\n'),
+    args: [1, 'always'],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      '<App foo={',
+      'bar',
+      '} />;'
+    ].join('\n'),
+    args: [1, 'never'],
+    ecmaFeatures: {jsx: true}
   }],
 
   invalid: [{
     code: '<App foo={ bar } />;',
     args: [1, 'never'],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: '<App foo={ bar } />;',
+    args: [1, 'never', {allowMultiline: false}],
     errors: [{
       message: 'There should be no space after \'{\''
     }, {
@@ -66,6 +95,15 @@ eslintTester.addRuleTest('lib/rules/jsx-curly-spacing', {
     }],
     ecmaFeatures: {jsx: true}
   }, {
+    code: '<App foo={bar} />;',
+    args: [1, 'always', {allowMultiline: false}],
+    errors: [{
+      message: 'A space is required after \'{\''
+    }, {
+      message: 'A space is required before \'}\''
+    }],
+    ecmaFeatures: {jsx: true}
+  }, {
     code: '<App foo={ bar} />;',
     args: [1, 'always'],
     errors: [{
@@ -99,11 +137,24 @@ eslintTester.addRuleTest('lib/rules/jsx-curly-spacing', {
       'bar',
       '} />;'
     ].join('\n'),
-    args: [1, 'never'],
+    args: [1, 'never', {allowMultiline: false}],
     errors: [{
       message: 'There should be no space after \'{\''
     }, {
       message: 'There should be no space before \'}\''
+    }],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      '<App foo={',
+      'bar',
+      '} />;'
+    ].join('\n'),
+    args: [1, 'always', {allowMultiline: false}],
+    errors: [{
+      message: 'There should be no newline after \'{\''
+    }, {
+      message: 'There should be no newline before \'}\''
     }],
     ecmaFeatures: {jsx: true}
   }]


### PR DESCRIPTION
What do you think about this? I had hoped it would be like that by default when I first read about that rule being introduced! Which prompts my next question: should `allowMultiline` be on by default? I currently put it off by default and I'm ignoring it when the option is set to `"always"` as to not break current users (new warnings/errors) that do:

```js
<Hello name={
  firstname
} />;
```

using

```json
"jsx-curly-spacing": [2, "always"]
```

If it were on by default, I could leverage the option in all cases, meaning users would have a way to enforce:

```js
// Valid
<Hello name={ firstname } />;

// Invalid
<Hello name={
  firstname
} />;
```

with

```json
"jsx-curly-spacing": [2, "always", {"allowMultiline": false}]
```

However, current users relying on

```js
<Hello name={
  firstname
} />;
```

to warn with the current defaults, would not be warned anymore.