### PR TITLE
fix: rules/prop-types crash

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -400,6 +400,10 @@ module.exports = Components.detect(function(context, components, utils) {
         }
         break;
       case 'VariableDeclarator':
+        if (!node.id || !node.id.properties) {
+          break;
+        }
+
         for (var i = 0, j = node.id.properties.length; i < j; i++) {
           // let {props: {firstname}} = this
           var thisDestructuring = (

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -400,9 +400,9 @@ module.exports = Components.detect(function(context, components, utils) {
         }
         break;
       case 'VariableDeclarator':
-        if (!node.id || !node.id.properties) {
-          break;
-        }
+        // if (!node.id || !node.id.properties) {
+        //   break;
+        // }
 
         for (var i = 0, j = node.id.properties.length; i < j; i++) {
           // let {props: {firstname}} = this
@@ -573,9 +573,18 @@ module.exports = Components.detect(function(context, components, utils) {
       // let {props: {firstname}} = this
       var thisDestructuring = node.init && node.init.type === 'ThisExpression' && node.id.type === 'ObjectPattern';
       // let {firstname} = props
-      var statelessDestructuring = node.init && node.init.name === 'props' && utils.getParentStatelessComponent();
+      var statelessDestructuring = node.init
+        && node.init.name === 'props'
+        && utils.getParentStatelessComponent();
+      var statelessDestructuringParentIsProps = statelessDestructuring
+        && statelessDestructuring.parent
+        && statelessDestructuring.parent.id
+        && statelessDestructuring.parent.id.type === 'ObjectPattern';
 
-      if (!thisDestructuring && !statelessDestructuring) {
+      if (
+        (!thisDestructuring && !statelessDestructuring)
+        || (statelessDestructuring && !statelessDestructuringParentIsProps)
+      ) {
         return;
       }
       markPropTypesAsUsed(node);

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -953,6 +953,38 @@ ruleTester.run('prop-types', rule, {
       ecmaFeatures: {
         jsx: true
       }
+    }, {
+      code: [
+        'var a = function() {',
+        '  var newProps1 = props1;',
+        '  const newProps2 = props2;',
+        '  let newProps3 = props3;',
+        '};',
+        'let b = function() {',
+        '  var newProps4 = props;',
+        '  const newProps5 = props;',
+        '  let newProps6 = props;',
+        '};',
+        'const c = function() {',
+        '  var newProps7 = props;',
+        '  const newProps8 = props;',
+        '  let newProps9 = props;',
+        '};',
+        'function d() {',
+        '  var newProps10 = props;',
+        '  const newProps11 = props;',
+        '  let newProps12 = props;',
+        '};',
+        'const e = () => {',
+        '  var newProps13 = props;',
+        '  const newProps14 = props;',
+        '  let newProps15 = props;',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      env: {
+        es6: true
+      }
     }
   ],
 


### PR DESCRIPTION
Adds a defensive check to prevent a crash:

```
eslint-plugin-react/lib/rules/prop-types.js:403
        for (var i = 0, j = node.id.properties.length; i < j; i++) {
                                              ^

TypeError: Cannot read property 'length' of undefined
    at markPropTypesAsUsed (eslint-plugin-react/lib/rules/prop-types.js:403:47)
    at EventEmitter.VariableDeclarator (eslint-plugin-react/lib/rules/prop-types.js:577:7)
    at emitOne (events.js:82:20)
    at EventEmitter.emit (events.js:169:7)
    at NodeEventGenerator.enterNode (eslint/lib/util/node-event-generator.js:42:22)
    at CommentEventGenerator.enterNode (eslint/lib/util/comment-event-generator.js:98:23)
    at Controller.controller.traverse.enter (eslint/lib/eslint.js:767:36)
    at Controller.__execute (estraverse/estraverse.js:397:31)
    at Controller.traverse (estraverse/estraverse.js:495:28)
    at EventEmitter.module.exports.api.verify (eslint/lib/eslint.js:764:24)
```