### PR TITLE
Treat component with render which returns createElement as Valid

### DIFF
--- a/lib/util/component.js
+++ b/lib/util/component.js
@@ -25,10 +25,18 @@ function isReactComponent(context, node) {
   while (scope.upper && scope.type !== 'function') {
     scope = scope.upper;
   }
-
-  var isComponentRender =
+  var returnsJSX =
     node.argument &&
-    node.argument.type === 'JSXElement' &&
+    node.argument.type === 'JSXElement'
+  ;
+  var returnsReactCreateElement =
+    node.argument &&
+    node.argument.callee &&
+    node.argument.callee.property &&
+    node.argument.callee.property.name === 'createElement'
+  ;
+  var isComponentRender =
+    (returnsJSX || returnsReactCreateElement) &&
     scope.block.parent.key && scope.block.parent.key.name === 'render'
   ;
   var isEmptyComponentRender =

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -206,6 +206,20 @@ ruleTester.run('sort-comp', rule, {
     },
     errors: [{message: 'render must be placed after displayName'}]
   }, {
+    // Must run rule when render uses createElement instead of JSX
+    code: [
+      'var Hello = React.createClass({',
+      '  render: function() {',
+      '    return React.createElement("div", null, "Hello");',
+      '  },',
+      '  displayName : \'Hello\',',
+      '});'
+    ].join('\n'),
+    ecmaFeatures: {
+      jsx: true
+    },
+    errors: [{message: 'render must be placed after displayName'}]
+  }, {
     // Must force a custom method to be placed before render
     code: [
       'var Hello = React.createClass({',


### PR DESCRIPTION
This component triggers a sort-comp warning:
```
return React.createClass({
  render: function() {
    return <div>Hello</div>;
  },
  displayName : 'Hello'
});
```

This one does not:
```
return React.createClass({
  render: function() {
    return React.createElement("div", null, "Hello");
  },
  displayName: 'Hello'
```

This change makes it so that classes of the latter type are correctly consider as react classes, and rules such as sort-comp will run against them.