### PR TITLE
Update babel-eslint 5.0.0-beta6 -> 5.0.0-beta10

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/yannickcr/eslint-plugin-react",
   "bugs": "https://github.com/yannickcr/eslint-plugin-react/issues",
   "devDependencies": {
-    "babel-eslint": "5.0.0-beta6",
+    "babel-eslint": "5.0.0-beta10",
     "coveralls": "2.11.6",
     "eslint": "2.0.0-alpha-1",
     "istanbul": "0.4.1",


### PR DESCRIPTION
The current version gives me the following error when I try to run tests
on master:

> TypeError: Cannot read property 'visitClass' of undefined

It looks like this has since been resolved by the related packages, so
we can avoid this problem by bumping versions.

More info: https://github.com/babel/babel-eslint/issues/243