### PR TITLE
Fix line-aligned jsx-closing-bracket-location fixer

### DIFF
--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -202,17 +202,7 @@ module.exports = function(context) {
               return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
                 '\n' + tagSpaces.join(' ') + closingTag);
             case 'line-aligned':
-              var walkNode = node;
-              var lineSpaces = 0;
-              while ((walkNode = walkNode.parent)) {
-                if (walkNode.type === 'VariableDeclaration' ||
-                    walkNode.type === 'ReturnStatement' ||
-                    walkNode.type === 'ExpressionStatement') {
-                  lineSpaces = walkNode.loc.start.column + 1;
-                  break;
-                }
-              }
-              lineSpaces = new Array(lineSpaces);
+              var lineSpaces = new Array(+correctColumn + 1);
               return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
                 '\n' + lineSpaces.join(' ') + closingTag);
             default:


### PR DESCRIPTION
Since we already know what the correct column would be, we can use that to derive the number of spaces to add.

Fixes #533.

Don’t have time to write tests right now, sorry.