### PR TITLE
Add new rule: no-comment-textnodes

### DIFF
--- a/docs/rules/no-comment-textnodes.md
+++ b/docs/rules/no-comment-textnodes.md
@@ -1,0 +1,68 @@
+# Prevent comments from being inserted as text nodes (no-comment-textnodes)
+
+This rule prevents comment strings (e.g. beginning with `//` or `/*`) from being accidentally
+injected as a text node in JSX statements.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+var Hello = React.createClass({
+  render: function() {
+    return (
+      <div>// empty div</div>
+    );
+  }
+});
+
+var Hello = React.createClass({
+  render: function() {
+    return (
+      <div>
+        /* empty div */
+      </div>
+    );
+  }
+});
+```
+
+The following patterns are not considered warnings:
+
+```js
+var Hello = React.createClass({
+  displayName: 'Hello',
+  render: function() {
+    return <div>{/* empty div */}</div>;
+  }
+});
+
+var Hello = React.createClass({
+  displayName: 'Hello',
+  render: function() {
+    return <div /* empty div */></div>;
+  }
+});
+
+var Hello = React.createClass({
+  displayName: 'Hello',
+  render: function() {
+    return <div className={'foo' /* temp class */}</div>;
+  }
+});
+```
+
+## Legitimate uses
+
+It's possible you may want to legitimately output comment start characters (`//` or `/*`)
+in a JSX text node. In which case, you can do the following:
+
+```js
+var Hello = React.createClass({
+  render: function() {
+    return (
+      <div>{'/* This will be output as a text node */'}</div>
+    );
+  }
+});
+```

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
     'display-name': require('./lib/rules/display-name'),
     'wrap-multilines': require('./lib/rules/wrap-multilines'),
     'self-closing-comp': require('./lib/rules/self-closing-comp'),
+    'no-comment-textnodes': require('./lib/rules/no-comment-textnodes'),
     'no-danger': require('./lib/rules/no-danger'),
     'no-set-state': require('./lib/rules/no-set-state'),
     'no-is-mounted': require('./lib/rules/no-is-mounted'),

--- a/lib/rules/no-comment-textnodes.js
+++ b/lib/rules/no-comment-textnodes.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Comments inside children section of tag should be placed inside braces.
+ * @author Ben Vinegar
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = function(context) {
+  function reportLiteralNode(node) {
+    context.report(node, 'Comments inside children section of tag should be placed inside braces');
+  }
+
+  // --------------------------------------------------------------------------
+  // Public
+  // --------------------------------------------------------------------------
+
+  return {
+    Literal: function(node) {
+      if (/\s*\/(\/|\*)/.test(node.value)) {
+        // inside component, e.g. <div>literal</div>
+        if (node.parent.type !== 'JSXAttribute' &&
+            node.parent.type !== 'JSXExpressionContainer' &&
+            node.parent.type.indexOf('JSX') !== -1) {
+          reportLiteralNode(node);
+        }
+      }
+    }
+  };
+};
+
+module.exports.schema = [{
+  type: 'object',
+  properties: {},
+  additionalProperties: false
+}];

--- a/tests/lib/rules/no-comment-textnodes.js
+++ b/tests/lib/rules/no-comment-textnodes.js
@@ -1,0 +1,204 @@
+/**
+ * @fileoverview Tests for no-comment-textnodes
+ * @author Ben Vinegar
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/no-comment-textnodes');
+var RuleTester = require('eslint').RuleTester;
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('jsx-needs-i18n', rule, {
+
+  valid: [
+    {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (',
+        '      <div>',
+        '        {/* valid */}',
+        '      </div>',
+        '    );',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (<div>{/* valid */}</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    const bar = (<div>{/* valid */}</div>);',
+        '    return bar;',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  foo: (<div>{/* valid */}</div>),',
+        '  render() {',
+        '    return this.foo;',
+        '  },',
+        '});'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (',
+        '      <div>',
+        '        {/* valid */}',
+        '        {/* valid 2 */}',
+        '        {/* valid 3 */}',
+        '      </div>',
+        '    );',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (',
+        '      <div>',
+        '      </div>',
+        '    );',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'var foo = require(\'foo\');'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        '<Foo bar=\'test\'>',
+        '  {/* valid */}',
+        '</Foo>'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    },
+
+    // inside element declarations
+    {
+      code: [
+        '<Foo /* valid */ placeholder={\'foo\'}/>'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    },
+    {
+      code: [
+        '<Foo title={\'foo\' /* valid */}/>'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint'
+    }
+  ],
+
+  invalid: [
+    {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (<div>// invalid</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint',
+      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (<div>/* invalid */</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint',
+      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (',
+        '      <div>',
+        '        // invalid',
+        '      </div>',
+        '    );',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint',
+      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (',
+        '      <div>',
+        '        asdjfl',
+        '        /* invalid */',
+        '        foo',
+        '      </div>',
+        '    );',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint',
+      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return (',
+        '      <div>',
+        '        {\'asdjfl\'}',
+        '        // invalid',
+        '        {\'foo\'}',
+        '      </div>',
+        '    );',
+        '  }',
+        '}'
+      ].join('\n'),
+      args: [1],
+      parser: 'babel-eslint',
+      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+    }
+  ]
+});


### PR DESCRIPTION
Our team has run into issues where people mistakenly commit comments as text nodes, and they have managed to get through code review and appeared (embarrassingly) in our UI. I threw together this rule to try and catch such occasions, and thought it might be useful to other users of this ESLint plugin.

Feedback, comments greatly appreciated.