### PR TITLE
Introduce `state-usage` rule that detects unused/undeclared state

### DIFF
--- a/docs/rules/state-usage.md
+++ b/docs/rules/state-usage.md
@@ -1,0 +1,94 @@
+# Prevent unused state or using state that has never been set (state-usage)
+
+When refactoring components to decouple states,
+it usually happens that we forgot to change `state` into `props`.
+Also, sometimes, we leave an unused state in the component.
+
+
+## Rule Details
+
+This rule aims to detect unused state or undeclared states.
+
+A state field is used when referenced using `this.state.stateName`,
+and a state field is considered declared when appeared in an object literal
+inside `getInitialState()`
+
+The following patterns are considered warnings:
+
+```js
+React.createClass({
+  getInitialState: function () {
+    return {unused: true};
+  }
+});
+```
+
+```js
+React.createClass({
+  onClick: function () {
+    this.setState({unused: true});
+  }
+});
+```
+
+```js
+React.createClass({
+  render: function () {
+    return <span>{this.state.undeclared}</span>
+  }
+});
+```
+
+The following patterns are not warnings:
+
+```js
+React.createClass({
+  getInitialState: function () {
+    return {used: true};
+  },
+  render: function () {
+    return <span>{this.state.used}</span>
+  }
+});
+```
+
+## When Not To Use It
+
+You should not use this if you are using any of these:
+
+- Non-deterministic state:
+
+  ```js
+  getInitialState: function () {
+    return getStateFromStore();
+  }
+  ```
+
+  ```js
+  getInitialState: function () {
+    return Object.assign({a: 1}, getExtraState());
+  }
+  ```
+
+- Non-identifier state keys:
+
+  ```js
+  getInitialState: function () {
+    return {
+      'quotes': false,
+      ['computed']: false,
+    };
+  }
+  ```
+
+  ```js
+  render: function () {
+    return <span>{this.state['quotes']}</span>;
+  }
+  ```
+
+  ```js
+  render: function () {
+    return <span>{this.state[getStateKeyForWhateverUnexplainedReason()]}</span>;
+  }
+  ```

--- a/index.js
+++ b/index.js
@@ -30,7 +30,8 @@ module.exports = {
     'jsx-closing-bracket-location': require('./lib/rules/jsx-closing-bracket-location'),
     'no-direct-mutation-state': require('./lib/rules/no-direct-mutation-state'),
     'forbid-prop-types': require('./lib/rules/forbid-prop-types'),
-    'prefer-es6-class': require('./lib/rules/prefer-es6-class')
+    'prefer-es6-class': require('./lib/rules/prefer-es6-class'),
+    'state-usage': require('./lib/rules/state-usage')
   },
   rulesConfig: {
     'jsx-uses-react': 0,
@@ -61,6 +62,7 @@ module.exports = {
     'jsx-closing-bracket-location': 0,
     'no-direct-mutation-state': 0,
     'forbid-prop-types': 0,
-    'prefer-es6-class': 0
+    'prefer-es6-class': 0,
+    'state-usage': 0
   }
 };

