### PR TITLE
False positive jsx key rule

### DIFF
--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -52,6 +52,10 @@ module.exports = function(context) {
 
     // Array.prototype.map
     CallExpression: function (node) {
+      if (node.callee && node.callee.type !== 'MemberExpression') {
+        return;
+      }
+
       if (node.callee && node.callee.property && node.callee.property.name !== 'map') {
         return;
       }

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -34,7 +34,8 @@ ruleTester.run('jsx-key', rule, {
     {code: '[1, 2, 3].map(x => { return <App key={x} /> });', parserOptions: parserOptions},
     {code: '[1, 2, 3].foo(x => <App />);', parserOptions: parserOptions},
     {code: 'var App = () => <div />;', parserOptions: parserOptions},
-    {code: '[1, 2, 3].map(function(x) { return; });', parserOptions: parserOptions}
+    {code: '[1, 2, 3].map(function(x) { return; });', parserOptions: parserOptions},
+    {code: 'foo(() => <div />);', parserOptions: parserOptions}
   ],
   invalid: [
     {code: '[<App />];',


### PR DESCRIPTION
Identified and added a fix for a false positive from the `jsx-key` rule. Happens when you pass a function that returns a `JSXElement` as the first parameter.