### PR TITLE
Docs: How to automatically sort-comp compliance

### DIFF
--- a/docs/rules/sort-comp.md
+++ b/docs/rules/sort-comp.md
@@ -2,6 +2,8 @@
 
 When creating React components it is more convenient to always follow the same organisation for methods order to helps you to easily find lifecyle methods, event handlers, etc.
 
+**Fixable:** This rule is automatically fixable using the [`sort-comp` transform](https://github.com/reactjs/react-codemod/blob/master/transforms/sort-comp.js) in [react-codemod](https://www.npmjs.com/package/react-codemod).
+
 ## Rule Details
 
 With default configuration the following organisation must be followed:


### PR DESCRIPTION
There's now a jstransform codemod to do this automatically,
https://github.com/reactjs/react-codemod/blob/master/transforms/sort-comp.js

Added a note about it based on the pattern in http://eslint.org/docs/rules/no-trailing-spaces