### PR TITLE
bumps deps; peerDeps allows ESLint 2 or 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,11 +27,17 @@
     "jsx-ast-utils": "^1.2.1"
   },
   "devDependencies": {
-    "babel-eslint": "6.0.5",
+    "babel-eslint": "^6.0.5",
     "coveralls": "2.11.9",
-    "eslint": "2.13.1",
+    "eslint": "^3.0.0",
     "istanbul": "0.4.4",
     "mocha": "2.5.3"
+  },
+  "peerDependencies": {
+    "eslint": "^2.13.1 || ^3.0.0"
+  },
+  "engines": {
+    "node": ">=0.10"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
- specify ESLint 2 **or 3** as a peerDependency to help `npm` users identify compatibility issues

- specify Node.js 0.10 as the minimum (same as ESLint 2)