### PR TITLE
Add `pragma` config option to `react-in-jsx-scope`

### DIFF
--- a/docs/rules/react-in-jsx-scope.md
+++ b/docs/rules/react-in-jsx-scope.md
@@ -35,6 +35,26 @@ var Foo = require('foo');
 var Hello = <div>Hello {this.props.name}</div>;
 ```
 
+## Rule Options
+
+```js
+...
+"react-in-jsx-scope": [<enabled>, { "pragma": <string> }]
+...
+```
+
+### `pragma`
+
+As an alternative to specifying the above pragma in each source file, you can specify
+this configuration option:
+
+```js
+var Foo = require('Foo');
+
+var Hello = <div>Hello {this.props.name}</div>;
+```
+
+
 ## When Not To Use It
 
 If you are setting `React` as a global variable you can disable this rule.

--- a/lib/rules/react-in-jsx-scope.js
+++ b/lib/rules/react-in-jsx-scope.js
@@ -14,7 +14,8 @@ var JSX_ANNOTATION_REGEX = /^\*\s*@jsx\s+([^\s]+)/;
 
 module.exports = function(context) {
 
-  var id = 'React';
+  var config = context.options[0] || {};
+  var id = config.pragma || 'React';
   var NOT_DEFINED_MESSAGE = '\'{{name}}\' must be in scope when using JSX';
 
   return {
@@ -41,4 +42,12 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [];
+module.exports.schema = [{
+  type: 'object',
+  properties: {
+    pragma: {
+      type: 'string'
+    }
+  },
+  additionalProperties: false
+}];


### PR DESCRIPTION
Update the `react-in-jsx-scope` rule to match the behaviour of `jsx-uses-react`, allowing a custom `jsxPragma`.
```js
...
"react-in-jsx-scope": [2, { "pragma": "createElement" }]
...
```
Fixes: https://github.com/yannickcr/eslint-plugin-react/issues/228