### PR TITLE
Add auto fix for jsx-curly-spacing

### DIFF
--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -1,6 +1,12 @@
 /**
  * @fileoverview Enforce or disallow spaces inside of curly braces in JSX attributes.
- * @author Jamund Ferguson, Brandyn Bennett, Michael Ficarra, Vignesh Anand, Jamund Ferguson, Yannick Croissant
+ * @author Jamund Ferguson
+ * @author Brandyn Bennett
+ * @author Michael Ficarra
+ * @author Vignesh Anand
+ * @author Jamund Ferguson
+ * @author Yannick Croissant
+ * @author Erik Wendel
  */
 'use strict';
 
@@ -43,8 +49,15 @@ module.exports = function(context) {
   * @returns {void}
   */
   function reportNoBeginningNewline(node, token) {
-    context.report(node, token.loc.start,
-      'There should be no newline after \'' + token.value + '\'');
+    context.report({
+      node: node,
+      loc: token.loc.start,
+      message: 'There should be no newline after \'' + token.value + '\'',
+      fix: function(fixer) {
+        var nextToken = context.getSourceCode().getTokenAfter(token);
+        return fixer.replaceTextRange([token.range[1], nextToken.range[0]], spaced ? ' ' : '');
+      }
+    });
   }
 
   /**
@@ -54,8 +67,15 @@ module.exports = function(context) {
   * @returns {void}
   */
   function reportNoEndingNewline(node, token) {
-    context.report(node, token.loc.start,
-      'There should be no newline before \'' + token.value + '\'');
+    context.report({
+      node: node,
+      loc: token.loc.start,
+      message: 'There should be no newline before \'' + token.value + '\'',
+      fix: function(fixer) {
+        var previousToken = context.getSourceCode().getTokenBefore(token);
+        return fixer.replaceTextRange([previousToken.range[1], token.range[0]], spaced ? ' ' : '');
+      }
+    });
   }
 
   /**
@@ -65,8 +85,15 @@ module.exports = function(context) {
   * @returns {void}
   */
   function reportNoBeginningSpace(node, token) {
-    context.report(node, token.loc.start,
-      'There should be no space after \'' + token.value + '\'');
+    context.report({
+      node: node,
+      loc: token.loc.start,
+      message: 'There should be no space after \'' + token.value + '\'',
+      fix: function(fixer) {
+        var nextToken = context.getSourceCode().getTokenAfter(token);
+        return fixer.removeRange([token.range[1], nextToken.range[0]]);
+      }
+    });
   }
 
   /**
@@ -76,8 +103,15 @@ module.exports = function(context) {
   * @returns {void}
   */
   function reportNoEndingSpace(node, token) {
-    context.report(node, token.loc.start,
-      'There should be no space before \'' + token.value + '\'');
+    context.report({
+      node: node,
+      loc: token.loc.start,
+      message: 'There should be no space before \'' + token.value + '\'',
+      fix: function(fixer) {
+        var previousToken = context.getSourceCode().getTokenBefore(token);
+        return fixer.removeRange([previousToken.range[1], token.range[0]]);
+      }
+    });
   }
 
   /**
@@ -87,8 +121,14 @@ module.exports = function(context) {
   * @returns {void}
   */
   function reportRequiredBeginningSpace(node, token) {
-    context.report(node, token.loc.start,
-      'A space is required after \'' + token.value + '\'');
+    context.report({
+      node: node,
+      loc: token.loc.start,
+      message: 'A space is required after \'' + token.value + '\'',
+      fix: function(fixer) {
+        return fixer.insertTextAfter(token, ' ');
+      }
+    });
   }
 
   /**
@@ -98,8 +138,14 @@ module.exports = function(context) {
   * @returns {void}
   */
   function reportRequiredEndingSpace(node, token) {
-    context.report(node, token.loc.start,
-          'A space is required before \'' + token.value + '\'');
+    context.report({
+      node: node,
+      loc: token.loc.start,
+      message: 'A space is required before \'' + token.value + '\'',
+      fix: function(fixer) {
+        return fixer.insertTextBefore(token, ' ');
+      }
+    });
   }
 
   /**

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforce or disallow spaces inside of curly braces in JSX attributes.
  * @author Yannick Croissant
+ * @author Erik Wendel
  */
 'use strict';
 
@@ -81,6 +82,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
 
   invalid: [{
     code: '<App foo={ bar } />;',
+    output: '<App foo={bar} />;',
     options: ['never'],
     errors: [{
       message: 'There should be no space after \'{\''
@@ -90,6 +92,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
     parserOptions: parserOptions
   }, {
     code: '<App foo={ bar } />;',
+    output: '<App foo={bar} />;',
     options: ['never', {allowMultiline: false}],
     errors: [{
       message: 'There should be no space after \'{\''
@@ -99,6 +102,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
     parserOptions: parserOptions
   }, {
     code: '<App foo={bar} />;',
+    output: '<App foo={ bar } />;',
     options: ['always'],
     errors: [{
       message: 'A space is required after \'{\''
@@ -108,6 +112,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
     parserOptions: parserOptions
   }, {
     code: '<App foo={bar} />;',
+    output: '<App foo={ bar } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
       message: 'A space is required after \'{\''
@@ -117,6 +122,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
     parserOptions: parserOptions
   }, {
     code: '<App foo={ bar} />;',
+    output: '<App foo={ bar } />;',
     options: ['always'],
     errors: [{
       message: 'A space is required before \'}\''
@@ -124,6 +130,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
     parserOptions: parserOptions
   }, {
     code: '<App foo={bar } />;',
+    output: '<App foo={ bar } />;',
     options: ['always'],
     errors: [{
       message: 'A space is required after \'{\''
@@ -131,6 +138,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
     parserOptions: parserOptions
   }, {
     code: '<App foo={ bar} />;',
+    output: '<App foo={bar} />;',
     options: ['never'],
     errors: [{
       message: 'There should be no space after \'{\''
@@ -138,6 +146,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
     parserOptions: parserOptions
   }, {
     code: '<App foo={bar } />;',
+    output: '<App foo={bar} />;',
     options: ['never'],
     errors: [{
       message: 'There should be no space before \'}\''
@@ -149,6 +158,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
       'bar',
       '} />;'
     ].join('\n'),
+    output: '<App foo={bar} />;',
     options: ['never', {allowMultiline: false}],
     errors: [{
       message: 'There should be no space after \'{\''
@@ -162,6 +172,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
       'bar',
       '} />;'
     ].join('\n'),
+    output: '<App foo={ bar } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
       message: 'There should be no newline after \'{\''


### PR DESCRIPTION
Hello!

This PR implements autofixing for the rule "jsx-curly-spacing", meaning it will add or remove whitespaces in JSX expressions according to the given options.

We would like to use this rule on our app but have too many errors for a manual fix, so I thought I'd give it a go.

This is my first PR to any opensource project ever, so my apologies if I got something wrong!