### PR TITLE
New rule: jsx-spread-operator-position

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ The plugin has a [recommended configuration](#user-content-recommended-configura
 * [jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md): Validate closing bracket location in JSX (fixable)
 * [jsx-curly-spacing](docs/rules/jsx-curly-spacing.md): Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
 * [jsx-equals-spacing](docs/rules/jsx-equals-spacing.md): Enforce or disallow spaces around equal signs in JSX attributes (fixable)
-* [jsx-first-prop-new-line](docs/rules/jsx-first-prop-new-line.md): Enforce position of the first prop in JSX
 * [jsx-handler-names](docs/rules/jsx-handler-names.md): Enforce event handler naming conventions in JSX
 * [jsx-indent-props](docs/rules/jsx-indent-props.md): Validate props indentation in JSX (fixable)
 * [jsx-indent](docs/rules/jsx-indent.md): Validate JSX indentation

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The plugin has a [recommended configuration](#user-content-recommended-configura
 * [jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md): Validate closing bracket location in JSX (fixable)
 * [jsx-curly-spacing](docs/rules/jsx-curly-spacing.md): Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
 * [jsx-equals-spacing](docs/rules/jsx-equals-spacing.md): Enforce or disallow spaces around equal signs in JSX attributes (fixable)
+* [jsx-first-prop-new-line](docs/rules/jsx-first-prop-new-line.md): Enforce position of the first prop in JSX
 * [jsx-handler-names](docs/rules/jsx-handler-names.md): Enforce event handler naming conventions in JSX
 * [jsx-indent-props](docs/rules/jsx-indent-props.md): Validate props indentation in JSX (fixable)
 * [jsx-indent](docs/rules/jsx-indent.md): Validate JSX indentation
@@ -114,6 +115,7 @@ The plugin has a [recommended configuration](#user-content-recommended-configura
 * [jsx-pascal-case](docs/rules/jsx-pascal-case.md): Enforce PascalCase for user-defined JSX components
 * [jsx-sort-props](docs/rules/jsx-sort-props.md): Enforce props alphabetical sorting
 * [jsx-space-before-closing](docs/rules/jsx-space-before-closing.md): Validate spacing before closing bracket in JSX (fixable)
+* [jsx-spread-operator-position](docs/rules/jsx-spread-operator-position.md): Enforce position of spread operator when using it to pass props in JSX.
 * [jsx-uses-react](docs/rules/jsx-uses-react.md): Prevent React to be incorrectly marked as unused
 * [jsx-uses-vars](docs/rules/jsx-uses-vars.md): Prevent variables used in JSX to be incorrectly marked as unused
 

--- a/docs/rules/jsx-spread-operator-position.md
+++ b/docs/rules/jsx-spread-operator-position.md
@@ -1,0 +1,45 @@
+# Spread Operator Position (jsx-spread-operator-position)
+
+Ensure correct position when using the spread operator in JSX.
+
+## Rule Details
+
+This rule ensures the position of spread operator when using it to pass props in JSX components. Only is enabled when using the spread operator.
+* `begin`: The first property is always be the spread operator.
+* `end` : The last property is always the spread operator.
+
+The following patterns are considered warnings when configured `"begin"`:
+
+```js
+<Hello prop1 {...this.props} />
+```
+
+The following patterns are not considered warnings when configured `"begin"`:
+
+```js
+<Hello {...this.props} />
+
+<Hello {...this.props} prop1 />
+
+<Hello prop1 />
+```
+
+The following patterns are considered warnings when configured `"end"`:
+
+```js
+<Hello {...this.props} prop1 />
+```
+
+The following patterns are not considered warnings when configured `"end"`:
+
+```js
+<Hello {...this.props} />
+
+<Hello prop1 {...this.props} />
+
+<Hello prop1 />
+```
+
+## When not to use
+
+If you are not using JSX then you can disable this rule.

--- a/index.js
+++ b/index.js
@@ -42,7 +42,8 @@ module.exports = {
     'jsx-key': require('./lib/rules/jsx-key'),
     'no-string-refs': require('./lib/rules/no-string-refs'),
     'prefer-stateless-function': require('./lib/rules/prefer-stateless-function'),
-    'require-render-return': require('./lib/rules/require-render-return')
+    'require-render-return': require('./lib/rules/require-render-return'),
+    'jsx-spread-operator-position': require('./lib/rules/jsx-spread-operator-position')
   },
   configs: {
     recommended: {

--- a/lib/rules/jsx-spread-operator-position.js
+++ b/lib/rules/jsx-spread-operator-position.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Enforce the location of the spread operator
+ * @author Joachim Seminck
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = function (context) {
+  var configuration = context.options[0];
+
+  function attributesContainSpreadOperator(node) {
+    if (node.attributes.length === 0) {
+      return false;
+    }
+
+    var spreadOperatorFound = false;
+    node.attributes.forEach(function(decl) {
+      if (decl.type === 'JSXSpreadAttribute') {
+        spreadOperatorFound = true;
+      }
+    });
+
+    return spreadOperatorFound;
+  }
+
+  return {
+    JSXOpeningElement: function (node) {
+      if ((configuration === 'begin') && attributesContainSpreadOperator(node)) {
+        var firstAttribute = node.attributes[0];
+        if (firstAttribute.type !== 'JSXSpreadAttribute' && node.attributes.length > 1) {
+          context.report({
+            node: firstAttribute,
+            message: 'First property should be the spread operator'
+          });
+        }
+      } else if (configuration === 'end' && attributesContainSpreadOperator(node)) {
+        var lastAttribute = node.attributes[node.attributes.length - 1];
+        if (lastAttribute.type !== 'JSXSpreadAttribute' && node.attributes.length > 1) {
+          context.report({
+            node: lastAttribute,
+            message: 'Last property should be the spread operator'
+          });
+        }
+      }
+      return;
+    }
+  };
+};
+
+module.exports.schema = [{
+  enum: ['begin', 'end']
+}];

--- a/tests/lib/rules/jsx-spread-operator-position.js
+++ b/tests/lib/rules/jsx-spread-operator-position.js
@@ -1,0 +1,70 @@
+/**
+* @fileoverview Enforce the location of the spread operator
+* @author Joachim Seminck
+ */
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/jsx-spread-operator-position');
+var RuleTester = require('eslint').RuleTester;
+
+var parserOptions = 'babel-eslint';
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('jsx-spread-operator-position', rule, {
+
+  valid: [
+    {
+      code: '<Foo {...this.props} a b />',
+      options: ['begin'],
+      parser: parserOptions
+    },
+    {
+      code: '<Foo a b {...this.props} />',
+      options: ['end'],
+      parser: parserOptions
+    },
+    {
+      code: '<Foo a b />',
+      options: ['begin'],
+      parser: parserOptions
+    },
+    {
+      code: '<Foo a b />',
+      options: ['end'],
+      parser: parserOptions
+    },
+    {
+      code: '<Foo {...this.props} />',
+      options: ['begin'],
+      parser: parserOptions
+    },
+    {
+      code: '<Foo {...this.props} />',
+      options: ['end'],
+      parser: parserOptions
+    }
+  ],
+
+  invalid: [
+    {
+      code: '<Foo {...this.props} a b />',
+      options: ['end'],
+      errors: [{message: 'Last property should be the spread operator'}],
+      parser: parserOptions
+    },
+    {
+      code: '<Foo a b {...this.props} />',
+      options: ['begin'],
+      errors: [{message: 'First property should be the spread operator'}],
+      parser: parserOptions
+    }
+  ]
+});


### PR DESCRIPTION
A rule we want to enforce in our project is consistent position when using spread operator as a prop in JSX components.

E.g. we either want it always at the beginning
```js
<MyComponent {...this.props.data} prop1 prop2 />
```

or at the end (we are still fighting about what approach to take)
```js
<MyComponent prop1 prop2 {this.props.data} />
```

I couldn't find any rule which enforces this... so decided to make another experiment and add it.  There are two options: "begin" and "end".

I think the rule naming could use some fine-tuning. Not sure what would be a good name.

Please review the idea, code, style and add comments where needed. If you want this rule to be added then I will do my best to get it included.
