### PR TITLE
Remove no-danger from recommended rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,6 @@ module.exports = {
         'react/jsx-no-undef': 2,
         'react/jsx-uses-react': 2,
         'react/jsx-uses-vars': 2,
-        'react/no-danger': 2,
         'react/no-deprecated': 2,
         'react/no-did-mount-set-state': [2, 'allow-in-func'],
         'react/no-did-update-set-state': [2, 'allow-in-func'],


### PR DESCRIPTION
Using `dangerouslySetInnerHTML` is already very explicit and there are some things you actually can't do w/out it. I don't think I'd say that using it isn't "recommended". It's totally ok if you use it the way it's intended to be used.