### PR TITLE
Updated description to provide more context

### DIFF
--- a/docs/rules/no-set-state.md
+++ b/docs/rules/no-set-state.md
@@ -1,6 +1,6 @@
 # Prevent usage of setState (no-set-state)
 
-When using an architecture that separates your application state from your UI components (e.g. Flux), it may be desirable to forbid the use of local component state.
+When using an architecture that separates your application state from your UI components (e.g. Flux), it may be desirable to forbid the use of local component state. This rule is especially helpful in read-only applications (that don't use forms), since local component state should rarely be necessary in such cases.
 
 ## Rule Details
 


### PR DESCRIPTION
I've found this rule really helpful on Flux/Redux apps that don't use forms. I typically only use setState when working with forms.