### PR TITLE
Add option to the self-closing-comp

### DIFF
--- a/docs/rules/self-closing-comp.md
+++ b/docs/rules/self-closing-comp.md
@@ -26,9 +26,9 @@ The rule can take one argument to select types of tags, which should be self-clo
 
 ```js
 ...
-"self-closing-comp": [<enabled>, {
-  "component" <boolean> || true,
-  "html" <boolean> || false
+"self-closing-comp": ["error", {
+  "component": true,
+  "html": false
 }]
 ...
 ```

--- a/docs/rules/self-closing-comp.md
+++ b/docs/rules/self-closing-comp.md
@@ -17,5 +17,79 @@ var contentContainer = <div className="content"></div>;
 
 var HelloJohn = <Hello name="John" />;
 
-var Profile = <Hello name="John"><img src="picture.png" /></Hello>; 
+var Profile = <Hello name="John"><img src="picture.png" /></Hello>;
+```
+
+## Rule Options
+
+It takes an option as the second parameter, which corresponding what components tags should be self-closed when this is possible.
+
+```js
+...
+"self-closing-comp": [<enabled>, 'all'|'component'|'html'>]
+...
+```
+
+### `all`
+
+All tags, including custom components and html components should be self-closed.
+
+The following patterns are considered warnings:
+
+```js
+var HelloJohn = <Hello name="John"></Hello>;
+
+var contentContainer = <div className="content"></div>;
+```
+
+The following patterns are not considered warnings:
+
+```js
+var HelloJohn = <Hello name="John" />;
+
+var Profile = <Hello name="John"><img src="picture.png" /></Hello>;
+
+var contentContainer = <div className="content" />;
+
+var contentContainer = <div className="content"><div /></div>;
+```
+
+### `component`
+
+Only custom components tags should be self-closed. This is the default option.
+
+The following patterns are considered warnings:
+
+```js
+var HelloJohn = <Hello name="John"></Hello>;
+```
+
+The following patterns are not considered warnings:
+
+```js
+var contentContainer = <div className="content"></div>;
+
+var HelloJohn = <Hello name="John" />;
+
+var Profile = <Hello name="John"><img src="picture.png" /></Hello>;
+```
+
+### `html`
+
+Only html components tags should be self-closed.
+
+The following patterns are considered warnings:
+
+```js
+var contentContainer = <div className="content"></div>;
+```
+
+The following patterns are not considered warnings:
+
+```js
+var HelloJohn = <Hello name="John"></Hello>;
+
+var contentContainer = <div className="content" />;
+
+var contentContainer = <div className="content"><div /></div>;
 ```

--- a/docs/rules/self-closing-comp.md
+++ b/docs/rules/self-closing-comp.md
@@ -22,41 +22,20 @@ var Profile = <Hello name="John"><img src="picture.png" /></Hello>;
 
 ## Rule Options
 
-It takes an option as the second parameter, which corresponding what components tags should be self-closed when this is possible.
+The rule can take one argument to select types of tags, which should be self-closed when this is possible. By default only custom components tags should be self-closed.
 
 ```js
 ...
-"self-closing-comp": [<enabled>, 'all'|'component'|'html'>]
+"self-closing-comp": [<enabled>, {
+  "component" <boolean> || true,
+  "html" <boolean> || false
+}]
 ...
-```
-
-### `all`
-
-All tags, including custom components and html components should be self-closed.
-
-The following patterns are considered warnings:
-
-```js
-var HelloJohn = <Hello name="John"></Hello>;
-
-var contentContainer = <div className="content"></div>;
-```
-
-The following patterns are not considered warnings:
-
-```js
-var HelloJohn = <Hello name="John" />;
-
-var Profile = <Hello name="John"><img src="picture.png" /></Hello>;
-
-var contentContainer = <div className="content" />;
-
-var contentContainer = <div className="content"><div /></div>;
 ```
 
 ### `component`
 
-Only custom components tags should be self-closed. This is the default option.
+When `true`, custom components tags should be self-closed.
 
 The following patterns are considered warnings:
 
@@ -76,7 +55,7 @@ var Profile = <Hello name="John"><img src="picture.png" /></Hello>;
 
 ### `html`
 
-Only html components tags should be self-closed.
+When `true`, html components tags should be self-closed.
 
 The following patterns are considered warnings:
 
@@ -87,8 +66,6 @@ var contentContainer = <div className="content"></div>;
 The following patterns are not considered warnings:
 
 ```js
-var HelloJohn = <Hello name="John"></Hello>;
-
 var contentContainer = <div className="content" />;
 
 var contentContainer = <div className="content"><div /></div>;

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -31,11 +31,10 @@ module.exports = function(context) {
   }
 
   function isShouldBeSelfClosed(node) {
-    var configuration = context.options[0] || 'component';
+    var configuration = context.options[0] || {component: true};
     return (
-      configuration === 'all' ||
-      configuration === 'component' && isComponent(node) ||
-      configuration === 'html' && isTagName(node.name.name)
+      configuration.component && isComponent(node) ||
+      configuration.html && isTagName(node.name.name)
     ) && !node.selfClosing && !hasChildren(node);
   }
 
