### PR TITLE
[new] - Throw error on stage-0 function-bind syntax.

### DIFF
--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -64,6 +64,14 @@ module.exports = function(context) {
           node: node,
           message: 'JSX props should not use arrow functions'
         });
+      } else if (
+        !configuration.allowBind &&
+        valueNode.type === 'BindExpression'
+      ) {
+        context.report({
+          node: node,
+          message: 'JSX props should not use ::'
+        });
       }
     }
   };

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -128,6 +128,13 @@ ruleTester.run('jsx-no-bind', rule, {
       code: '<div ref={c => this._input = c}></div>',
       errors: [{message: 'JSX props should not use arrow functions'}],
       parser: 'babel-eslint'
+    },
+
+    // Bind expression
+    {
+      code: '<div foo={::this.onChange} />',
+      errors: [{message: 'JSX props should not use ::'}],
+      parser: 'babel-eslint'
     }
   ]
 });

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -135,6 +135,16 @@ ruleTester.run('jsx-no-bind', rule, {
       code: '<div foo={::this.onChange} />',
       errors: [{message: 'JSX props should not use ::'}],
       parser: 'babel-eslint'
+    },
+    {
+      code: '<div foo={foo.bar::baz} />',
+      errors: [{message: 'JSX props should not use ::'}],
+      parser: 'babel-eslint'
+    },
+    {
+      code: '<div foo={foo::bar} />',
+      errors: [{message: 'JSX props should not use ::'}],
+      parser: 'babel-eslint'
     }
   ]
 });


### PR DESCRIPTION
Fixes #532 

[function-bind](http://babeljs.io/blog/2015/05/14/function-bind)