### PR TITLE
Fix forbid-prop-types exploding on object spread

### DIFF
--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -55,6 +55,9 @@ module.exports = function(context) {
     declarations.forEach(function(declaration) {
       var target;
       var value = declaration.value;
+      if (!value) {
+        return;
+      }
       if (
         value.type === 'MemberExpression' &&
         value.property &&

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -441,5 +441,25 @@ ruleTester.run('forbid-prop-types', rule, {
       forbid: ['object']
     }],
     errors: 1
+  }, {
+    // Object spread should not cause an error.
+    code: [
+      'const extraPropTypes = {',
+      '  foo: React.PropTypes.string',
+      '};',
+      'class Component extends React.Component {',
+      '  static propTypes = {',
+      '    ...extraPropTypes,',
+      '    a: React.PropTypes.string,',
+      '    c: React.PropTypes.number',
+      '  };',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: 0
   }]
 });


### PR DESCRIPTION
If you pass an object spread to `propTypes`, `forbid-prop-types` currently freaks out.  This at least keeps it from throwing a `Cannot read property 'type' of undefined`