### PR TITLE
Update require-extension.md with information on setting up Webpack.

### DIFF
--- a/docs/rules/require-extension.md
+++ b/docs/rules/require-extension.md
@@ -33,6 +33,14 @@ The set of forbidden extensions is configurable. By default '.jsx' is blocked. I
 }
 ```
 
+To configure WebPack to resolve '.jsx' add the following to `webpack.config.js`:
+
+```js
+resolve: {
+    extensions: ["", ".js", ".jsx"]
+  },
+```
+
 ## When Not To Use It
 
 If you have file in your project with a '.jsx' file extension and do not have `require()` configured to automatically resolve '.jsx' files.


### PR DESCRIPTION
I think it would be helpful to help users satisfy the requirements for this rule.

If someone knows how to configure Browserify, please add it.