### PR TITLE
Integrate jsx-ast-utils

### DIFF
--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -5,6 +5,8 @@
 'use strict';
 
 // var Components = require('../util/Components');
+var hasProp = require('jsx-ast-utils').hasProp;
+
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -12,17 +14,8 @@
 
 module.exports = function(context) {
 
-  function hasKeyProp(node) {
-    return node.openingElement.attributes.some(function(decl) {
-      if (decl.type === 'JSXSpreadAttribute') {
-        return false;
-      }
-      return (decl.name.name === 'key');
-    });
-  }
-
   function checkIteratorElement(node) {
-    if (node.type === 'JSXElement' && !hasKeyProp(node)) {
+    if (node.type === 'JSXElement' && !hasProp(node.openingElement.attributes, 'key')) {
       context.report({
         node: node,
         message: 'Missing "key" prop for element in iterator'
@@ -38,7 +31,7 @@ module.exports = function(context) {
 
   return {
     JSXElement: function(node) {
-      if (hasKeyProp(node)) {
+      if (hasProp(node.openingElement.attributes, 'key')) {
         return;
       }
 

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -5,7 +5,7 @@
 'use strict';
 
 // var Components = require('../util/Components');
-var hasProp = require('jsx-ast-utils').hasProp;
+var hasProp = require('jsx-ast-utils/hasProp');
 
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+var propName = require('jsx-ast-utils').propName;
+
 // -----------------------------------------------------------------------------
 // Rule Definition
 // -----------------------------------------------------------------------------
@@ -39,7 +41,7 @@ module.exports = function(context) {
     },
 
     JSXAttribute: function(node) {
-      var isRef = configuration.ignoreRefs && node.name.name === 'ref';
+      var isRef = configuration.ignoreRefs && propName(node) === 'ref';
       if (isRef || !node.value || !node.value.expression) {
         return;
       }

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -5,7 +5,7 @@
  */
 'use strict';
 
-var propName = require('jsx-ast-utils').propName;
+var propName = require('jsx-ast-utils/propName');
 
 // -----------------------------------------------------------------------------
 // Rule Definition

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+var elementType = require('jsx-ast-utils').elementType;
+
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
@@ -25,29 +27,22 @@ module.exports = function(context) {
 
   return {
     JSXOpeningElement: function(node) {
-      switch (node.name.type) {
-        case 'JSXIdentifier':
-          node = node.name;
-          break;
-        case 'JSXMemberExpression':
-          node = node.name.object;
-          break;
-        case 'JSXNamespacedName':
-          node = node.name.namespace;
-          break;
-        default:
-          break;
+      var name = elementType(node);
+
+      // Get namespace if the type is JSXNamespacedName.
+      if (name.indexOf(':') > -1) {
+        name = name.substring(0, name.indexOf(':'));
       }
 
-      var isPascalCase = PASCAL_CASE_REGEX.test(node.name);
-      var isCompatTag = COMPAT_TAG_REGEX.test(node.name);
-      var isAllowedAllCaps = allowAllCaps && ALL_CAPS_TAG_REGEX.test(node.name);
-      var isIgnored = ignore.indexOf(node.name) !== -1;
+      var isPascalCase = PASCAL_CASE_REGEX.test(name);
+      var isCompatTag = COMPAT_TAG_REGEX.test(name);
+      var isAllowedAllCaps = allowAllCaps && ALL_CAPS_TAG_REGEX.test(name);
+      var isIgnored = ignore.indexOf(name) !== -1;
 
       if (!isPascalCase && !isCompatTag && !isAllowedAllCaps && !isIgnored) {
         context.report({
           node: node,
-          message: 'Imported JSX component ' + node.name + ' must be in PascalCase'
+          message: 'Imported JSX component ' + name + ' must be in PascalCase'
         });
       }
     }

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -5,7 +5,7 @@
 
 'use strict';
 
-var elementType = require('jsx-ast-utils').elementType;
+var elementType = require('jsx-ast-utils/elementType');
 
 // ------------------------------------------------------------------------------
 // Constants

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -4,12 +4,14 @@
  */
 'use strict';
 
+var propName = require('jsx-ast-utils').propName;
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-function isCallbackPropName(propName) {
-  return /^on[A-Z]/.test(propName);
+function isCallbackPropName(name) {
+  return /^on[A-Z]/.test(name);
 }
 
 module.exports = function(context) {
@@ -26,8 +28,8 @@ module.exports = function(context) {
           return attrs[idx + 1];
         }
 
-        var previousPropName = memo.name.name;
-        var currentPropName = decl.name.name;
+        var previousPropName = propName(memo);
+        var currentPropName = propName(decl);
         var previousValue = memo.value;
         var currentValue = decl.value;
         var previousIsCallback = isCallbackPropName(previousPropName);

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-var propName = require('jsx-ast-utils').propName;
+var propName = require('jsx-ast-utils/propName');
 
 // ------------------------------------------------------------------------------
 // Rule Definition

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/yannickcr/eslint-plugin-react",
   "bugs": "https://github.com/yannickcr/eslint-plugin-react/issues",
   "dependencies": {
-    "doctrine": "^1.2.0"
+    "doctrine": "^1.2.0",
+    "jsx-ast-utils": "^1.1.1"
   },
   "devDependencies": {
     "babel-eslint": "6.0.4",


### PR DESCRIPTION
as discussed in evcohen/eslint-plugin-jsx-a11y#54 we can integrate the [jsx-ast-utils](https://github.com/evcohen/jsx-ast-utils) package here for better code reuse across these packages. 

We can start adding API functions to fit use cases for this project as well to `jsx-ast-utils` in the next few iterations (i.e. styling and spacing functions)