### PR TITLE
allow es6 class rule to be configured to discourage usage as well

### DIFF
--- a/lib/rules/prefer-es6-class.js
+++ b/lib/rules/prefer-es6-class.js
@@ -11,11 +11,14 @@ var Components = require('../util/Components');
 // ------------------------------------------------------------------------------
 
 module.exports = Components.detect(function(context, components, utils) {
+  var configuration = context.options[0] || 'always';
 
   return {
     ObjectExpression: function(node) {
-      if (utils.isES5Component(node)) {
+      if (utils.isES5Component(node) && configuration === 'always') {
         context.report(node, 'Component should use es6 class instead of createClass');
+      } else if (utils.isES6Component(node) && configuration === 'never') {
+        context.report(node, 'Component should use createClass instead of es6 class');
       }
     }
   };


### PR DESCRIPTION
Doesn't change the default behavior, but allows you to specify 'never' as an option that recommends createClass over using es6 classes.

[The argument for switching is still a little murky](http://reactjsnews.com/composing-components/). In the meantime its nice to be able to force it in either case.
