### PR TITLE
Fix jsx-curly-spacing: spacing around spread operator

### DIFF
--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -143,13 +143,14 @@ module.exports = function(context) {
   /**
    * Determines if spacing in curly braces is valid.
    * @param {ASTNode} node The AST node to check.
-   * @param {Token} first The first token to check (should be the opening brace)
-   * @param {Token} second The second token to check (should be first after the opening brace)
-   * @param {Token} penultimate The penultimate token to check (should be last before closing brace)
-   * @param {Token} last The last token to check (should be closing brace)
    * @returns {void}
    */
-  function validateBraceSpacing(node, first, second, penultimate, last) {
+  function validateBraceSpacing(node) {
+    var first = context.getFirstToken(node);
+    var last = sourceCode.getLastToken(node);
+    var second = context.getTokenAfter(first);
+    var penultimate = sourceCode.getTokenBefore(last);
+
     if (spaced) {
       if (!sourceCode.isSpaceBetweenTokens(first, second)) {
         reportRequiredBeginningSpace(node, first);
@@ -181,14 +182,8 @@ module.exports = function(context) {
   // --------------------------------------------------------------------------
 
   return {
-    JSXExpressionContainer: function(node) {
-      var first = context.getFirstToken(node);
-      var last = sourceCode.getLastToken(node);
-      var second = context.getTokenAfter(first);
-      var penultimate = sourceCode.getTokenBefore(last);
-
-      validateBraceSpacing(node, first, second, penultimate, last);
-    }
+    JSXExpressionContainer: validateBraceSpacing,
+    JSXSpreadAttribute: validateBraceSpacing
   };
 };
 

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -83,6 +83,88 @@ ruleTester.run('jsx-curly-spacing', rule, {
     options: ['never'],
     parserOptions: parserOptions,
     parser: 'babel-eslint'
+  }, {
+    code: '<App {...bar} />;',
+    parserOptions: parserOptions
+  }, {
+    code: '<App {...bar} />;',
+    options: ['never'],
+    parserOptions: parserOptions
+  }, {
+    code: '<App { ...bar } />;',
+    options: ['always'],
+    parserOptions: parserOptions
+  }, {
+    code: '<App { ...bar } />;',
+    options: ['always', {allowMultiline: false}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App {',
+      '...bar',
+      '} />;'
+    ].join('\n'),
+    options: ['always'],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App {',
+      '...bar',
+      '} />;'
+    ].join('\n'),
+    options: ['always'],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App {',
+      '...bar',
+      '} />;'
+    ].join('\n'),
+    options: ['never'],
+    parserOptions: parserOptions
+  }, {
+    code: '<App {...bar/* comment */} />;',
+    options: ['never'],
+    parserOptions: parserOptions,
+    parser: 'babel-eslint'
+  }, {
+    code: '<App foo={bar} {...baz} />;',
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={bar} {...baz} />;',
+    options: ['never'],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={ bar } { ...baz } />;',
+    options: ['always'],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={ bar } { ...baz } />;',
+    options: ['always', {allowMultiline: false}],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={{ bar:baz }} {...baz} />;',
+    options: ['never'],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={ {bar:baz} } { ...baz } />;',
+    options: ['always'],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App foo={',
+      'bar',
+      '} {',
+      '...bar',
+      '}/>;'
+    ].join('\n'),
+    options: ['always'],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={bar/* comment */} {...baz/* comment */} />;',
+    options: ['never'],
+    parserOptions: parserOptions,
+    parser: 'babel-eslint'
   }],
 
   invalid: [{
@@ -180,6 +262,242 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ bar } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
+      message: 'There should be no newline after \'{\''
+    }, {
+      message: 'There should be no newline before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App { ...bar } />;',
+    output: '<App {...bar} />;',
+    options: ['never'],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App { ...bar } />;',
+    output: '<App {...bar} />;',
+    options: ['never', {allowMultiline: false}],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App {...bar} />;',
+    output: '<App { ...bar } />;',
+    options: ['always'],
+    errors: [{
+      message: 'A space is required after \'{\''
+    }, {
+      message: 'A space is required before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App {...bar} />;',
+    output: '<App { ...bar } />;',
+    options: ['always', {allowMultiline: false}],
+    errors: [{
+      message: 'A space is required after \'{\''
+    }, {
+      message: 'A space is required before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App { ...bar} />;',
+    output: '<App { ...bar } />;',
+    options: ['always'],
+    errors: [{
+      message: 'A space is required before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App {...bar } />;',
+    output: '<App { ...bar } />;',
+    options: ['always'],
+    errors: [{
+      message: 'A space is required after \'{\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App { ...bar} />;',
+    output: '<App {...bar} />;',
+    options: ['never'],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App {...bar } />;',
+    output: '<App {...bar} />;',
+    options: ['never'],
+    errors: [{
+      message: 'There should be no space before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App {',
+      '...bar',
+      '} />;'
+    ].join('\n'),
+    output: '<App {...bar} />;',
+    options: ['never', {allowMultiline: false}],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App {',
+      '...bar',
+      '} />;'
+    ].join('\n'),
+    output: '<App { ...bar } />;',
+    options: ['always', {allowMultiline: false}],
+    errors: [{
+      message: 'There should be no newline after \'{\''
+    }, {
+      message: 'There should be no newline before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={ bar } { ...baz } />;',
+    output: '<App foo={bar} {...baz} />;',
+    options: ['never'],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }, {
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={ bar } { ...baz } />;',
+    output: '<App foo={bar} {...baz} />;',
+    options: ['never', {allowMultiline: false}],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }, {
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={bar} {...baz} />;',
+    output: '<App foo={ bar } { ...baz } />;',
+    options: ['always'],
+    errors: [{
+      message: 'A space is required after \'{\''
+    }, {
+      message: 'A space is required before \'}\''
+    }, {
+      message: 'A space is required after \'{\''
+    }, {
+      message: 'A space is required before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={bar} {...baz} />;',
+    output: '<App foo={ bar } { ...baz } />;',
+    options: ['always', {allowMultiline: false}],
+    errors: [{
+      message: 'A space is required after \'{\''
+    }, {
+      message: 'A space is required before \'}\''
+    }, {
+      message: 'A space is required after \'{\''
+    }, {
+      message: 'A space is required before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={ bar} { ...baz} />;',
+    output: '<App foo={ bar } { ...baz } />;',
+    options: ['always'],
+    errors: [{
+      message: 'A space is required before \'}\''
+    }, {
+      message: 'A space is required before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={bar } {...baz } />;',
+    output: '<App foo={ bar } { ...baz } />;',
+    options: ['always'],
+    errors: [{
+      message: 'A space is required after \'{\''
+    }, {
+      message: 'A space is required after \'{\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={ bar} { ...baz} />;',
+    output: '<App foo={bar} {...baz} />;',
+    options: ['never'],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space after \'{\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: '<App foo={bar } {...baz } />;',
+    output: '<App foo={bar} {...baz} />;',
+    options: ['never'],
+    errors: [{
+      message: 'There should be no space before \'}\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App foo={',
+      'bar',
+      '} {',
+      '...baz',
+      '} />;'
+    ].join('\n'),
+    output: '<App foo={bar} {...baz} />;',
+    options: ['never', {allowMultiline: false}],
+    errors: [{
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }, {
+      message: 'There should be no space after \'{\''
+    }, {
+      message: 'There should be no space before \'}\''
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App foo={',
+      'bar',
+      '} {',
+      '...baz',
+      '} />;'
+    ].join('\n'),
+    output: '<App foo={ bar } { ...baz } />;',
+    options: ['always', {allowMultiline: false}],
+    errors: [{
+      message: 'There should be no newline after \'{\''
+    }, {
+      message: 'There should be no newline before \'}\''
+    }, {
       message: 'There should be no newline after \'{\''
     }, {
       message: 'There should be no newline before \'}\''

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -81,8 +81,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
   }, {
     code: '<App foo={bar/* comment */} />;',
     options: ['never'],
-    parserOptions: parserOptions,
-    parser: 'babel-eslint'
+    parserOptions: parserOptions
   }, {
     code: '<App {...bar} />;',
     parserOptions: parserOptions
@@ -125,8 +124,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
   }, {
     code: '<App {...bar/* comment */} />;',
     options: ['never'],
-    parserOptions: parserOptions,
-    parser: 'babel-eslint'
+    parserOptions: parserOptions
   }, {
     code: '<App foo={bar} {...baz} />;',
     parserOptions: parserOptions
@@ -163,8 +161,7 @@ ruleTester.run('jsx-curly-spacing', rule, {
   }, {
     code: '<App foo={bar/* comment */} {...baz/* comment */} />;',
     options: ['never'],
-    parserOptions: parserOptions,
-    parser: 'babel-eslint'
+    parserOptions: parserOptions
   }],
 
   invalid: [{


### PR DESCRIPTION
Fixes https://github.com/yannickcr/eslint-plugin-react/issues/606
Added two type of tests:
* creating jsx elements using only JSXSpreadAttribute syntax
* creating jsx elements using both JSXSAttribute  and JSXSpreadAttribute syntax