### PR TITLE
fix crashes in jsx-key

### DIFF
--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -46,13 +46,13 @@ module.exports = function(context) {
 
     // Array.prototype.map
     CallExpression: function (node) {
-      if (node.callee.property.name !== 'map') {
+      if (node.callee && node.callee.property && node.callee.property.name !== 'map') {
         return;
       }
 
       var fn = node.arguments[0];
-      var isFn = fn.type === 'FunctionExpression';
-      var isArrFn = fn.type === 'ArrowFunctionExpression';
+      var isFn = fn && fn.type === 'FunctionExpression';
+      var isArrFn = fn && fn.type === 'ArrowFunctionExpression';
 
       if (isArrFn && fn.body.type === 'JSXElement') {
         checkIteratorElement(fn.body);
@@ -60,9 +60,10 @@ module.exports = function(context) {
 
       if (isFn || isArrFn) {
         if (fn.body.type === 'BlockStatement') {
-          checkIteratorElement(
-            getReturnStatement(fn.body.body).argument
-          );
+          var returnStatement = getReturnStatement(fn.body.body);
+          if (returnStatement) {
+            checkIteratorElement(returnStatement.argument);
+          }
         }
       }
     }

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -25,6 +25,8 @@ var parserOptions = {
 var ruleTester = new RuleTester();
 ruleTester.run('jsx-key', rule, {
   valid: [
+    {code: 'fn()', parserOptions: parserOptions},
+    {code: '[1, 2, 3].map(function () {})', parserOptions: parserOptions},
     {code: '<App />;', parserOptions: parserOptions},
     {code: '[<App key={0} />, <App key={1} />];', parserOptions: parserOptions},
     {code: '[1, 2, 3].map(function(x) { return <App key={x} /> });', parserOptions: parserOptions},


### PR DESCRIPTION
I was having the same crashes as #373 when using `jsx-key`.

It was triggering for non jsx stuff, so I added a few "valid" tests which don't actually test anything except that the rule doesn't crash. I'm not sure if its appropriate to have those tests in the specific rule test file, but I figured it would be good to prevent regressions.