### PR TITLE
fix another crash in jsx-key

### DIFF
--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -61,7 +61,7 @@ module.exports = function(context) {
       if (isFn || isArrFn) {
         if (fn.body.type === 'BlockStatement') {
           var returnStatement = getReturnStatement(fn.body.body);
-          if (returnStatement) {
+          if (returnStatement && returnStatement.argument) {
             checkIteratorElement(returnStatement.argument);
           }
         }


### PR DESCRIPTION
similar to PR #374

fix this crash:
```
TypeError: Cannot read property 'type' of null
    at checkIteratorElement (/Users/nuno/cp/james/node_modules/eslint-plugin-react/lib/rules/jsx-key.js:25:13)
    at EventEmitter.CallExpression (/Users/nuno/cp/james/node_modules/eslint-plugin-react/lib/rules/jsx-key.js:65:13)
```