### PR TITLE
Add 'line-aligned' option for jsx-closing-bracket-location

### DIFF
--- a/docs/rules/jsx-closing-bracket-location.md
+++ b/docs/rules/jsx-closing-bracket-location.md
@@ -55,6 +55,7 @@ The second form allows you to distinguish between non-empty and self-closing tag
 Enforced location for the closing bracket.
 
 * `tag-aligned`: must be aligned with the opening tag.
+* `line-aligned`: must be aligned with the line containing the opening tag.
 * `after-props`: must be placed right after the last prop.
 * `props-aligned`: must be aligned with the last prop.
 
@@ -67,6 +68,7 @@ The following patterns are considered warnings:
 ```jsx
 // 'jsx-closing-bracket-location': 1
 // 'jsx-closing-bracket-location': [1, 'tag-aligned']
+// 'jsx-closing-bracket-location': [1, 'line-aligned']
 <Hello 
   firstName="John"
   lastName="Smith"
@@ -77,6 +79,37 @@ The following patterns are considered warnings:
   lastName="Smith">
   Hello
 </Say>;
+
+// 'jsx-closing-bracket-location': 1
+// 'jsx-closing-bracket-location': [1, 'tag-aligned']
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+/>;
+
+var x = function() {
+  return <Say
+    firstName="John"
+    lastName="Smith"
+  >
+    Hello
+  </Say>;
+};
+
+// 'jsx-closing-bracket-location': [1, 'line-aligned']
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+        />;
+
+var x = function() {
+  return <Say
+    firstName="John"
+    lastName="Smith"
+         >
+    Hello
+         </Say>;
+};
 
 // 'jsx-closing-bracket-location': [1, 'after-props']
 <Hello 
@@ -108,6 +141,7 @@ The following patterns are not considered warnings:
 ```jsx
 // 'jsx-closing-bracket-location': 1
 // 'jsx-closing-bracket-location': [1, 'tag-aligned']
+// 'jsx-closing-bracket-location': [1, 'line-aligned']
 <Hello
   firstName="John"
   lastName="Smith"
@@ -119,6 +153,37 @@ The following patterns are not considered warnings:
 >
   Hello
 </Say>;
+
+// 'jsx-closing-bracket-location': 1
+// 'jsx-closing-bracket-location': [1, 'tag-aligned']
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+        />;
+
+var x = function() {
+  return <Say
+    firstName="John"
+    lastName="Smith"
+         >
+    Hello
+         </Say>;
+};
+
+// 'jsx-closing-bracket-location': [1, 'line-aligned']
+var x = <Hello
+  firstName="John"
+  lastName="Smith"
+/>;
+
+var x = function() {
+  return <Say
+    firstName="John"
+    lastName="Smith"
+  >
+    Hello
+  </Say>;
+};
 
 // 'jsx-closing-bracket-location': [1, {selfClosing: 'after-props'}]
 <Hello 

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -14,7 +14,8 @@ module.exports = function(context) {
     'after-props': 'placed after the last prop',
     'after-tag': 'placed after the opening tag',
     'props-aligned': 'aligned with the last prop',
-    'tag-aligned': 'aligned with the opening tag'
+    'tag-aligned': 'aligned with the opening tag',
+    'line-aligned': 'aligned with the line containing the opening tag'
   };
   var DEFAULT_LOCATION = 'tag-aligned';
 
@@ -80,15 +81,19 @@ module.exports = function(context) {
         return tokens.lastProp.column === tokens.closing.column;
       case 'tag-aligned':
         return tokens.opening.column === tokens.closing.column;
+      case 'line-aligned':
+        return tokens.openingStartOfLine.column === tokens.closing.column;
       default:
         return true;
     }
   }
 
   /**
-   * Get the locations of the opening bracket, closing bracket and last prop
+   * Get the locations of the opening bracket, closing bracket, last prop, and
+   * start of opening line.
    * @param {ASTNode} node The node to check
-   * @return {Object} Locations of the opening bracket, closing bracket and last prop
+   * @return {Object} Locations of the opening bracket, closing bracket, last
+   * prop and start of opening line.
    */
   function getTokensLocations(node) {
     var opening = context.getFirstToken(node).loc.start;
@@ -102,12 +107,18 @@ module.exports = function(context) {
         line: context.getLastToken(lastProp).loc.end.line
       };
     }
+    var openingLine = context.getSourceCode().lines[opening.line - 1];
+    var openingStartOfLine = {
+      column: /^\s*/.exec(openingLine)[0].length,
+      line: opening.line
+    };
     return {
       tag: tag,
       opening: opening,
       closing: closing,
       lastProp: lastProp,
-      selfClosing: node.selfClosing
+      selfClosing: node.selfClosing,
+      openingStartOfLine: openingStartOfLine
     };
   }
 
