### PR TITLE
Add rule to support ReactDOM (React 0.14 beta)

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   rules: {
     'jsx-uses-react': require('./lib/rules/jsx-uses-react'),
+    'jsx-uses-reactdom': require('./lib/rules/jsx-uses-reactdom'),
     'no-multi-comp': require('./lib/rules/no-multi-comp'),
     'prop-types': require('./lib/rules/prop-types'),
     'display-name': require('./lib/rules/display-name'),
@@ -25,6 +26,7 @@ module.exports = {
   },
   rulesConfig: {
     'jsx-uses-react': 0,
+    'jsx-uses-reactdom': 0,
     'no-multi-comp': 0,
     'prop-types': 0,
     'display-name': 0,

--- a/lib/rules/jsx-uses-reactdom.js
+++ b/lib/rules/jsx-uses-reactdom.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Prevent React to be marked as unused
+ * @author Glen Mailer
+ */
+'use strict';
+
+var variableUtil = require('../util/variable');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+var JSX_ANNOTATION_REGEX = /^\*\s*@jsx\s+([^\s]+)/;
+
+module.exports = function(context) {
+
+  var config = context.options[0] || {};
+  var id = config.pragma || 'ReactDOM';
+
+  // --------------------------------------------------------------------------
+  // Public
+  // --------------------------------------------------------------------------
+
+  return {
+
+    JSXOpeningElement: function() {
+      variableUtil.markVariableAsUsed(context, id);
+    },
+
+    BlockComment: function(node) {
+      var matches = JSX_ANNOTATION_REGEX.exec(node.value);
+      if (!matches) {
+        return;
+      }
+      id = matches[1].split('.')[0];
+    }
+
+  };
+
+};
+
+module.exports.schema = [{
+  type: 'object',
+  properties: {
+    pragma: {
+      type: 'string'
+    }
+  },
+  additionalProperties: false
+}];

--- a/tests/lib/rules/jsx-uses-reactdom.js
+++ b/tests/lib/rules/jsx-uses-reactdom.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Tests for jsx-uses-reactdom
+ * @author Don Abrams
+ */
+
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+var eslint = require('eslint').linter;
+var ESLintTester = require('eslint-tester');
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslint.defineRule('jsx-uses-reactdom', require('../../../lib/rules/jsx-uses-reactdom'));
+eslintTester.addRuleTest('node_modules/eslint/lib/rules/no-unused-vars', {
+  valid: [
+    {code: '/*eslint jsx-uses-reactdom:1*/ var ReactDOM; <div />;', ecmaFeatures: {jsx: true}},
+    {code: '/*eslint jsx-uses-reactdom:1*/ var ReactDOM; (function () { <div /> })();', ecmaFeatures: {jsx: true}},
+    {code: '/*eslint jsx-uses-reactdom:1*/ /** @jsx Foo */ var Foo; <div />;', ecmaFeatures: {jsx: true}},
+    {code: '/*eslint jsx-uses-reactdom:[1,{"pragma":"Foo"}]*/ var Foo; <div />;', ecmaFeatures: {jsx: true}}
+  ],
+  invalid: [
+    {code: '/*eslint jsx-uses-reactdom:1*/ var ReactDOM;',
+     errors: [{message: 'ReactDOM is defined but never used'}], ecmaFeatures: {jsx: true}},
+    {code: '/*eslint jsx-uses-reactdom:1*/ /** @jsx Foo */ var ReactDOM; <div />;',
+     errors: [{message: 'ReactDOM is defined but never used'}], ecmaFeatures: {jsx: true}}
+  ]
+});


### PR DESCRIPTION
In React 0.14, JSX will use two packages, React and ReactDOM (see https://facebook.github.io/react/blog/2015/07/03/react-v0.14-beta-1.html). This adds a rule, `jsx-uses-reactdom` exactly similar to `jsx-uses-react`.

I took the approach of copying the `jsx-uses-react` rule rather than modifying it to take multiple vars to use. The relative merit of the approach I took is debatable.

I probably wouldn't accept this pull request until 0.14 goes out of beta but I found it useful for me today.