### PR TITLE
Add prefix-members rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,8 @@ module.exports = {
     'prefer-es6-class': require('./lib/rules/prefer-es6-class'),
     'jsx-key': require('./lib/rules/jsx-key'),
     'no-string-refs': require('./lib/rules/no-string-refs'),
-    'prefer-stateless-function': require('./lib/rules/prefer-stateless-function')
+    'prefer-stateless-function': require('./lib/rules/prefer-stateless-function'),
+    'prefix-members': require('./lib/rules/prefix-members')
   },
   configs: {
     recommended: {

--- a/lib/rules/prefix-members.js
+++ b/lib/rules/prefix-members.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Enforce "_" prefix to user methods in a React component definition
+ * @author Adrian Toncean
+ */
+'use strict';
+
+var Components = require('../util/Components');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = Components.detect(function(context, components, utils) {
+  var reactMemberNames = [
+    'displayName',
+    'propTypes',
+    'contextTypes',
+    'childContextTypes',
+    'mixins',
+    'statics',
+    'defaultProps',
+    'constructor',
+    'getDefaultProps',
+    'state',
+    'getInitialState',
+    'getChildContext',
+    'componentWillMount',
+    'componentDidMount',
+    'componentWillReceiveProps',
+    'shouldComponentUpdate',
+    'componentWillUpdate',
+    'componentDidUpdate',
+    'render',
+    'componentWillUnmount'
+  ];
+
+  function isValid(name) {
+    return name[0] === '_' || reactMemberNames.indexOf(name) !== -1;
+  }
+
+  function verifyMember(member) {
+    if (
+      !member.computed &&
+      member.key && member.key.type === 'Identifier'
+    ) {
+      if (!isValid(member.key.name)) {
+        context.report({
+          node: member.key,
+          message: 'User-defined component member "{{name}}" must be prefixed with an "_"',
+          data: {
+            name: member.key.name
+          }
+        });
+      }
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Public
+  // --------------------------------------------------------------------------
+
+  return {
+    ObjectExpression: function(node) {
+      if (utils.isES5Component(node)) {
+        node.properties.forEach(verifyMember);
+      }
+    },
+    ClassDeclaration: function(node) {
+      if (utils.isES6Component(node)) {
+        node.body.body.forEach(verifyMember);
+      }
+    }
+  };
+});
+
+module.exports.schema = [];

--- a/tests/lib/rules/prefix-members.js
+++ b/tests/lib/rules/prefix-members.js
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview Enforce "_" prefix to user methods in a React component definition
+ * @author Adrian Toncean
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/prefix-members');
+var RuleTester = require('eslint').RuleTester;
+
+require('babel-eslint');
+
+var parserOptions = {
+  ecmaVersion: 6,
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('prefix-members', rule, {
+  valid: [{
+    code: [
+      'var Hello = React.createClass({',
+      '  render: function() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var Hello = React.createClass({',
+      '  _handleClick: function() {',
+      '    console.log(\'click\');',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  _handleClick() {',
+      '    console.log(\'click\');',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var Hello = {',
+      '  renader: function() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '};'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class Hello extends Greeting {',
+      '  reander() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var Hello = React.createClass({',
+      '  [RENDER]: function() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  [RENDER]() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }],
+  invalid: [{
+    code: [
+      'var Hello = React.createClass({',
+      '  reander: function() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'User-defined component member "reander" must be prefixed with an "_"'
+    }]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  reander() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'User-defined component member "reander" must be prefixed with an "_"'
+    }]
+  }]
+});


### PR DESCRIPTION
I've mistyped `shouldComponentUpdate` and other React class members with long names too many times. This rule is intended to prevent that.

There's an unwritten convention that user methods should start with an `_` (flux tutorial uses this http://facebook.github.io/flux/docs/todo-list.html). This way it's easy to tell if a React method was misspelled by checking that member names that don't start with an `_` are in a short list of valid React methods.

This rule appeals to people who want to enforce the `_` prefix and also avoid bugs caused by typos.

Example that triggers a warning:

``` js
var Hello = React.createClass({
  componentDidUpdaet() { 
    // this never executes since there's a typo in the method name
  },
  render: function() {
    return <div>Hello {this.props.name}</div>;
  }
});
```

Example that doesn't trigger a warning:

``` js
var Hello = React.createClass({
  _handleClick() { 
    // ...
  },
  render: function() {
    return <div onClick={this._handleClick}>Hello {this.props.name}</div>;
  }
});
```

It has 100% coverage, but no doc yet - if this rule is good to be merged then I can write that too.
