### PR TITLE
Add `jsx-pascal-case` to complete list of rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Finally, enable all of the rules that you would like to use.
     "react/jsx-no-duplicate-props": 1,
     "react/jsx-no-literals": 1,
     "react/jsx-no-undef": 1,
+    "react/jsx-pascal-case": 1,
     "react/jsx-quotes": 1,
     "react/jsx-sort-prop-types": 1,
     "react/jsx-sort-props": 1,


### PR DESCRIPTION
The `jsx-pascal-case` isn't in the example complete config.