### PR TITLE
Custom validator detection

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -610,6 +610,12 @@ module.exports.schema = [{
       items: {
         type: 'string'
       }
+    },
+    customValidators: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
     }
   },
   additionalProperties: false

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -18,6 +18,7 @@ module.exports = function(context) {
 
   var configuration = context.options[0] || {};
   var ignored = configuration.ignore || [];
+  var customValidators = configuration.customValidators || [];
 
   var componentList = new ComponentList();
 
@@ -70,6 +71,15 @@ module.exports = function(context) {
    */
   function isIgnored(name) {
     return ignored.indexOf(name) !== -1;
+  }
+
+  /**
+   * Checks if prop should be validated by plugin-react-proptypes
+   * @param {String} validator Name of validator to check.
+   * @returns {Boolean} True if validator should be checked by custom validator.
+   */
+  function hasCustomValidator(validator) {
+    return customValidators.indexOf(validator) !== -1;
   }
 
   /**
@@ -203,6 +213,15 @@ module.exports = function(context) {
    *    the property is declared without the need for further analysis.
    */
   function buildReactDeclarationTypes(value) {
+    if (
+      value &&
+      value.callee &&
+      value.callee.object &&
+      hasCustomValidator(value.callee.object.name)
+    ) {
+      return true;
+    }
+
     if (
       value.type === 'MemberExpression' &&
       value.property &&

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -597,6 +597,87 @@ eslintTester.addRuleTest('lib/rules/prop-types', {
         classes: true,
         jsx: true
       }
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  propTypes: {',
+        '    firstname: CustomValidator.string',
+        '  },',
+        '  render: function() {',
+        '    return <div>{this.props.firstname}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      args: [1, {customValidators: ['CustomValidator']}],
+      ecmaFeatures: {
+        jsx: true
+      }
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  propTypes: {',
+        '    outer: CustomValidator.shape({',
+        '      inner: CustomValidator.map',
+        '    })',
+        '  },',
+        '  render: function() {',
+        '    return <div>{this.props.outer.inner}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      args: [1, {customValidators: ['CustomValidator']}],
+      ecmaFeatures: {
+        jsx: true
+      }
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  propTypes: {',
+        '    outer: React.PropTypes.shape({',
+        '      inner: CustomValidator.string',
+        '    })',
+        '  },',
+        '  render: function() {',
+        '    return <div>{this.props.outer.inner}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      args: [1, {customValidators: ['CustomValidator']}],
+      ecmaFeatures: {
+        jsx: true
+      }
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  propTypes: {',
+        '    outer: CustomValidator.shape({',
+        '      inner: React.PropTypes.string',
+        '    })',
+        '  },',
+        '  render: function() {',
+        '    return <div>{this.props.outer.inner}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      args: [1, {customValidators: ['CustomValidator']}],
+      ecmaFeatures: {
+        jsx: true
+      }
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  propTypes: {',
+        '    name: React.PropTypes.string',
+        '  },',
+        '  render: function() {',
+        '    return <div>{this.props.name.get("test")}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      args: [1, {customValidators: ['CustomValidator']}],
+      ecmaFeatures: {
+        jsx: true
+      }
     }
   ],
 


### PR DESCRIPTION
A possible solution to the problem presented in #145.
Since we can't know what the `React.PropTypes` or `MyCustomValidator` is refering to when checking if it should be statically evaluated (or how to do so) I proposed adding an optional configuration to the prop-types rules: `customValidators`.

This allows us to ignore specific proptypes that the plugin doesn't have explicit knowledge of.

Example Usage:
``` javascript
"react/prop-types": [2, {customValidators: ['CustomValidator']}]

// Sample.js
var Hello = React.createClass({
  propTypes: {
    outer: React.PropTypes.shape({
      inner: CustomValidator.map
    })
  },
  render: function() {
    return <div>{this.props.outer.inner.get('test')}</div>;
  }
})
```

As a side note, it could possibly be added so the listed custom validators be actual modules that validate said props.