### PR TITLE
jsx-curly-spacing rule breaks with comments

### DIFF
--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -78,6 +78,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     ].join('\n'),
     options: ['never'],
     parserOptions: parserOptions
+  }, {
+    code: '<App foo={bar/* comment */} />;',
+    options: ['never'],
+    parserOptions: parserOptions,
+    parser: 'babel-eslint'
   }],
 
   invalid: [{


### PR DESCRIPTION
When the `jsx-curly-spacing` rule is set to `never` the rule reports an error when there is a comment in the expression. I've added a failing test to illustrate this but I'm not sure how to go about fixing it. Any pointers?

Using https://astexplorer.net/#/Y9uxLiaZ7W it looks like it should be possible to use the `trailingComments` and `leadingComments` attributes on the node to take comments into account when comparing ranges though I'm not sure how to access them in the `isSpaced` function (https://github.com/jkimbo/eslint-plugin-react/blob/2b5a612755723862ec51790b7a6037d3ed68e594/lib/rules/jsx-curly-spacing.js#L37-L45)