### PR TITLE
[Fix] Don’t check filenames on text input.

### DIFF
--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -32,9 +32,12 @@ module.exports = function(context) {
   return {
 
     JSXElement: function(node) {
-      var allowedExtensions = getExtensionsConfig();
       var filename = context.getFilename();
+      if (filename === '<text>') {
+        return;
+      }
 
+      var allowedExtensions = getExtensionsConfig();
       var isAllowedExtension = allowedExtensions.some(function (extension) {
         return filename.slice(-extension.length) === extension;
       });

--- a/tests/lib/rules/jsx-filename-extension.js
+++ b/tests/lib/rules/jsx-filename-extension.js
@@ -34,6 +34,11 @@ ruleTester.run('jsx-filename-extension', rule, {
 
   valid: [
     {
+      filename: '<text>',
+      code: withJSX,
+      parserOptions: parserOptions
+    },
+    {
       filename: 'MyComponent.jsx',
       code: withJSX,
       parserOptions: parserOptions


### PR DESCRIPTION
Fixes #662.