### PR TITLE
Fix crash when using eslint 1.10.0

### DIFF
--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -10,7 +10,7 @@ var Components = require('../util/Components');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-module.exports = Components.detect(function(context, components) {
+module.exports = Components.detect(function(context, components, utils) {
 
   var config = context.options[0] || {};
   var acceptTranspilerName = config.acceptTranspilerName || false;
@@ -131,7 +131,7 @@ module.exports = Components.detect(function(context, components) {
       if (!isDisplayNameDeclaration(node.property)) {
         return;
       }
-      var component = context.react.getRelatedComponent(node);
+      var component = utils.getRelatedComponent(node);
       if (!component) {
         return;
       }

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -10,7 +10,7 @@ var Components = require('../util/Components');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-module.exports = Components.detect(function(context, components) {
+module.exports = Components.detect(function(context, components, utils) {
 
   /**
    * Checks if the component is valid
@@ -51,7 +51,7 @@ module.exports = Components.detect(function(context, components) {
         item.object.type === 'ThisExpression' &&
         item.property.name === 'state'
       ) {
-        var component = components.get(context.react.getParentComponent());
+        var component = components.get(utils.getParentComponent());
         var mutations = component && component.mutations || [];
         mutations.push(node.left.object);
         components.set(node, {

--- a/lib/rules/prefer-es6-class.js
+++ b/lib/rules/prefer-es6-class.js
@@ -10,11 +10,11 @@ var Components = require('../util/Components');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-module.exports = Components.detect(function(context) {
+module.exports = Components.detect(function(context, components, utils) {
 
   return {
     ObjectExpression: function(node) {
-      if (context.react.isES5Component(node)) {
+      if (utils.isES5Component(node)) {
         context.report(node, 'Component should use es6 class instead of createClass');
       }
     }

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -13,7 +13,7 @@ var Components = require('../util/Components');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-module.exports = Components.detect(function(context, components) {
+module.exports = Components.detect(function(context, components, utils) {
 
   var configuration = context.options[0] || {};
   var ignored = configuration.ignore || [];
@@ -28,7 +28,7 @@ module.exports = Components.detect(function(context, components) {
    */
   function isPropTypesUsage(node) {
     var isClassUsage = (
-      (context.react.getParentES6Component() || context.react.getParentES5Component()) &&
+      (utils.getParentES6Component() || utils.getParentES5Component()) &&
       node.object.type === 'ThisExpression' && node.property.name === 'props'
     );
     var isStatelessFunctionUsage = node.object.name === 'props';
@@ -328,7 +328,7 @@ module.exports = Components.detect(function(context, components) {
    */
   function getPropertyName(node) {
     var isDirectProp = /^props(\.|\[)/.test(context.getSource(node));
-    var isInClassComponent = context.react.getParentES6Component() || context.react.getParentES5Component();
+    var isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
     var isNotInConstructor = !inConstructor(node);
     if (isDirectProp && isInClassComponent && isNotInConstructor) {
       return void 0;
@@ -408,7 +408,7 @@ module.exports = Components.detect(function(context, components) {
         throw new Error(node.type + ' ASTNodes are not handled by markPropTypesAsUsed');
     }
 
-    var component = components.get(context.react.getParentComponent());
+    var component = components.get(utils.getParentComponent());
     var usedPropTypes = component && component.usedPropTypes || [];
 
     switch (type) {
@@ -569,7 +569,7 @@ module.exports = Components.detect(function(context, components) {
           markPropTypesAsUsed(node);
           break;
         case 'declaration':
-          var component = context.react.getRelatedComponent(node);
+          var component = utils.getRelatedComponent(node);
           if (!component) {
             return;
           }

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -108,7 +108,7 @@ function componentRule(rule, context) {
   var components = new Components();
 
   // Utilities for component detection
-  context.react = {
+  var utils = {
 
     /**
      * Check if the node is a React ES5 component
@@ -176,9 +176,9 @@ function componentRule(rule, context) {
      */
     getParentComponent: function() {
       return (
-        context.react.getParentES6Component() ||
-        context.react.getParentES5Component() ||
-        context.react.getParentStatelessComponent()
+        utils.getParentES6Component() ||
+        utils.getParentES5Component() ||
+        utils.getParentStatelessComponent()
       );
     },
 
@@ -191,7 +191,7 @@ function componentRule(rule, context) {
       var scope = context.getScope();
       while (scope) {
         var node = scope.block && scope.block.parent && scope.block.parent.parent;
-        if (node && context.react.isES5Component(node)) {
+        if (node && utils.isES5Component(node)) {
           return node;
         }
         scope = scope.upper;
@@ -210,7 +210,7 @@ function componentRule(rule, context) {
         scope = scope.upper;
       }
       var node = scope && scope.block;
-      if (!node || !context.react.isES6Component(node)) {
+      if (!node || !utils.isES6Component(node)) {
         return null;
       }
       return node;
@@ -316,14 +316,14 @@ function componentRule(rule, context) {
   // Component detection instructions
   var detectionInstructions = {
     ClassDeclaration: function(node) {
-      if (!context.react.isES6Component(node)) {
+      if (!utils.isES6Component(node)) {
         return;
       }
       components.add(node, 2);
     },
 
     ClassProperty: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
@@ -331,14 +331,14 @@ function componentRule(rule, context) {
     },
 
     ObjectExpression: function(node) {
-      if (!context.react.isES5Component(node)) {
+      if (!utils.isES5Component(node)) {
         return;
       }
       components.add(node, 2);
     },
 
     FunctionExpression: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
@@ -346,7 +346,7 @@ function componentRule(rule, context) {
     },
 
     FunctionDeclaration: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
@@ -354,11 +354,11 @@ function componentRule(rule, context) {
     },
 
     ArrowFunctionExpression: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
-      if (node.expression && context.react.isReturningJSX(node)) {
+      if (node.expression && utils.isReturningJSX(node)) {
         components.add(node, 2);
       } else {
         components.add(node, 1);
@@ -366,7 +366,7 @@ function componentRule(rule, context) {
     },
 
     ThisExpression: function(node) {
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node || !/Function/.test(node.type)) {
         return;
       }
@@ -375,10 +375,10 @@ function componentRule(rule, context) {
     },
 
     ReturnStatement: function(node) {
-      if (!context.react.isReturningJSX(node)) {
+      if (!utils.isReturningJSX(node)) {
         return;
       }
-      node = context.react.getParentComponent();
+      node = utils.getParentComponent();
       if (!node) {
         return;
       }
@@ -387,7 +387,7 @@ function componentRule(rule, context) {
   };
 
   // Update the provided rule instructions to add the component detection
-  var ruleInstructions = rule(context, components);
+  var ruleInstructions = rule(context, components, utils);
   var updatedRuleInstructions = util._extend({}, ruleInstructions);
   Object.keys(detectionInstructions).forEach(function(instruction) {
     updatedRuleInstructions[instruction] = function(node) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "devDependencies": {
     "babel-eslint": "4.1.5",
     "coveralls": "2.11.4",
-    "eslint": "1.9.0",
+    "eslint": "1.10.0",
     "istanbul": "0.4.0",
     "mocha": "2.3.4"
   },


### PR DESCRIPTION
Instead of putting the `react` object on `context`, this PR creates it as a separate variable and passes it as a 3rd parameter to the fn passed to `Components.detect`.

fixes #323