### PR TITLE
Now only reporting up to once per file for `jsx-filename-extension`

### DIFF
--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -25,15 +25,21 @@ module.exports = function(context) {
     return context.options[0] && context.options[0].extensions || DEFAULTS.extensions;
   }
 
+  var invalidExtension;
+  var invalidNode;
+
   // --------------------------------------------------------------------------
   // Public
   // --------------------------------------------------------------------------
 
   return {
-
     JSXElement: function(node) {
       var filename = context.getFilename();
       if (filename === '<text>') {
+        return;
+      }
+
+      if (invalidNode) {
         return;
       }
 
@@ -46,11 +52,18 @@ module.exports = function(context) {
         return;
       }
 
-      var extension = path.extname(filename);
+      invalidNode = node;
+      invalidExtension = path.extname(filename);
+    },
+
+    'Program:exit': function() {
+      if (!invalidNode) {
+        return;
+      }
 
       context.report({
-        node: node,
-        message: 'JSX not allowed in files with extension \'' + extension + '\''
+        node: invalidNode,
+        message: 'JSX not allowed in files with extension \'' + invalidExtension + '\''
       });
     }
   };

--- a/tests/lib/rules/jsx-filename-extension.js
+++ b/tests/lib/rules/jsx-filename-extension.js
@@ -22,7 +22,7 @@ var parserOptions = {
 // Code Snippets
 // ------------------------------------------------------------------------------
 
-var withJSX = 'module.exports = function MyComponent() { return <div />; }';
+var withJSX = 'module.exports = function MyComponent() { return <div>\n<div />\n</div>; }';
 var withoutJSX = 'module.exports = {}';
 
 // ------------------------------------------------------------------------------


### PR DESCRIPTION
Things could get very spammy for no reason if you had a lot of JSX in a "disallowed file". I kept the first node for the report since it facilitates locating the culprit.

Let me know if there is anything!