### PR TITLE
New Rule: jsx-no-target-blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The plugin has a [recommended configuration](#user-content-recommended-configura
 * [jsx-no-bind](docs/rules/jsx-no-bind.md): Prevent usage of `.bind()` and arrow functions in JSX props
 * [jsx-no-duplicate-props](docs/rules/jsx-no-duplicate-props.md): Prevent duplicate props in JSX
 * [jsx-no-literals](docs/rules/jsx-no-literals.md): Prevent usage of unwrapped JSX strings
+* [jsx-no-target-blank](docs/rules/jsx-no-target-blank.md): Prevent usage of unsafe `target='\_blank'`
 * [jsx-no-undef](docs/rules/jsx-no-undef.md): Disallow undeclared variables in JSX
 * [jsx-pascal-case](docs/rules/jsx-pascal-case.md): Enforce PascalCase for user-defined JSX components
 * [jsx-sort-props](docs/rules/jsx-sort-props.md): Enforce props alphabetical sorting

--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -1,0 +1,27 @@
+# Prevent usage of unsafe target='_blank' (jsx-no-target-blank)
+
+When creating a JSX element that has an a tag, it is often desired to have
+the link open in a new tab using the target='_blank' attribute. Using this
+attribute unaccompanied by rel='noreferrer noopener', however, is a severe
+security vulnerability ([see here for more details](https://mathiasbynens.github.io/rel-noopener))
+This rules requires that you accompany all target='_blank' attributes with rel='noreferrer noopener'.
+
+## Rule Details
+
+The following patterns are considered errors:
+
+```javascript
+var Hello = <a target='_blank'></a>
+```
+
+The following patterns are not considered erros:
+
+```javascript
+var Hello = <p target='_blank'></p>
+var Hello = <a target='_blank' rel='noopener noreferrer'></a>
+var Hello = <a></a>
+```
+
+## When Not To Use It
+
+If you do not have any external links, you can disable this rule

--- a/index.js
+++ b/index.js
@@ -43,7 +43,8 @@ module.exports = {
     'no-string-refs': require('./lib/rules/no-string-refs'),
     'prefer-stateless-function': require('./lib/rules/prefer-stateless-function'),
     'require-render-return': require('./lib/rules/require-render-return'),
-    'jsx-first-prop-new-line': require('./lib/rules/jsx-first-prop-new-line')
+    'jsx-first-prop-new-line': require('./lib/rules/jsx-first-prop-new-line'),
+    'jsx-no-target-blank': require('./lib/rules/jsx-no-target-blank')
   },
   configs: {
     recommended: {

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Forbid target='_blank' attribute
+ * @author Kevin Miller
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = function(context) {
+  return {
+    JSXAttribute: function(node) {
+      if (node.name.name === 'target' && node.value.value === '_blank') {
+        var relFound = false;
+        var attrs = node.parent.attributes;
+        for (var idx in attrs) {
+          if (attrs[idx].name.name === 'rel') {
+            var tags = attrs[idx].value.value.split(' ');
+            if (tags.indexOf('noopener') >= 0 && tags.indexOf('noreferrer') >= 0) {
+              relFound = true;
+              break;
+            }
+          }
+        }
+        if (!relFound) {
+          context.report(node, 'Using target="_blank" without rel="noopener noreferrer" ' +
+          'is a security risk: see https://mathiasbynens.github.io/rel-noopener');
+        }
+      }
+    }
+  };
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Forbid target='_blank' attribute
+ * @author Kevin Miller
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/jsx-no-target-blank');
+var RuleTester = require('eslint').RuleTester;
+
+var parserOptions = {
+  ecmaVersion: 6,
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('jsx-no-target-blank', rule, {
+  valid: [
+    {code: '<a href="foobar"></a>', parserOptions: parserOptions},
+    {code: '<a randomTag></a>', parserOptions: parserOptions},
+    {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>', parserOptions: parserOptions}
+  ],
+  invalid: [
+    {code: '<a target="_blank"></a>', parserOptions: parserOptions,
+     errors: [{message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      ' see https://mathiasbynens.github.io/rel-noopener'}]},
+    {code: '<a target="_blank" rel=""></a>', parserOptions: parserOptions,
+     errors: [{message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      ' see https://mathiasbynens.github.io/rel-noopener'}]},
+    {code: '<a target="_blank" rel="noopenernoreferrer"></a>', parserOptions: parserOptions,
+     errors: [{message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      ' see https://mathiasbynens.github.io/rel-noopener'}]}
+  ]
+});


### PR DESCRIPTION
New rule to protect against a pretty serious security vulnerability: https://mathiasbynens.github.io/rel-noopener

Using `target='_blank'` to open a link in a new tab is inherently unsafe and should always be accompanied by `rel='noopener noreferrer'`