### PR TITLE
Allow consecutive uppercase letters in jsx-pascal-case

### DIFF
--- a/docs/rules/jsx-pascal-case.md
+++ b/docs/rules/jsx-pascal-case.md
@@ -20,6 +20,10 @@ The following patterns are considered warnings:
 <test_component />
 ```
 
+```js
+<YELLING />
+```
+
 The following patterns are not considered warnings:
 
 ```js
@@ -30,6 +34,10 @@ The following patterns are not considered warnings:
 <TestComponent>
   <div />
 </TestComponent>
+```
+
+```js
+<CSSTransitionGroup />
 ```
 
 ## When Not To Use It

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -11,7 +11,7 @@ var variableUtil = require('../util/variable');
 // Constants
 // ------------------------------------------------------------------------------
 
-var PASCAL_CASE_REGEX = /^[A-Z][a-z]+(?:[A-Z][a-z]+)*$/;
+var PASCAL_CASE_REGEX = /^[A-Z]+[a-z]+(?:[A-Z]+[a-z]*)*$/;
 
 // ------------------------------------------------------------------------------
 // Rule Definition

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -27,6 +27,22 @@ ruleTester.run('jsx-pascal-case', rule, {
     }
   }, {
     code: [
+      'var CSSTransitionGroup;',
+      '<CSSTransitionGroup />'
+    ].join('\n'),
+    ecmaFeatures: {
+      jsx: true
+    }
+  }, {
+    code: [
+      'var BetterThanCSS;',
+      '<BetterThanCSS />'
+    ].join('\n'),
+    ecmaFeatures: {
+      jsx: true
+    }
+  }, {
+    code: [
       'var TestComponent;',
       '<TestComponent>',
       '  <div />',
@@ -55,6 +71,15 @@ ruleTester.run('jsx-pascal-case', rule, {
       jsx: true
     },
     errors: [{message: 'Imported JSX component test_component must be in PascalCase'}]
+  }, {
+    code: [
+      'var YELLING;',
+      '<YELLING />'
+    ].join('\n'),
+    ecmaFeatures: {
+      jsx: true
+    },
+    errors: [{message: 'Imported JSX component YELLING must be in PascalCase'}]
   }, {
     code: [
       'var testComponent;',


### PR DESCRIPTION
I've run into a couple of cases where I have consecutive capital letters
in React components (e.g. <CSSTransitionGroup>), and jsx-pascal-case is
complaining about them. This commit fixes this problem by allowing
consecutive uppercase letters.

Fixes #328