### PR TITLE
Fix jsx-sort-prop-types issue with custom propTypes

### DIFF
--- a/lib/rules/jsx-sort-prop-types.js
+++ b/lib/rules/jsx-sort-prop-types.js
@@ -40,7 +40,7 @@ module.exports = function(context) {
   }
 
   function getValueName(node) {
-    return node.value.property.name;
+    return node.value.property && node.value.property.name;
   }
 
   function isCallbackPropName(propName) {

--- a/tests/lib/rules/jsx-sort-prop-types.js
+++ b/tests/lib/rules/jsx-sort-prop-types.js
@@ -284,6 +284,21 @@ ruleTester.run('jsx-sort-prop-types', rule, {
       '  }',
       '}',
       'First.propTypes = {',
+      '    fooRequired: MyPropType,',
+      '};'
+    ].join('\n'),
+    options: [{
+      requiredFirst: true
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.propTypes = {',
       '    barRequired: React.PropTypes.string.isRequired,',
       '    fooRequired: React.PropTypes.any.isRequired,',
       '    a: React.PropTypes.any,',


### PR DESCRIPTION
Closes #408

caveats:

Might not behave correctly with complex propTypes when the are `required` although this was a problem with the original PR ( #392 ). But it might be fixed here too. I simply don't know how :grin: 