### PR TITLE
Add `requiredFirst` option to jsx-sort-prop-types

### DIFF
--- a/docs/rules/jsx-sort-prop-types.md
+++ b/docs/rules/jsx-sort-prop-types.md
@@ -80,7 +80,8 @@ class Component extends React.Component {
 ...
 "jsx-sort-prop-types": [<enabled>, {
   "callbacksLast": <boolean>,
-  "ignoreCase": <boolean>
+  "ignoreCase": <boolean>,
+  "requiredFirst": <boolean>,
 }]
 ...
 ```
@@ -100,6 +101,22 @@ var Component = React.createClass({
     z: React.PropTypes.string,
     onBar: React.PropTypes.func,
     onFoo: React.PropTypes.func,
+  },
+...
+});
+```
+
+### `requiredFirst`
+
+When `true`, prop types for required props must be listed before all other props:
+
+```js
+var Component = React.createClass({
+  propTypes: {
+    barRequired: React.PropTypes.any.isRequired,
+    fooRequired: React.PropTypes.any.isRequired,
+    a: React.PropTypes.number,
+    z: React.PropTypes.string,
   },
 ...
 });

--- a/lib/rules/jsx-sort-prop-types.js
+++ b/lib/rules/jsx-sort-prop-types.js
@@ -77,8 +77,8 @@ module.exports = function(context) {
         }
         if (!previousIsRequired && currentIsRequired) {
           // Encountered a non-required prop after a required prop
-          context.report(prev, 'Required prop types must be listed before all other prop types');
-          return prev;
+          context.report(curr, 'Required prop types must be listed before all other prop types');
+          return curr;
         }
       }
 

--- a/lib/rules/jsx-sort-prop-types.js
+++ b/lib/rules/jsx-sort-prop-types.js
@@ -10,6 +10,7 @@
 module.exports = function(context) {
 
   var configuration = context.options[0] || {};
+  var requiredFirst = configuration.requiredFirst || false;
   var callbacksLast = configuration.callbacksLast || false;
   var ignoreCase = configuration.ignoreCase || false;
 
@@ -38,8 +39,16 @@ module.exports = function(context) {
     return node.key.type === 'Identifier' ? node.key.name : node.key.value;
   }
 
+  function getValueName(node) {
+    return node.value.property.name;
+  }
+
   function isCallbackPropName(propName) {
     return /^on[A-Z]/.test(propName);
+  }
+
+  function isRequiredProp(node) {
+    return getValueName(node) === 'isRequired';
   }
 
   /**
@@ -51,12 +60,26 @@ module.exports = function(context) {
     declarations.reduce(function(prev, curr) {
       var prevPropName = getKey(prev);
       var currentPropName = getKey(curr);
+      var previousIsRequired = isRequiredProp(prev);
+      var currentIsRequired = isRequiredProp(curr);
       var previousIsCallback = isCallbackPropName(prevPropName);
       var currentIsCallback = isCallbackPropName(currentPropName);
 
       if (ignoreCase) {
         prevPropName = prevPropName.toLowerCase();
         currentPropName = currentPropName.toLowerCase();
+      }
+
+      if (requiredFirst) {
+        if (previousIsRequired && !currentIsRequired) {
+          // Transition between required and non-required. Don't compare for alphabetical.
+          return curr;
+        }
+        if (!previousIsRequired && currentIsRequired) {
+          // Encountered a non-required prop after a required prop
+          context.report(prev, 'Required prop types must be listed before all other prop types');
+          return prev;
+        }
       }
 
       if (callbacksLast) {
@@ -117,6 +140,9 @@ module.exports = function(context) {
 module.exports.schema = [{
   type: 'object',
   properties: {
+    requiredFirst: {
+      type: 'boolean'
+    },
     callbacksLast: {
       type: 'boolean'
     },

--- a/tests/lib/rules/jsx-sort-prop-types.js
+++ b/tests/lib/rules/jsx-sort-prop-types.js
@@ -538,6 +538,29 @@ ruleTester.run('jsx-sort-prop-types', rule, {
     code: [
       'var First = React.createClass({',
       '  propTypes: {',
+      '    fooRequired: React.PropTypes.string.isRequired,',
+      '    barRequired: React.PropTypes.string.isRequired,',
+      '    a: React.PropTypes.any',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      requiredFirst: true
+    }],
+    parserOptions: parserOptions,
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 4,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: {',
       '    a: React.PropTypes.any,',
       '    barRequired: React.PropTypes.string.isRequired,',
       '    onFoo: React.PropTypes.func',
@@ -553,7 +576,7 @@ ruleTester.run('jsx-sort-prop-types', rule, {
     parserOptions: parserOptions,
     errors: [{
       message: 'Required prop types must be listed before all other prop types',
-      line: 3,
+      line: 4,
       column: 5,
       type: 'Property'
     }]

--- a/tests/lib/rules/jsx-sort-prop-types.js
+++ b/tests/lib/rules/jsx-sort-prop-types.js
@@ -195,6 +195,20 @@ ruleTester.run('jsx-sort-prop-types', rule, {
     code: [
       'var First = React.createClass({',
       '  propTypes: {',
+      '    barRequired: React.PropTypes.func.isRequired,',
+      '    onBar: React.PropTypes.func,',
+      '    z: React.PropTypes.any',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: {',
       '    a: React.PropTypes.any,',
       '    z: React.PropTypes.string,',
       '    onBar: React.PropTypes.func,',
@@ -243,6 +257,43 @@ ruleTester.run('jsx-sort-prop-types', rule, {
       '};'
     ].join('\n'),
     options: [{
+      callbacksLast: true
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.propTypes = {',
+      '    barRequired: React.PropTypes.string.isRequired,',
+      '    a: React.PropTypes.any',
+      '};'
+    ].join('\n'),
+    options: [{
+      requiredFirst: true
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.propTypes = {',
+      '    barRequired: React.PropTypes.string.isRequired,',
+      '    fooRequired: React.PropTypes.any.isRequired,',
+      '    a: React.PropTypes.any,',
+      '    z: React.PropTypes.string,',
+      '    onBar: React.PropTypes.func,',
+      '    onFoo: React.PropTypes.func',
+      '};'
+    ].join('\n'),
+    options: [{
+      requiredFirst: true,
       callbacksLast: true
     }],
     parserOptions: parserOptions
@@ -480,6 +531,29 @@ ruleTester.run('jsx-sort-prop-types', rule, {
     errors: [{
       message: 'Callback prop types must be listed after all other prop types',
       line: 5,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: {',
+      '    a: React.PropTypes.any,',
+      '    barRequired: React.PropTypes.string.isRequired,',
+      '    onFoo: React.PropTypes.func',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      requiredFirst: true
+    }],
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Required prop types must be listed before all other prop types',
+      line: 3,
       column: 5,
       type: 'Property'
     }]


### PR DESCRIPTION
Hey there, I've been really enjoying `eslint-plugin-react`, thanks for creating such a great set of React rules for ESLint!

Our team likes to put required prop type declarations first, followed by optional prop types. I extended the existing `jsx-sort-prop-types` rule to take a `requiredFirst` option to make this enforceable by ESLint.

When set to `true` required props must come first and be sorted alphabetically:

```js
class First extends React.Component {
  render() {
    return <div />;
  }
}

First.propTypes = {
  barRequired: React.PropTypes.string.isRequired,
  fooRequired: React.PropTypes.any.isRequired,
  a: React.PropTypes.any,
  z: React.PropTypes.string,
  onBar: React.PropTypes.func,
  onFoo: React.PropTypes.func
};
```

In addition to the changes this PR includes tests and documentation.

Figured others could find it useful too. :smiley: 