### PR TITLE
Fix crash with destructured PropTypes

### DIFF
--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -53,6 +53,7 @@ module.exports = function(context) {
    */
   function checkForbidden(declarations) {
     declarations.forEach(function(declaration) {
+      var target;
       if (
         declaration.value.type === 'MemberExpression' &&
         declaration.value.property &&
@@ -67,9 +68,13 @@ module.exports = function(context) {
       ) {
         declaration.value = declaration.value.callee;
       }
-
-      if (isForbidden(declaration.value.property.name)) {
-        context.report(declaration, 'Prop type `' + declaration.value.property.name + '` is forbidden');
+      if (declaration.value.property) {
+        target = declaration.value.property.name;
+      } else if (declaration.value.type === 'Identifier') {
+        target = declaration.value.name;
+      }
+      if (isForbidden(target)) {
+        context.report(declaration, 'Prop type `' + target + '` is forbidden');
       }
     });
   }

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -455,5 +455,24 @@ ruleTester.run('forbid-prop-types', rule, {
       forbid: ['instanceOf']
     }],
     errors: 1
+  }, {
+    code: [
+      'var object = React.PropTypes.object;',
+      'var Hello = React.createClass({',
+      '  propTypes: {',
+      '    retailer: object,',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    ecmaFeatures: {
+      jsx: true
+    },
+    options: [{
+      forbid: ['object']
+    }],
+    errors: 1
   }]
 });


### PR DESCRIPTION
Forbid-prop-types will crash if you have a bit of code that looks like:
```
var object = React.PropTypes.object;
var Comp = React.createClass({
  propTypes: {
    someProp: object
  },
  render: function() {.....}
});
```
This pull request fixes that issue and adds a test case to ensure that the above is correctly flagged as an error.
