### PR TITLE
Fix link in no-is-mounted documentation

### DIFF
--- a/docs/rules/no-is-mounted.md
+++ b/docs/rules/no-is-mounted.md
@@ -1,6 +1,6 @@
 # Prevent usage of isMounted (no-is-mounted)
 
-[`isMounted` is an anti-pattern](anti-pattern), is not available when using ES6 classes, and it is on its way to being officially deprecated.
+[`isMounted` is an anti-pattern][anti-pattern], is not available when using ES6 classes, and it is on its way to being officially deprecated.
 
 [anti-pattern]: https://facebook.github.io/react/blog/2015/12/16/ismounted-antipattern.html
 


### PR DESCRIPTION
When I made this link, I used the wrong markdown syntax so it was
linking to "anti-pattern" instead of the intended URL.