### PR TITLE
Fix A Crash

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -46,7 +46,7 @@ module.exports = function(context) {
 
     // Special case for class properties
     // (babel-eslint does not expose property name so we have to rely on tokens)
-    if (node.type === 'ClassProperty') {
+    if (node && node.type === 'ClassProperty') {
       var tokens = context.getFirstTokens(node, 2);
       if (
         tokens[0].value === 'propTypes' ||


### PR DESCRIPTION
In standard (latest `master`) when I enable `experimentalObjectRestSpread` in eslint. We run into this issue when using eslint 1.1.0 and eslint-plugin-react 3.2.1.


```js
~/dev/standard (master) $ node bin/cmd.js test.js
standard: Unexpected linter output:

TypeError: Cannot read property 'type' of undefined
    at isPropTypesDeclaration (/Users/jamuferguson/dev/standard/node_modules/eslint-plugin-react/lib/rules/prop-types.js:49:13)
    at /Users/jamuferguson/dev/standard/node_modules/eslint-plugin-react/lib/rules/prop-types.js:589:14
    at Array.forEach (native)
    at EventEmitter.ObjectExpression (/Users/jamuferguson/dev/standard/node_modules/eslint-plugin-react/lib/rules/prop-types.js:588:23)
    at EventEmitter.emit (events.js:129:20)
    at Controller.controller.traverse.enter (/Users/jamuferguson/dev/standard/node_modules/eslint/lib/eslint.js:824:25)
    at Controller.__execute (/Users/jamuferguson/dev/standard/node_modules/estraverse/estraverse.js:397:31)
    at Controller.traverse (/Users/jamuferguson/dev/standard/node_modules/estraverse/estraverse.js:495:28)
    at EventEmitter.module.exports.api.verify (/Users/jamuferguson/dev/standard/node_modules/eslint/lib/eslint.js:817:24)
    at processText (/Users/jamuferguson/dev/standard/node_modules/eslint/lib/cli-engine.js:199:27)
```

By all means tell me to file an issue first or whatever the correct approach is :)

By the way the code that caused the crash was the following:

```js
// rest params
let { a, ...b } = obj

// object spread
let c = { ...d };
```