### PR TITLE
Add a failing test for sort-prop-types

### DIFF
--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -365,6 +365,28 @@ ruleTester.run('sort-prop-types', rule, {
     }]
   }, {
     code: [
+      'const propTypes = {',
+      '  muiTheme: PropTypes.object.isRequired,',
+      '  className: PropTypes.string,',
+      '};',
+      '',
+      'const TextFieldLabel = (props) => {',
+      '  return (',
+      '    <div />',
+      '  );',
+      '};',
+      '',
+      'TextFieldLabel.propTypes = propTypes;'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 4,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
       'var First = React.createClass({',
       '  propTypes: {',
       '    Z: React.PropTypes.any,',


### PR DESCRIPTION
E.g, we are using this [pattern](https://github.com/callemall/material-ui/blob/master/src/TextField/TextFieldLabel.js) on the Material-UI repository.