### PR TITLE
[jsx-no-bind] Ensure node is MemberExpression before checking property name

### DIFF
--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -21,6 +21,7 @@ module.exports = function(context) {
       if (
         !configuration.allowBind &&
         valueNode.type === 'CallExpression' &&
+        valueNode.callee.type === 'MemberExpression' &&
         valueNode.callee.property.name === 'bind'
       ) {
         context.report(node, 'JSX props should not use .bind()');

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -29,6 +29,10 @@ ruleTester.run('jsx-no-bind', rule, {
       code: '<div meaningOfLife={42}></div>',
       parser: 'babel-eslint'
     },
+    {
+      code: '<div onClick={getHandler()}></div>',
+      parser: 'babel-eslint'
+    },
 
     // bind() explicitly allowed
     {


### PR DESCRIPTION
When I actually started using this rule in real-life code, I noticed that it was crashing for normal function calls (eg. `foo={bar()}`) as `node.callee.property` is `null` for those. Instead, we want to explicitly check that the callee is a `MemberExpression`.