@@ -60,5 +59,14 @@ module.exports = function(context) {
 };
 
 module.exports.schema = [{
-  enum: ['all', 'component', 'html']
+  type: 'object',
+  properties: {
+    component: {
+      type: 'boolean'
+    },
+    html: {
+      type: 'boolean'
+    }
+  },
+  additionalProperties: false
 }];

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -30,6 +30,15 @@ module.exports = function(context) {
     return true;
   }
 
+  function isShouldBeSelfClosed(node) {
+    var configuration = context.options[0] || 'component';
+    return (
+      configuration === 'all' ||
+      configuration === 'component' && isComponent(node) ||
+      configuration === 'html' && isTagName(node.name.name)
+    ) && !node.selfClosing && !hasChildren(node);
+  }
+
   // --------------------------------------------------------------------------
   // Public
   // --------------------------------------------------------------------------
@@ -37,7 +46,8 @@ module.exports = function(context) {
   return {
 
     JSXOpeningElement: function(node) {
-      if (!isComponent(node) || node.selfClosing || hasChildren(node)) {
+
+      if (!isShouldBeSelfClosed(node)) {
         return;
       }
       context.report({
@@ -49,4 +59,6 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [];
+module.exports.schema = [{
+  enum: ['all', 'component', 'html']
+}];

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -62,9 +62,11 @@ module.exports.schema = [{
   type: 'object',
   properties: {
     component: {
+      default: true,
       type: 'boolean'
     },
     html: {
+      default: false,
       type: 'boolean'
     }
   },

--- a/tests/lib/rules/self-closing-comp.js
+++ b/tests/lib/rules/self-closing-comp.js
@@ -51,6 +51,37 @@ ruleTester.run('self-closing-comp', rule, {
       code: 'var HelloJohn = <Hello name="John">&nbsp;</Hello>;',
       parserOptions: parserOptions
     }, {
+      code: 'var contentContainer = <div className="content"></div>;',
+      options: [],
+      parserOptions: parserOptions
+    }, {
+      code: 'var HelloJohn = <Hello name="John" />;',
+      options: [],
+      parserOptions: parserOptions
+    }, {
+      code: 'var Profile = <Hello name="John"><img src="picture.png" /></Hello>;',
+      options: [],
+      parserOptions: parserOptions
+    }, {
+      code: '\
+      <Hello>\
+        <Hello name="John" />\
+      </Hello>',
+      options: [],
+      parserOptions: parserOptions
+    }, {
+      code: 'var HelloJohn = <div>&nbsp;</div>;',
+      options: [],
+      parserOptions: parserOptions
+    }, {
+      code: 'var HelloJohn = <div>{\' \'}</div>;',
+      options: [],
+      parserOptions: parserOptions
+    }, {
+      code: 'var HelloJohn = <Hello name="John">&nbsp;</Hello>;',
+      options: [],
+      parserOptions: parserOptions
+    }, {
       code: 'var HelloJohn = <Hello name="John"></Hello>;',
       options: [{component: false}],
       parserOptions: parserOptions
@@ -95,6 +126,28 @@ ruleTester.run('self-closing-comp', rule, {
       }]
     }, {
       code: 'var HelloJohn = <Hello name="John"> </Hello>;',
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    },
+    {
+      code: 'var HelloJohn = <Hello name="John"></Hello>;',
+      options: [],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
+      options: [],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var HelloJohn = <Hello name="John"> </Hello>;',
+      options: [],
       parserOptions: parserOptions,
       errors: [{
         message: 'Empty components are self-closing'

--- a/tests/lib/rules/self-closing-comp.js
+++ b/tests/lib/rules/self-closing-comp.js
@@ -50,6 +50,48 @@ ruleTester.run('self-closing-comp', rule, {
     }, {
       code: 'var HelloJohn = <Hello name="John">&nbsp;</Hello>;',
       parserOptions: parserOptions
+    }, {
+      code: 'var HelloJohn = <Hello name="John" />;',
+      options: ['all'],
+      parserOptions: parserOptions
+    }, {
+      code: 'var Profile = <Hello name="John"><img src="picture.png" /></Hello>;',
+      options: ['all'],
+      parserOptions: parserOptions
+    }, {
+      code: '\
+      <Hello>\
+        <Hello name="John" />\
+      </Hello>',
+      options: ['all'],
+      parserOptions: parserOptions
+    }, {
+      code: 'var contentContainer = <div className="content" />;',
+      options: ['all'],
+      parserOptions: parserOptions
+    }, {
+      code: 'var contentContainer = <div className="content"><img src="picture.png" /></div>;',
+      options: ['all'],
+      parserOptions: parserOptions
+    }, {
+      code: '\
+      <div>\
+        <div className="content" />\
+      </div>',
+      options: ['all'],
+      parserOptions: parserOptions
+    }, {
+      code: 'var HelloJohn = <Hello name="John"></Hello>;',
+      options: ['html'],
+      parserOptions: parserOptions
+    }, {
+      code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
+      options: ['html'],
+      parserOptions: parserOptions
+    }, {
+      code: 'var HelloJohn = <Hello name="John"> </Hello>;',
+      options: ['html'],
+      parserOptions: parserOptions
     }
   ],
 
@@ -68,6 +110,69 @@ ruleTester.run('self-closing-comp', rule, {
       }]
     }, {
       code: 'var HelloJohn = <Hello name="John"> </Hello>;',
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var HelloJohn = <Hello name="John"></Hello>;',
+      options: ['all'],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
+      options: ['all'],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var HelloJohn = <Hello name="John"> </Hello>;',
+      options: ['all'],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var contentContainer = <div className="content"></div>;',
+      options: ['all'],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var contentContainer = <div className="content">\n</div>;',
+      options: ['all'],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var contentContainer = <div className="content"> </div>;',
+      options: ['all'],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var contentContainer = <div className="content"></div>;',
+      options: ['html'],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var contentContainer = <div className="content">\n</div>;',
+      options: ['html'],
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var contentContainer = <div className="content"> </div>;',
+      options: ['html'],
       parserOptions: parserOptions,
       errors: [{
         message: 'Empty components are self-closing'

--- a/tests/lib/rules/self-closing-comp.js
+++ b/tests/lib/rules/self-closing-comp.js
@@ -51,46 +51,31 @@ ruleTester.run('self-closing-comp', rule, {
       code: 'var HelloJohn = <Hello name="John">&nbsp;</Hello>;',
       parserOptions: parserOptions
     }, {
-      code: 'var HelloJohn = <Hello name="John" />;',
-      options: ['all'],
+      code: 'var HelloJohn = <Hello name="John"></Hello>;',
+      options: [{component: false}],
       parserOptions: parserOptions
     }, {
-      code: 'var Profile = <Hello name="John"><img src="picture.png" /></Hello>;',
-      options: ['all'],
+      code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
+      options: [{component: false}],
       parserOptions: parserOptions
     }, {
-      code: '\
-      <Hello>\
-        <Hello name="John" />\
-      </Hello>',
-      options: ['all'],
+      code: 'var HelloJohn = <Hello name="John"> </Hello>;',
+      options: [{component: false}],
       parserOptions: parserOptions
     }, {
       code: 'var contentContainer = <div className="content" />;',
-      options: ['all'],
+      options: [{html: true}],
       parserOptions: parserOptions
     }, {
       code: 'var contentContainer = <div className="content"><img src="picture.png" /></div>;',
-      options: ['all'],
+      options: [{html: true}],
       parserOptions: parserOptions
     }, {
       code: '\
       <div>\
         <div className="content" />\
       </div>',
-      options: ['all'],
-      parserOptions: parserOptions
-    }, {
-      code: 'var HelloJohn = <Hello name="John"></Hello>;',
-      options: ['html'],
-      parserOptions: parserOptions
-    }, {
-      code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
-      options: ['html'],
-      parserOptions: parserOptions
-    }, {
-      code: 'var HelloJohn = <Hello name="John"> </Hello>;',
-      options: ['html'],
+      options: [{html: true}],
       parserOptions: parserOptions
     }
   ],
@@ -115,64 +100,22 @@ ruleTester.run('self-closing-comp', rule, {
         message: 'Empty components are self-closing'
       }]
     }, {
-      code: 'var HelloJohn = <Hello name="John"></Hello>;',
-      options: ['all'],
-      parserOptions: parserOptions,
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    }, {
-      code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
-      options: ['all'],
-      parserOptions: parserOptions,
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    }, {
-      code: 'var HelloJohn = <Hello name="John"> </Hello>;',
-      options: ['all'],
-      parserOptions: parserOptions,
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    }, {
       code: 'var contentContainer = <div className="content"></div>;',
-      options: ['all'],
+      options: [{html: true}],
       parserOptions: parserOptions,
       errors: [{
         message: 'Empty components are self-closing'
       }]
     }, {
       code: 'var contentContainer = <div className="content">\n</div>;',
-      options: ['all'],
+      options: [{html: true}],
       parserOptions: parserOptions,
       errors: [{
         message: 'Empty components are self-closing'
       }]
     }, {
       code: 'var contentContainer = <div className="content"> </div>;',
-      options: ['all'],
-      parserOptions: parserOptions,
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    }, {
-      code: 'var contentContainer = <div className="content"></div>;',
-      options: ['html'],
-      parserOptions: parserOptions,
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    }, {
-      code: 'var contentContainer = <div className="content">\n</div>;',
-      options: ['html'],
-      parserOptions: parserOptions,
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    }, {
-      code: 'var contentContainer = <div className="content"> </div>;',
-      options: ['html'],
+      options: [{html: true}],
       parserOptions: parserOptions,
       errors: [{
         message: 'Empty components are self-closing'


### PR DESCRIPTION
This pr adds an option to the self-closing-comp suggested #572, which is corresponding what type of tags (`{component: <boolean>, html: <boolean>}`) should be self-closed when this is possible. **Note**: this not changes current behavior, default option is `{component: true, html: false}`, but in the next major
release we can change it to `{component: true, html: true}` to enforce all tags to be self-closing when that is possible.


