### PR TITLE
[fix] - Fix jsx-pascal-case for JSXMemberExpressions.

### DIFF
--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -29,9 +29,11 @@ module.exports = function(context) {
     JSXOpeningElement: function(node) {
       var name = elementType(node);
 
-      // Get namespace if the type is JSXNamespacedName.
+      // Get namespace if the type is JSXNamespacedName or JSXMemberExpression
       if (name.indexOf(':') > -1) {
         name = name.substring(0, name.indexOf(':'));
+      } else if (name.indexOf('.') > -1) {
+        name = name.substring(0, name.indexOf('.'));
       }
 
       var isPascalCase = PASCAL_CASE_REGEX.test(name);

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -59,6 +59,12 @@ ruleTester.run('jsx-pascal-case', rule, {
     parserOptions: parserOptions,
     options: [{allowAllCaps: true}]
   }, {
+    code: '<Modal.Header />',
+    parserOptions: parserOptions
+  }, {
+    code: '<Modal:Header />',
+    parserOptions: parserOptions
+  }, {
     code: '<IGNORED />',
     parserOptions: parserOptions,
     options: [{ignore: ['IGNORED']}]


### PR DESCRIPTION
Only test object (part before the `.`). Fixes #637