### PR TITLE
New rule options allowDecorators in require-optimization

### DIFF
--- a/docs/rules/require-optimization.md
+++ b/docs/rules/require-optimization.md
@@ -52,14 +52,30 @@ React.createClass({
 
 ```js
 ...
-"require-optimization": [<enabled>]
+"require-optimization": [<enabled>, { allowDecorators: [<allowDecorator>] }]
 ...
+```
+
+* `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
+* `allowDecorators`: optional array of decorators names to allow validation.
+
+
+### `allowDecorators`
+
+Sets the allowed names of decorators. If the variable is present in the chain of decorators, it validates
+
+The following patterns are not warnings:
+
+```js
+// ['pureRender']
+@pureRender
+class Hello extends React.Component {}
 ```
 
 ### Example
 
 ```js
 ...
-"require-optimization": 2
+"require-optimization": [2, {allowDecorators: ['customDecorators']}]
 ...
 ```

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -8,6 +8,8 @@ var Components = require('../util/Components');
 
 module.exports = Components.detect(function (context, components) {
   var MISSING_MESSAGE = 'Component is not optimized. Please add a shouldComponentUpdate method.';
+  var configuration = context.options[0] || {};
+  var allowDecorators = configuration.allowDecorators || [];
 
   /**
    * Checks to see if our component is decorated by PureRenderMixin via reactMixin
@@ -29,6 +31,30 @@ module.exports = Components.detect(function (context, components) {
           node.decorators[i].expression.arguments[0].name === 'PureRenderMixin'
         ) {
           return true;
+        }
+      }
+    }
+
+    return false;
+  };
+
+  /**
+   * Checks to see if our component is custom decorated
+   * @param {ASTNode} node The AST node being checked.
+   * @returns {Boolean} True if node is decorated name with a custom decorated, false if not.
+   */
+  var hasCustomDecorator = function (node) {
+    var allowLenght = allowDecorators.length;
+
+    if (allowLenght && node.decorators && node.decorators.length) {
+      for (var i = 0; i < allowLenght; i++) {
+        for (var j = 0, l = node.decorators.length; j < l; j++) {
+          if (
+            node.decorators[j].expression &&
+            node.decorators[j].expression.name === allowDecorators[i]
+          ) {
+            return true;
+          }
         }
       }
     }
@@ -102,7 +128,7 @@ module.exports = Components.detect(function (context, components) {
     },
 
     ClassDeclaration: function (node) {
-      if (!hasPureRenderDecorator(node)) {
+      if (!(hasPureRenderDecorator(node) || hasCustomDecorator(node))) {
         return;
       }
       markSCUAsDeclared(node);
@@ -148,3 +174,16 @@ module.exports = Components.detect(function (context, components) {
     }
   };
 });
+
+module.exports.schema = [{
+  type: 'object',
+  properties: {
+    allowDecorators: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    }
+  },
+  additionalProperties: false
+}];

--- a/tests/lib/rules/require-optimization.js
+++ b/tests/lib/rules/require-optimization.js
@@ -77,6 +77,17 @@ ruleTester.run('react-require-optimization', rule, {
     ].join('\n'),
     parser: 'babel-eslint',
     parserOptions: parserOptions
+  }, {
+    code: [
+      '@bar',
+      '@pureRender',
+      '@foo',
+      'class DecoratedComponent extends Component {' +
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{allowDecorators: ['renderPure', 'pureRender']}],
+    parserOptions: parserOptions
   }],
 
   invalid: [{
@@ -128,6 +139,20 @@ ruleTester.run('react-require-optimization', rule, {
       message: MESSAGE
     }],
     parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '@bar',
+      '@pure',
+      '@foo',
+      'class DecoratedComponent extends Component {' +
+      '}'
+    ].join('\n'),
+    errors: [{
+      message: MESSAGE
+    }],
+    parser: 'babel-eslint',
+    options: [{allowDecorators: ['renderPure', 'pureRender']}],
     parserOptions: parserOptions
   }]
 });


### PR DESCRIPTION
I like this require-optimization rule, but it is not suitable for our implementation. I think a lot of people use https://www.npmjs.com/package/pure-render-decorator or similar solutions. It is the reason I made an additional option. Now it will be possible to register a list of names of decorators, which allow to pass validation.

I hope my change will be useful and will get in release =)