--- a/lib/rules/state-usage.js
+++ b/lib/rules/state-usage.js
@@ -1,0 +1,149 @@
+/**
+ * @fileoverview Prevent unused state or using state that has never been set
+ * @author Thai Pangsakulyanont @ Taskworld.com
+ */
+'use strict';
+
+var componentUtil = require('../util/component');
+var ComponentList = componentUtil.List;
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+  var componentList = new ComponentList();
+
+  /**
+   * Returns a function that takes a path, and returns the property by following
+   * along that path, starting from a node. If along the way, a falsy value is
+   * encountered, it will be returned instead. This is similar to Lo-Dash’s
+   * `_.propertyOf`.
+   *
+   * @param {ASTNode} node The node to traverse.
+   * @returns {Function} A function that takes a path, and returns the value.
+   */
+  function getter(node) {
+    return function(path) {
+      var item = node;
+      var props = path.split('.');
+      for (var i = 0; i < props.length; i++) {
+        if (!item) {
+          return item;
+        }
+        item = item[props[i]];
+      }
+      return item;
+    };
+  }
+
+  function reportUnused(items) {
+    items.forEach(function(item) {
+      context.report(item.node, 'Unused state ' + item.name);
+    });
+  }
+
+  function reportUndeclared(items) {
+    items.forEach(function(item) {
+      context.report(item.node, 'Undeclared state ' + item.name);
+    });
+  }
+
+  function validateComponentStateUsage(component) {
+    var usage = component.stateUsage || [];
+    var declarations = component.stateDeclarations || [];
+    var used = {};
+    var declared = {};
+    var has = Object.prototype.hasOwnProperty;
+    declarations.forEach(function(item) {
+      (declared[item.name] || (declared[item.name] = [])).push(item);
+    });
+    usage.forEach(function(item) {
+      (used[item.name] || (used[item.name] = [])).push(item);
+    });
+    var name;
+    for (name in declared) {
+      if (has.call(declared, name) && !has.call(used, name)) {
+        reportUnused(declared[name]);
+      }
+    }
+    for (name in used) {
+      if (has.call(used, name) && !has.call(declared, name)) {
+        reportUndeclared(used[name]);
+      }
+    }
+  }
+
+  function isSetState(node) {
+    var get = getter(node);
+    if (get('parent.type') === 'ReturnStatement') {
+      return (
+        get('parent.parent.type') === 'BlockStatement' &&
+        get('parent.parent.parent.type') === 'FunctionExpression' &&
+        get('parent.parent.parent.parent.key.name') === 'getInitialState'
+      );
+    }
+    if (get('parent.type') === 'CallExpression') {
+      return (
+        get('parent.callee.object.type') === 'ThisExpression' &&
+        get('parent.callee.property.name') === 'setState'
+      );
+    }
+  }
+
+  return {
+
+    ObjectExpression: function(node) {
+      componentList.set(context, node);
+      if (!isSetState(node)) {
+        return;
+      }
+      node.properties.forEach(function(property) {
+        var get = getter(property);
+        var stateName = get('key.name');
+        if (!stateName) {
+          return;
+        }
+        var component = componentList.getByNode(context, node);
+        var stateDeclarations = component && component.stateDeclarations || [];
+        stateDeclarations.push({name: stateName, node: property});
+        componentList.set(context, node, {stateDeclarations: stateDeclarations});
+      });
+    },
+
+    ClassDeclaration: function(node) {
+      componentList.set(context, node);
+    },
+
+    MemberExpression: function(node) {
+      var get = getter(node);
+      if (
+        get('object.type') !== 'MemberExpression' ||
+        get('property.type') !== 'Identifier' ||
+        get('object.property.name') !== 'state' ||
+        get('object.object.type') !== 'ThisExpression'
+      ) {
+        return;
+      }
+      var stateName = node.property.name;
+      var component = componentList.getByNode(context, node);
+      var stateUsage = component && component.stateUsage || [];
+      stateUsage.push({name: stateName, node: node});
+      componentList.set(context, node, {stateUsage: stateUsage});
+    },
+
+    'Program:exit': function() {
+      var list = componentList.getList();
+      for (var component in list) {
+        if (!list.hasOwnProperty(component)) {
+          continue;
+        }
+        validateComponentStateUsage(list[component]);
+      }
+    }
+  };
+};
+
+module.exports.schema = [
+];

--- a/tests/lib/rules/state-usage.js
+++ b/tests/lib/rules/state-usage.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Prevent unused state or using state that has never been set
+ * @author Thai Pangsakulyanont @ Taskworld.com
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/state-usage');
+var RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+
+ruleTester.run('state-usage', rule, {
+
+  valid: [
+    {
+      code:
+        'React.createClass({ getInitialState: function () { return { meow: 1 }; },' +
+        'render: function () { return this.state.meow; } });'
+    }
+  ],
+  invalid: [
+    {
+      code: 'React.createClass({ getInitialState: function () { return { meow: 1 }; } });',
+      errors: [
+        {message: 'Unused state meow'}
+      ]
+    },
+    {
+      code: 'React.createClass({ onClick: function () { this.setState({ meow: 1 }); } });',
+      errors: [
+        {message: 'Unused state meow'}
+      ]
+    },
+    {
+      code: 'React.createClass({ render: function () { return this.state.meow; } });',
+      errors: [
+        {message: 'Undeclared state meow'}
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
This rule detects unused state:

``` js
React.createClass({
  getInitialState: function () {
    return {unused: true};
  }
});
```

And undeclared state:

``` js
React.createClass({
  render: function () {
    return <span>{this.state.undeclared}</span>
  }
});
```

This PR partially complements with #252, which should ease in refactoring.

Note that this is just the first working implementation, which I hacked it up mainly to ease my workflow when refactoring React components at @taskworld. I may not have time to polish it and make it work with ES6-class style components. But I think this may be useful to someone looking for this linting capability.
