### PR TITLE
add `state` in lifecycle methods

### DIFF
--- a/docs/rules/sort-comp.md
+++ b/docs/rules/sort-comp.md
@@ -6,7 +6,7 @@ When creating React components it is more convenient to always follow the same o
 
 With default configuration the following organisation must be followed:
 
-  1. lifecycle methods: `displayName`, `propTypes`, `contextTypes`, `childContextTypes`, `mixins`, `statics`,`defaultProps`, `constructor`, `getDefaultProps`, `getInitialState`, `getChildContext`, `componentWillMount`, `componentDidMount`, `componentWillReceiveProps`, `shouldComponentUpdate`, `componentWillUpdate`, `componentDidUpdate`, `componentWillUnmount` (in this order).
+  1. lifecycle methods: `displayName`, `propTypes`, `contextTypes`, `childContextTypes`, `mixins`, `statics`,`defaultProps`, `constructor`, `getDefaultProps`, `getInitialState`, `state`, `getChildContext`, `componentWillMount`, `componentDidMount`, `componentWillReceiveProps`, `shouldComponentUpdate`, `componentWillUpdate`, `componentDidUpdate`, `componentWillUnmount` (in this order).
   2. custom methods
   3. `render` method
 
@@ -67,6 +67,7 @@ The default configuration is:
       'constructor',
       'getDefaultProps',
       'getInitialState',
+      'state',
       'getChildContext',
       'componentWillMount',
       'componentDidMount',

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -63,6 +63,7 @@ module.exports = function(context) {
         'defaultProps',
         'constructor',
         'getDefaultProps',
+        'state',
         'getInitialState',
         'getChildContext',
         'componentWillMount',


### PR DESCRIPTION
In ESNext, the following is possible:
```
class extends React.Component {
  state = {
    key: value
  }
}
```