@@ -129,13 +140,13 @@ module.exports = function(context) {
 module.exports.schema = [{
   oneOf: [
     {
-      enum: ['after-props', 'props-aligned', 'tag-aligned']
+      enum: ['after-props', 'props-aligned', 'tag-aligned', 'line-aligned']
     },
     {
       type: 'object',
       properties: {
         location: {
-          enum: ['after-props', 'props-aligned', 'tag-aligned']
+          enum: ['after-props', 'props-aligned', 'tag-aligned', 'line-aligned']
         }
       },
       additionalProperties: false
@@ -143,10 +154,10 @@ module.exports.schema = [{
       type: 'object',
       properties: {
         nonEmpty: {
-          enum: ['after-props', 'props-aligned', 'tag-aligned']
+          enum: ['after-props', 'props-aligned', 'tag-aligned', 'line-aligned']
         },
         selfClosing: {
-          enum: ['after-props', 'props-aligned', 'tag-aligned']
+          enum: ['after-props', 'props-aligned', 'tag-aligned', 'line-aligned']
         }
       },
       additionalProperties: false

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -15,6 +15,7 @@ var MESSAGE_AFTER_PROPS = [{message: 'The closing bracket must be placed after t
 var MESSAGE_AFTER_TAG = [{message: 'The closing bracket must be placed after the opening tag'}];
 var MESSAGE_PROPS_ALIGNED = [{message: 'The closing bracket must be aligned with the last prop'}];
 var MESSAGE_TAG_ALIGNED = [{message: 'The closing bracket must be aligned with the opening tag'}];
+var MESSAGE_LINE_ALIGNED = [{message: 'The closing bracket must be aligned with the line containing the opening tag'}];
 
 // ------------------------------------------------------------------------------
 // Tests
@@ -53,6 +54,12 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ecmaFeatures: {jsx: true}
   }, {
     code: [
+      '<App foo />'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
       '<App ',
       '  foo />'
     ].join('\n'),
@@ -85,6 +92,14 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     code: [
       '<App ',
       '  foo',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      '<App ',
+      '  foo',
       '  />'
     ].join('\n'),
     options: [{location: 'props-aligned'}],
@@ -101,6 +116,14 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '></App>'
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      '<App',
+      '  foo',
+      '></App>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
     ecmaFeatures: {jsx: true}
   }, {
     code: [
@@ -138,6 +161,16 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '/>'
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      '<App',
+      '  foo={function() {',
+      '    console.log(\'bar\');',
+      '  }}',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
     ecmaFeatures: {jsx: true}
   }, {
     code: [
@@ -192,6 +225,86 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{nonEmpty: 'props-aligned'}],
     ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      'var x = function() {',
+      '  return <App',
+      '    foo',
+      '         >',
+      '      bar',
+      '         </App>',
+      '}'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      'var x = function() {',
+      '  return <App',
+      '    foo',
+      '         />',
+      '}'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      'var x = <App',
+      '  foo',
+      '        />'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      'var x = function() {',
+      '  return <App',
+      '    foo={function() {',
+      '      console.log(\'bar\');',
+      '    }}',
+      '  />',
+      '}'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      'var x = <App',
+      '  foo={function() {',
+      '    console.log(\'bar\');',
+      '  }}',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      '<Provider',
+      '  store',
+      '>',
+      '  <App',
+      '    foo={function() {',
+      '      console.log(\'bar\');',
+      '    }}',
+      '  />',
+      '</Provider>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true}
+  }, {
+    code: [
+      '<Provider',
+      '  store',
+      '>',
+      '  {baz && <App',
+      '    foo={function() {',
+      '      console.log(\'bar\');',
+      '    }}',
+      '  />}',
+      '</Provider>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true}
   }],
 
   invalid: [{
@@ -234,6 +347,14 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
   }, {
     code: [
       '<App ',
+      '  foo />'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true},
+    errors: MESSAGE_LINE_ALIGNED
+  }, {
+    code: [
+      '<App ',
       '  foo',
       '/>'
     ].join('\n'),
@@ -267,6 +388,15 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{location: 'tag-aligned'}],
     ecmaFeatures: {jsx: true},
     errors: MESSAGE_TAG_ALIGNED
+  }, {
+    code: [
+      '<App ',
+      '  foo',
+      '  />'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true},
+    errors: MESSAGE_LINE_ALIGNED
   }, {
     code: [
       '<App',
@@ -303,6 +433,15 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{location: 'tag-aligned'}],
     ecmaFeatures: {jsx: true},
     errors: MESSAGE_TAG_ALIGNED
+  }, {
+    code: [
+      '<App',
+      '  foo',
+      '  ></App>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true},
+    errors: MESSAGE_LINE_ALIGNED
   }, {
     code: [
       '<Provider ',
@@ -351,5 +490,25 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{nonEmpty: 'after-props'}],
     ecmaFeatures: {jsx: true},
     errors: MESSAGE_TAG_ALIGNED
+  }, {
+    code: [
+      'var x = function() {',
+      '  return <App',
+      '    foo',
+      '         />',
+      '}'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true},
+    errors: MESSAGE_LINE_ALIGNED
+  }, {
+    code: [
+      'var x = <App',
+      '  foo',
+      '        />'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    ecmaFeatures: {jsx: true},
+    errors: MESSAGE_LINE_ALIGNED
   }]
 });


### PR DESCRIPTION
`'line-aligned'` acts like `'tag-aligned'` except when the opening JSX tag
is preceded by other code on the same line.

This commit adds the rules, the corresponding tests, and updates the
documentation.

Test Plan:
npm install
npm run test