### PR TITLE
Handle spread props in jsx-no-target-blank rule

### DIFF
--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -15,7 +15,7 @@ module.exports = function(context) {
         var relFound = false;
         var attrs = node.parent.attributes;
         for (var idx in attrs) {
-          if (attrs[idx].name.name === 'rel') {
+          if (attrs[idx].name && attrs[idx].name.name === 'rel') {
             var tags = attrs[idx].value.value.split(' ');
             if (tags.indexOf('noopener') >= 0 && tags.indexOf('noreferrer') >= 0) {
               relFound = true;

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -27,7 +27,8 @@ ruleTester.run('jsx-no-target-blank', rule, {
   valid: [
     {code: '<a href="foobar"></a>', parserOptions: parserOptions},
     {code: '<a randomTag></a>', parserOptions: parserOptions},
-    {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>', parserOptions: parserOptions}
+    {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>', parserOptions: parserOptions},
+    {code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>', parserOptions: parserOptions}
   ],
   invalid: [
     {code: '<a target="_blank"></a>', parserOptions: parserOptions,

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -28,7 +28,8 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {code: '<a href="foobar"></a>', parserOptions: parserOptions},
     {code: '<a randomTag></a>', parserOptions: parserOptions},
     {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>', parserOptions: parserOptions},
-    {code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>', parserOptions: parserOptions}
+    {code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>', parserOptions: parserOptions},
+    {code: '<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>', parserOptions: parserOptions}
   ],
   invalid: [
     {code: '<a target="_blank"></a>', parserOptions: parserOptions,


### PR DESCRIPTION
When running the `jsx-no-target-blank` rule against code like the following:

```
<a {...this.props} target='_blank' />
```

the following error would be raised:

```
TypeError: Cannot read property 'name' of undefined
```

The root cause is that the node representing the spread props does not have a `name` property.

Note that if the desired `rel` attribute appears before the spread props, the error does not occur.
