### PR TITLE
Added type limits to jsx-no-literals.

### DIFF
--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -24,7 +24,9 @@ module.exports = function(context) {
       if (
        !/^[\s]+$/.test(node.value) &&
         node.parent &&
-        node.parent.type !== 'JSXExpressionContainer'
+        node.parent.type !== 'JSXExpressionContainer' &&
+        node.parent.type !== 'JSXAttribute' &&
+        node.parent.type.indexOf('JSX') !== -1
       ) {
         reportLiteralNode(node);
       }

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -94,6 +94,20 @@ ruleTester.run('jsx-no-literals', rule, {
       ].join('\n'),
       args: [1],
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'var foo = require(\'foo\');'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        '<Foo bar=\'test\'>',
+        '  {\'blarg\'}',
+        '</Foo>'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
     }
   ],
 


### PR DESCRIPTION
This is the initial warnings range that I was considering before and should only report while inside of a JSX component.