### PR TITLE
Add defensive coding to support experimental object spread properties

### DIFF
--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -158,6 +158,10 @@ module.exports = function(context) {
     ObjectExpression: function(node) {
       // Search for the displayName declaration
       node.properties.forEach(function(property) {
+        if (!property.key) {
+          return;
+        }
+
         if (!isDisplayNameDeclaration(property.key)) {
           return;
         }

--- a/lib/rules/jsx-sort-prop-types.js
+++ b/lib/rules/jsx-sort-prop-types.js
@@ -81,6 +81,10 @@ module.exports = function(context) {
 
     ObjectExpression: function(node) {
       node.properties.forEach(function(property) {
+        if (!property.key) {
+          return;
+        }
+
         if (!isPropTypesDeclaration(property.key)) {
           return;
         }


### PR DESCRIPTION
In a file like this with experimental object spread properties syntax:

```javascript
function lol(a, b, c) {
  return {...a, b, c};
}
```

The following rules were throwing an error because `node.property` is undefined in a property node of type `ExperimentalSpreadProperty`.

Not sure if this is the right approach, but at least it allows me to run eslint!