### PR TITLE
Add event handlers to no-unknown-property

### DIFF
--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -22,7 +22,12 @@ var DOM_PROPERTY_NAMES = [
   'cellPadding', 'cellSpacing', 'charSet', 'classID', 'className', 'colSpan', 'contentEditable', 'contextMenu',
   'crossOrigin', 'dateTime', 'encType', 'formAction', 'formEncType', 'formMethod', 'formNoValidate', 'formTarget',
   'frameBorder', 'hrefLang', 'htmlFor', 'httpEquiv', 'marginHeight', 'marginWidth', 'maxLength', 'mediaGroup',
-  'noValidate', 'radioGroup', 'readOnly', 'rowSpan', 'spellCheck', 'srcDoc', 'srcSet', 'tabIndex', 'useMap',
+  'noValidate', 'onBlur', 'onChange', 'onClick', 'onContextMenu', 'onCopy', 'onCut', 'onDoubleClick',
+  'onDrag', 'onDragEnd', 'onDragEnter', 'onDragExit', 'onDragLeave', 'onDragOver', 'onDragStart', 'onDrop',
+  'onFocus', 'onInput', 'onKeyDown', 'onKeyPress', 'onKeyUp', 'onMouseDown', 'onMouseEnter', 'onMouseLeave',
+  'onMouseMove', 'onMouseOut', 'onMouseOver', 'onMouseUp', 'onPaste', 'onScroll', 'onSubmit', 'onTouchCancel',
+  'onTouchEnd', 'onTouchMove', 'onTouchStart', 'onWheel',
+  'radioGroup', 'readOnly', 'rowSpan', 'spellCheck', 'srcDoc', 'srcSet', 'tabIndex', 'useMap',
   'itemProp', 'itemScope', 'itemType', 'itemRef', 'itemID'
 ];
 

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -45,6 +45,14 @@ eslintTester.addRuleTest('lib/rules/no-unknown-property', {
   }, {
     code: '<div accesskey="bar"></div>;',
     errors: [{message: 'Unknown property \'accesskey\' found, use \'accessKey\' instead'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: '<div onclick="bar"></div>;',
+    errors: [{message: 'Unknown property \'onclick\' found, use \'onClick\' instead'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: '<div onmousedown="bar"></div>;',
+    errors: [{message: 'Unknown property \'onmousedown\' found, use \'onMouseDown\' instead'}],
     ecmaFeatures: {jsx: true}}
   ]
 });


### PR DESCRIPTION
Enforce casing for all event handlers from https://facebook.github.io/react/docs/events.html

I hate trying to debug my click handlers when I've typed `onclick` instead of `onClick` in my components.