### PR TITLE
make jsx-handler-names error messages less specific

### DIFF
--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -51,19 +51,16 @@ module.exports = function(context) {
 
       var propIsEventHandler = PROP_EVENT_HANDLER_REGEX.test(propKey);
       var propFnIsNamedCorrectly = EVENT_HANDLER_REGEX.test(propValue);
-      var eventName;
 
       if (propIsEventHandler && !propFnIsNamedCorrectly) {
-        eventName = propKey.split(eventHandlerPropPrefix)[1];
         context.report(
           node,
-          'Handler function for ' + propKey + ' prop key must be named ' + eventHandlerPrefix + eventName
+          'Handler function for ' + propKey + ' prop key must begin with \'' + eventHandlerPrefix + '\''
         );
       } else if (propFnIsNamedCorrectly && !propIsEventHandler) {
-        eventName = propValue.split(eventHandlerPrefix)[1];
         context.report(
           node,
-          'Prop key for ' + propValue + ' must be named ' + eventHandlerPropPrefix + eventName
+          'Prop key for ' + propValue + ' must begin with \'' + eventHandlerPropPrefix + '\''
         );
       }
     }

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -68,7 +68,7 @@ ruleTester.run('jsx-handler-names', rule, {
     ecmaFeatures: {
       jsx: true
     },
-    errors: [{message: 'Handler function for onChange prop key must be named handleChange'}]
+    errors: [{message: 'Handler function for onChange prop key must begin with \'handle\''}]
   }, {
     code: [
       '<TestComponent handleChange={this.handleChange} />'
@@ -76,7 +76,7 @@ ruleTester.run('jsx-handler-names', rule, {
     ecmaFeatures: {
       jsx: true
     },
-    errors: [{message: 'Prop key for handleChange must be named onChange'}]
+    errors: [{message: 'Prop key for handleChange must begin with \'on\''}]
   }, {
     code: [
       '<TestComponent onChange={this.onChange} />'
@@ -84,6 +84,6 @@ ruleTester.run('jsx-handler-names', rule, {
     ecmaFeatures: {
       jsx: true
     },
-    errors: [{message: 'Handler function for onChange prop key must be named handleChange'}]
+    errors: [{message: 'Handler function for onChange prop key must begin with \'handle\''}]
   }]
 });


### PR DESCRIPTION
I realized the error messages were previously specifying a more specific method name than the rule actually enforced. 

For example, `onChange={this.itemClicked}` would throw the warning `Handler function for onChange prop key must be named handleChange`, when really `this.handleItemClick` would (and should) pass.