### PR TITLE
Parse explicit declaration that class extends React.Component

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -5,6 +5,7 @@
 'use strict';
 
 var util = require('util');
+var doctrine = require('doctrine');
 var variableUtil = require('./variable');
 var pragmaUtil = require('./pragma');
 
@@ -143,6 +144,10 @@ function componentRule(rule, context) {
      * @returns {Boolean} True if the node is a React ES5 component, false if not
      */
     isES5Component: function(node) {
+      if (utils.isExplicitComponent(node)) {
+        return true;
+      }
+
       if (!node.parent) {
         return false;
       }
@@ -156,10 +161,39 @@ function componentRule(rule, context) {
      * @returns {Boolean} True if the node is a React ES6 component, false if not
      */
     isES6Component: function(node) {
+      if (utils.isExplicitComponent(node)) {
+        return true;
+      }
+
       if (!node.superClass) {
         return false;
       }
       return new RegExp('^(' + pragma + '\\.)?Component$').test(sourceCode.getText(node.superClass));
+    },
+
+    /**
+     * Check if the node is explicitly declared as a descendant of a React Component
+     *
+     * @param {ASTNode} node The AST node being checked (can be a ReturnStatement or an ArrowFunctionExpression).
+     * @returns {Boolean} True if the node is explicitly declared as a descendant of a React Component, false if not
+     */
+    isExplicitComponent: function(node) {
+      var comment = sourceCode.getJSDocComment(node);
+
+      if (comment === null) {
+        return false;
+      }
+
+      var commentAst = doctrine.parse(comment.value, {
+        unwrap: true,
+        tags: ['extends', 'augments']
+      });
+
+      var relevantTags = commentAst.tags.filter(function(tag) {
+        return tag.name === 'React.Component';
+      });
+
+      return relevantTags.length > 0;
     },
 
     /**

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -144,10 +144,6 @@ function componentRule(rule, context) {
      * @returns {Boolean} True if the node is a React ES5 component, false if not
      */
     isES5Component: function(node) {
-      if (utils.isExplicitComponent(node)) {
-        return true;
-      }
-
       if (!node.parent) {
         return false;
       }

--- a/package.json
+++ b/package.json
@@ -22,10 +22,12 @@
   },
   "homepage": "https://github.com/yannickcr/eslint-plugin-react",
   "bugs": "https://github.com/yannickcr/eslint-plugin-react/issues",
+  "dependencies": {
+    "doctrine": "^1.2.0"
+  },
   "devDependencies": {
     "babel-eslint": "6.0.0-beta.6",
     "coveralls": "2.11.8",
-    "doctrine": "^1.2.0",
     "eslint": "2.4.0",
     "istanbul": "0.4.2",
     "mocha": "2.4.5"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-eslint": "6.0.0-beta.6",
     "coveralls": "2.11.8",
+    "doctrine": "^1.2.0",
     "eslint": "2.4.0",
     "istanbul": "0.4.2",
     "mocha": "2.4.5"

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1235,6 +1235,22 @@ ruleTester.run('prop-types', rule, {
       }]
     }, {
       code: [
+        '/** @extends React.Component */',
+        'class Hello extends ChildComponent {',
+        '  render() {',
+        '    return <div>Hello {this.props.name}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'name\' is missing in props validation',
+        line: 4,
+        column: 35,
+        type: 'Identifier'
+      }]
+    }, {
+      code: [
         'class Hello extends React.Component {',
         '  render() {',
         '    return <div>Hello {this.props.firstname} {this.props.lastname}</div>;',


### PR DESCRIPTION
This small addition enables linting component-specific rules if the author uses a JSDoc explicitly indicating that the component is a descendent of React.Component

e.g.
```
/** @extends React.Component */
class MyClass extends ChildClass {
...
```

Provides a good workaround for issues such as #68 