### PR TITLE
`react/display-name`: `ignoreTranspilerName` should only work with `React.createClass`

### DIFF
--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -91,32 +91,8 @@ module.exports = Components.detect(function(context, components, utils) {
         node.parent.parent &&
         node.parent.parent.type === 'VariableDeclarator'
     );
-    var namedClass = (
-      (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') &&
-      node.id &&
-      node.id.name
-    );
 
-    var namedFunctionDeclaration = (
-      (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') &&
-      node.id &&
-      node.id.name
-    );
-
-    var namedFunctionExpression = (
-      (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') &&
-      node.parent &&
-      (node.parent.type === 'VariableDeclarator' || node.parent.method === true)
-    );
-
-    if (
-      namedObjectAssignment || namedObjectDeclaration ||
-      namedClass ||
-      namedFunctionDeclaration || namedFunctionExpression
-    ) {
-      return true;
-    }
-    return false;
+    return namedObjectAssignment || namedObjectDeclaration;
   }
 
   // --------------------------------------------------------------------------
@@ -143,43 +119,8 @@ module.exports = Components.detect(function(context, components, utils) {
       markDisplayNameAsDeclared(component.node);
     },
 
-    FunctionExpression: function(node) {
-      if (ignoreTranspilerName || !hasTranspilerName(node)) {
-        return;
-      }
-      markDisplayNameAsDeclared(node);
-    },
-
-    FunctionDeclaration: function(node) {
-      if (ignoreTranspilerName || !hasTranspilerName(node)) {
-        return;
-      }
-      markDisplayNameAsDeclared(node);
-    },
-
-    ArrowFunctionExpression: function(node) {
-      if (ignoreTranspilerName || !hasTranspilerName(node)) {
-        return;
-      }
-      markDisplayNameAsDeclared(node);
-    },
-
     MethodDefinition: function(node) {
       if (!isDisplayNameDeclaration(node.key)) {
-        return;
-      }
-      markDisplayNameAsDeclared(node);
-    },
-
-    ClassExpression: function(node) {
-      if (ignoreTranspilerName || !hasTranspilerName(node)) {
-        return;
-      }
-      markDisplayNameAsDeclared(node);
-    },
-
-    ClassDeclaration: function(node) {
-      if (ignoreTranspilerName || !hasTranspilerName(node)) {
         return;
       }
       markDisplayNameAsDeclared(node);

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -127,15 +127,6 @@ ruleTester.run('display-name', rule, {
     parserOptions: parserOptions
   }, {
     code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
-    parser: 'babel-eslint'
-  }, {
-    code: [
       'export default class Hello {',
       '  render() {',
       '    return <div>Hello {this.props.name}</div>;',
@@ -191,28 +182,32 @@ ruleTester.run('display-name', rule, {
     code: [
       'var Hello = function() {',
       '  return <div>Hello {this.props.name}</div>;',
-      '}'
+      '};',
+      'Hello.displayName = \'Hello\';'
     ].join('\n'),
     parser: 'babel-eslint'
   }, {
     code: [
       'function Hello() {',
       '  return <div>Hello {this.props.name}</div>;',
-      '}'
+      '}',
+      'Hello.displayName = \'Hello\';'
     ].join('\n'),
     parser: 'babel-eslint'
   }, {
     code: [
       'var Hello = () => {',
       '  return <div>Hello {this.props.name}</div>;',
-      '}'
+      '};',
+      'Hello.displayName = \'Hello\';'
     ].join('\n'),
     parser: 'babel-eslint'
   }, {
     code: [
       'module.exports = function Hello() {',
       '  return <div>Hello {this.props.name}</div>;',
-      '}'
+      '}',
+      'Hello.displayName = \'Hello\';'
     ].join('\n'),
     parser: 'babel-eslint'
   }, {
@@ -299,7 +294,8 @@ ruleTester.run('display-name', rule, {
       '      <button />',
       '    );',
       '  }',
-      '};'
+      '};',
+      'Mixin.Button.displayName = \'Button\';'
     ].join('\n'),
     parser: 'babel-eslint'
   }, {
@@ -319,16 +315,6 @@ ruleTester.run('display-name', rule, {
       'var obj = {',
       '  pouf: function() {',
       '    return any',
-      '  }',
-      '};'
-    ].join('\n'),
-    parser: 'babel-eslint'
-  }, {
-    code: [
-      'export default {',
-      '  renderHello() {',
-      '    let {name} = this.props;',
-      '    return <div>{name}</div>;',
       '  }',
       '};'
     ].join('\n'),
@@ -352,6 +338,7 @@ ruleTester.run('display-name', rule, {
       'import React, {Component} from "react";',
       'function someDecorator(ComposedComponent) {',
       '  return class MyDecorator extends Component {',
+      '    static displayName = \'MyDecorator(ComposedComponent.displayName)\';',
       '    render() {return <ComposedComponent {...this.props} />;}',
       '  };',
       '}',
@@ -513,6 +500,45 @@ ruleTester.run('display-name', rule, {
     options: [{
       ignoreTranspilerName: true
     }],
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: [
+      'import React, {Component} from "react";',
+      'function someDecorator(ComposedComponent) {',
+      '  return class MyDecorator extends Component {',
+      '    render() {return <ComposedComponent {...this.props} />;}',
+      '  };',
+      '}',
+      'module.exports = someDecorator;'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: [
+      'export default {',
+      '  renderHello() {',
+      '    let {name} = this.props;',
+      '    return <div>{name}</div>;',
+      '  }',
+      '};'
+    ].join('\n'),
     parser: 'babel-eslint',
     errors: [{
       message: 'Component definition is missing display name'


### PR DESCRIPTION
Babel's plugin to add `displayName` ([`babel-plugin-transform-react-display-name`](https://github.com/babel/babel/tree/master/packages/babel-plugin-transform-react-display-name)) to components only works with `React.createClass` components (some more info [here](https://phabricator.babeljs.io/T1331)).

The [`react/display-name`](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md) rule in this repo, however, gives the impression that Babel will add a `displayName` to any `class` or `function` component too as the rule reports them as valid when they are missing `displayName` and the `ignoreTranspilerName` option is `false`.

This change brings the rule into line with what actually happens by not assuming that a `displayName` will be added by Babel for `class` and `function` components.

I realise this is quite a big change for this rule but I think it's causing a lot of people to think a `displayName` is being added automatically when it isn't at the moment. Especially since most people don't really use `React.createClass` anymore. Also, I think because React will use the `function.name` or `class.name` in error messages and the developer tools when `displayName` is missing this problem is being hidden. 

I've updated the tests and tried to keep good coverage but please let me know if anything is missing.
