### PR TITLE
Update `jsx-sort-props` to allow sorting callbacks last

### DIFF
--- a/docs/rules/jsx-sort-prop-types.md
+++ b/docs/rules/jsx-sort-prop-types.md
@@ -78,13 +78,32 @@ class Component extends React.Component {
 
 ```js
 ...
-"jsx-sort-prop-types": [<enabled>, { "ignoreCase": <boolean> }]
+"jsx-sort-prop-types": [<enabled>, {
+  "callbacksLast": <boolean>,
+  "ignoreCase": <boolean>
+}]
 ...
 ```
 
 ### `ignoreCase`
 
 When `true` the rule ignores the case-sensitivity of the declarations order.
+
+### `callbacksLast`
+
+When `true`, prop types for props beginning with "on" must be listed after all other props:
+
+```js
+var Component = React.createClass({
+  propTypes: {
+    a: React.PropTypes.number,
+    z: React.PropTypes.string,
+    onBar: React.PropTypes.func,
+    onFoo: React.PropTypes.func,
+  },
+...
+});
+```
 
 ## When not to use
 

--- a/docs/rules/jsx-sort-props.md
+++ b/docs/rules/jsx-sort-props.md
@@ -24,7 +24,10 @@ The following patterns are considered okay and do not cause warnings:
 
 ```js
 ...
-"jsx-sort-props": [<enabled>, { "ignoreCase": <boolean> }]
+"jsx-sort-props": [<enabled>, {
+  "callbacksLast": <boolean>,
+  "ignoreCase": <boolean>
+}]
 ...
 ```
 

--- a/docs/rules/jsx-sort-props.md
+++ b/docs/rules/jsx-sort-props.md
@@ -38,6 +38,14 @@ The following patterns are considered okay and do not cause warnings:
 <Hello name="John" Number="2" />;
 ```
 
+### `callbacksLast`
+
+When `true`, callbacks must be listed after all other props:
+
+```js
+<Hello tel={5555555} onClick={this._handleClick} />
+```
+
 ## When not to use
 
 This rule is a formatting preference and not following it won't negatively affect the quality of your code. If alphabetizing props isn't a part of your coding standards, then you can leave this rule off.

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -8,10 +8,15 @@
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+function isCallbackPropName(propName) {
+  return /^on[A-Z]/.test(propName);
+}
+
 module.exports = function(context) {
 
   var configuration = context.options[0] || {};
   var ignoreCase = configuration.ignoreCase || false;
+  var callbacksLast = configuration.callbacksLast || false;
 
   return {
     JSXOpeningElement: function(node) {
@@ -20,15 +25,29 @@ module.exports = function(context) {
           return attrs[idx + 1];
         }
 
-        var lastPropName = memo.name.name;
-        var currenPropName = decl.name.name;
+        var previousPropName = memo.name.name;
+        var currentPropName = decl.name.name;
+        var previousIsCallback = isCallbackPropName(previousPropName);
+        var currentIsCallback = isCallbackPropName(currentPropName);
 
         if (ignoreCase) {
-          lastPropName = lastPropName.toLowerCase();
-          currenPropName = currenPropName.toLowerCase();
+          previousPropName = previousPropName.toLowerCase();
+          currentPropName = currentPropName.toLowerCase();
         }
 
-        if (currenPropName < lastPropName) {
+        if (callbacksLast) {
+          if (!previousIsCallback && currentIsCallback) {
+            // Entering the callback prop section
+            return decl;
+          }
+          if (previousIsCallback && !currentIsCallback) {
+            // Encountered a non-callback prop after a callback prop
+            context.report(decl, 'Callbacks must be listed after all other props');
+            return memo;
+          }
+        }
+
+        if (currentPropName < previousPropName) {
           context.report(decl, 'Props should be sorted alphabetically');
           return memo;
         }
@@ -42,6 +61,11 @@ module.exports = function(context) {
 module.exports.schema = [{
   type: 'object',
   properties: {
+    // Whether callbacks (prefixed with "on") should be listed at the very end,
+    // after all other props.
+    callbacksLast: {
+      type: 'boolean'
+    },
     ignoreCase: {
       type: 'boolean'
     }

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -42,7 +42,7 @@ module.exports = function(context) {
           }
           if (previousIsCallback && !currentIsCallback) {
             // Encountered a non-callback prop after a callback prop
-            context.report(decl, 'Callbacks must be listed after all other props');
+            context.report(memo, 'Callbacks must be listed after all other props');
             return memo;
           }
         }

--- a/tests/lib/rules/jsx-sort-prop-types.js
+++ b/tests/lib/rules/jsx-sort-prop-types.js
@@ -208,6 +208,69 @@ ruleTester.run('jsx-sort-prop-types', rule, {
       experimentalObjectRestSpread: true,
       jsx: true
     }
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: {',
+      '    a: React.PropTypes.any,',
+      '    z: React.PropTypes.string,',
+      '    onBar: React.PropTypes.func,',
+      '    onFoo: React.PropTypes.func',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      callbacksLast: true
+    }],
+    ecmaFeatures: {
+      jsx: true
+    }
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static propTypes = {',
+      '    a: React.PropTypes.any,',
+      '    z: React.PropTypes.string,',
+      '    onBar: React.PropTypes.func,',
+      '    onFoo: React.PropTypes.func',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{
+      callbacksLast: true
+    }],
+    parser: 'babel-eslint',
+    ecmaFeatures: {
+      classes: true,
+      jsx: true
+    }
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.propTypes = {',
+      '    a: React.PropTypes.any,',
+      '    z: React.PropTypes.string,',
+      '    onBar: React.PropTypes.func,',
+      '    onFoo: React.PropTypes.func',
+      '};'
+    ].join('\n'),
+    options: [{
+      callbacksLast: true
+    }],
+    ecmaFeatures: {
+      classes: true,
+      jsx: true
+    }
   }],
 
   invalid: [{
@@ -364,5 +427,112 @@ ruleTester.run('jsx-sort-prop-types', rule, {
       jsx: true
     },
     errors: 2
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: {',
+      '    a: React.PropTypes.any,',
+      '    z: React.PropTypes.string,',
+      '    onFoo: React.PropTypes.func,',
+      '    onBar: React.PropTypes.func',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      callbacksLast: true
+    }],
+    ecmaFeatures: {
+      jsx: true
+    },
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 6,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static propTypes = {',
+      '    a: React.PropTypes.any,',
+      '    z: React.PropTypes.string,',
+      '    onFoo: React.PropTypes.func,',
+      '    onBar: React.PropTypes.func',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{
+      callbacksLast: true
+    }],
+    parser: 'babel-eslint',
+    ecmaFeatures: {
+      classes: true,
+      jsx: true
+    },
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 6,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.propTypes = {',
+      '    a: React.PropTypes.any,',
+      '    z: React.PropTypes.string,',
+      '    onFoo: React.PropTypes.func,',
+      '    onBar: React.PropTypes.func',
+      '};'
+    ].join('\n'),
+    options: [{
+      callbacksLast: true
+    }],
+    ecmaFeatures: {
+      classes: true,
+      jsx: true
+    },
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 10,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: {',
+      '    a: React.PropTypes.any,',
+      '    onBar: React.PropTypes.func,',
+      '    onFoo: React.PropTypes.func,',
+      '    z: React.PropTypes.string',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      callbacksLast: true
+    }],
+    ecmaFeatures: {
+      jsx: true
+    },
+    errors: [{
+      message: 'Callback prop types must be listed after all other prop types',
+      line: 5,
+      column: 5,
+      type: 'Property'
+    }]
   }]
 });

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -22,6 +22,13 @@ var expectedError = {
   message: 'Props should be sorted alphabetically',
   type: 'JSXAttribute'
 };
+var expectedCallbackError = {
+  message: 'Callbacks must be listed after all other props',
+  type: 'JSXAttribute'
+};
+var callbacksLastArgs = [{
+  callbacksLast: true
+}];
 var ignoreCaseArgs = [{
   ignoreCase: true
 }];
@@ -40,9 +47,12 @@ ruleTester.run('jsx-sort-props', rule, {
     {code: '<App {...this.props} a="c" b="b" c="a" />;', ecmaFeatures: features},
     {code: '<App c="a" {...this.props} a="c" b="b" />;', ecmaFeatures: features},
     {code: '<App A a />;', ecmaFeatures: features},
+    // Ignoring case
     {code: '<App a A />;', options: ignoreCaseArgs, ecmaFeatures: features},
     {code: '<App a B c />;', options: ignoreCaseArgs, ecmaFeatures: features},
-    {code: '<App A b C />;', options: ignoreCaseArgs, ecmaFeatures: features}
+    {code: '<App A b C />;', options: ignoreCaseArgs, ecmaFeatures: features},
+    // Sorting callbacks below all other props
+    {code: '<App a z onBar onFoo />;', options: callbacksLastArgs, ecmaFeatures: features}
   ],
   invalid: [
     {code: '<App b a />;', errors: [expectedError], ecmaFeatures: features},
@@ -53,6 +63,13 @@ ruleTester.run('jsx-sort-props', rule, {
     {code: '<App B A c />;', options: ignoreCaseArgs, errors: [expectedError], ecmaFeatures: features},
     {code: '<App c="a" a="c" b="b" />;', errors: 2, ecmaFeatures: features},
     {code: '<App {...this.props} c="a" a="c" b="b" />;', errors: 2, ecmaFeatures: features},
-    {code: '<App d="d" b="b" {...this.props} c="a" a="c" />;', errors: 2, ecmaFeatures: features}
+    {code: '<App d="d" b="b" {...this.props} c="a" a="c" />;', errors: 2, ecmaFeatures: features},
+    {code: '<App a z onFoo onBar />;', errors: [expectedError], options: callbacksLastArgs, ecmaFeatures: features},
+    {
+      code: '<App a onBar onFoo z />;',
+      errors: [expectedCallbackError],
+      options: callbacksLastArgs,
+      ecmaFeatures: features
+    }
   ]
 });


### PR DESCRIPTION
In my team (ads at Facebook) we tend to sort callbacks to the end, in their own group:

```js
<Foo
  a="blah"
  b="blah"
  y="blah"
  z="blah"
  onAwesome={() => alert('Woohoo!')}
  onClick={blah}
  onFoo={blah}
  onZoom={blah}
```

This change adds a `callbacksLast` configuration option to allow this style of sorting.

Also fixed the `currenPropName` typo (missing `t`) and renamed `lastPropName` to `previousPropName` so it's clearer that it's the previously encountered prop and **not** the very last prop of the JSX tag.