### PR TITLE
rule: forbid-prop-types, handle situation where getFirstTokens() call returns only 1 Token

### DIFF
--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -33,7 +33,7 @@ module.exports = function(context) {
     // (babel-eslint does not expose property name so we have to rely on tokens)
     if (node.type === 'ClassProperty') {
       var tokens = context.getFirstTokens(node, 2);
-      if (tokens[0].value === 'propTypes' || tokens[1].value === 'propTypes') {
+      if (tokens[0].value === 'propTypes' || (tokens[1] && tokens[1].value === 'propTypes')) {
         return true;
       }
       return false;


### PR DESCRIPTION
if you run `eslint test.jsx`
```js
//test.jsx
class A {
  const
}
```
with
```
//.eslintrc
{
  "parser": "babel-eslint",
  "ecmaFeatures": {
    "jsx": true
  },
  "rules": {
    "react/forbid-prop-types": 1,
  },
  "plugins": [
    "react"
  ]
}
```
you get the following output
```
/Users/nuno/cp/james/node_modules/eslint-plugin-react/lib/rules/forbid-prop-types.js:38
        if (tokens[0].value === 'propTypes' || tokens[1].value === 'propTypes') {
                                                        ^

TypeError: Cannot read property 'value' of undefined
    at isPropTypesDeclaration (/Users/nuno/cp/james/node_modules/eslint-plugin-react/lib/rules/forbid-prop-types.js:38:19)
    at EventEmitter.ClassProperty (/Users/nuno/cp/james/node_modules/eslint-plugin-react/lib/rules/forbid-prop-types.js:87:11)
    at emitOne (events.js:77:13)
    at EventEmitter.emit (events.js:169:7)
    at NodeEventGenerator.enterNode (/Users/nuno/cp/james/node_modules/eslint/lib/util/node-event-generator.js:42:22)
    at CommentEventGenerator.enterNode (/Users/nuno/cp/james/node_modules/eslint/lib/util/comment-event-generator.js:98:23)

    at Controller.controller.traverse.enter (/Users/nuno/cp/james/node_modules/eslint/lib/eslint.js:767:36)
    at Controller.__execute (/Users/nuno/cp/james/node_modules/estraverse/estraverse.js:397:31)
    at Controller.traverse (/Users/nuno/cp/james/node_modules/estraverse/estraverse.js:495:28)
    at EventEmitter.module.exports.api.verify (/Users/nuno/cp/james/node_modules/eslint/lib/eslint.js:764:24)
```
because tokens is
```
[ Token {
    type: 'Keyword',
    value: 'const',
    start: 12,
    end: 17,
    loc: SourceLocation { start: [Object], end: [Object] },
    range: [ 12, 17 ] } ]
```

PS: (not sure whether we should also test for tokens[0] in the same fashion)
PPS: i know that first file is non-sensical javascript, this bug manifests itself when eslint is run continuously (eg. with the atom plugin linter-eslint), imagine that line saying `const` as what the linter sees when i'm midway writing `constructor`