### PR TITLE
Update docs to specify JSX closing bracket location as fixable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The plugin has a [recommended configuration](#user-content-recommended-configura
 ## JSX-specific rules
 
 * [jsx-boolean-value](docs/rules/jsx-boolean-value.md): Enforce boolean attributes notation in JSX (fixable)
-* [jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md): Validate closing bracket location in JSX
+* [jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md): Validate closing bracket location in JSX (fixable)
 * [jsx-curly-spacing](docs/rules/jsx-curly-spacing.md): Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
 * [jsx-equals-spacing](docs/rules/jsx-equals-spacing.md): Enforce or disallow spaces around equal signs in JSX attributes (fixable)
 * [jsx-handler-names](docs/rules/jsx-handler-names.md): Enforce event handler naming conventions in JSX

--- a/docs/rules/jsx-closing-bracket-location.md
+++ b/docs/rules/jsx-closing-bracket-location.md
@@ -2,6 +2,8 @@
 
 Enforce the closing bracket location for JSX multiline elements.
 
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+
 ## Rule Details
 
 This rule checks all JSX multiline elements and verifies the location of the closing bracket. By default this one must be aligned with the opening tag.


### PR DESCRIPTION
Forgot to update the docs earlier.