### PR TITLE
[fix] - Ensure callee is of type Identifier before checking its name.

### DIFF
--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -20,7 +20,7 @@ module.exports = function(context) {
       if (
         !configuration.allowBind &&
         callee.type !== 'MemberExpression' ||
-        callee.property.name !== 'bind'
+        (callee.property.type === 'Identifier' && callee.property.name !== 'bind')
       ) {
         return;
       }


### PR DESCRIPTION
Don't know why they're getting that error, but this should fix #642 