### PR TITLE
Repair `--fix` for props-aligned in jsx-closing-bracket-location

### DIFF
--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -167,7 +167,6 @@ module.exports = function(context) {
     'JSXOpeningElement:exit': function(node) {
       var attributeNode = lastAttributeNode[getOpeningElementId(node)];
       var cachedLastAttributeEndPos = attributeNode ? attributeNode.end : null;
-      var cachedLastAttributeStartPos = attributeNode ? attributeNode.start : null;
       var expectedNextLine;
       var tokens = getTokensLocations(node);
       var expectedLocation = getExpectedLocation(tokens);
@@ -205,17 +204,11 @@ module.exports = function(context) {
               return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
                 (expectedNextLine ? '\n' : '') + closingTag);
             case 'props-aligned':
-              var spaces = new Array(cachedLastAttributeEndPos - cachedLastAttributeStartPos);
+            case 'tag-aligned':
+            case 'line-aligned':
+              var spaces = new Array(+correctColumn + 1);
               return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
                 '\n' + spaces.join(' ') + closingTag);
-            case 'tag-aligned':
-              var tagSpaces = new Array(+correctColumn + 1);
-              return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
-                '\n' + tagSpaces.join(' ') + closingTag);
-            case 'line-aligned':
-              var lineSpaces = new Array(+correctColumn + 1);
-              return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
-                '\n' + lineSpaces.join(' ') + closingTag);
             default:
               return true;
           }

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -685,6 +685,70 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     }]
   }, {
     code: [
+      'const Button = function(props) {',
+      '  return (',
+      '    <Button',
+      '      size={size}',
+      '      onClick={onClick}',
+      '                                    >',
+      '      Button Text',
+      '    </Button>',
+      '  );',
+      '};'
+    ].join('\n'),
+    output: [
+      'const Button = function(props) {',
+      '  return (',
+      '    <Button',
+      '      size={size}',
+      '      onClick={onClick}',
+      '    >',
+      '      Button Text',
+      '    </Button>',
+      '  );',
+      '};'
+    ].join('\n'),
+    options: ['tag-aligned'],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 5, false),
+      line: 6,
+      column: 37
+    }]
+  }, {
+    code: [
+      'const Button = function(props) {',
+      '  return (',
+      '    <Button',
+      '      size={size}',
+      '      onClick={onClick}',
+      '                                    >',
+      '      Button Text',
+      '    </Button>',
+      '  );',
+      '};'
+    ].join('\n'),
+    output: [
+      'const Button = function(props) {',
+      '  return (',
+      '    <Button',
+      '      size={size}',
+      '      onClick={onClick}',
+      '    >',
+      '      Button Text',
+      '    </Button>',
+      '  );',
+      '};'
+    ].join('\n'),
+    options: ['line-aligned'],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 5, false),
+      line: 6,
+      column: 37
+    }]
+  }, {
+    code: [
       '<Provider',
       '  store',
       '  >',

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -653,6 +653,38 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     }]
   }, {
     code: [
+      'const Button = function(props) {',
+      '  return (',
+      '    <Button',
+      '      size={size}',
+      '      onClick={onClick}',
+      '                                    >',
+      '      Button Text',
+      '    </Button>',
+      '  );',
+      '};'
+    ].join('\n'),
+    output: [
+      'const Button = function(props) {',
+      '  return (',
+      '    <Button',
+      '      size={size}',
+      '      onClick={onClick}',
+      '      >',
+      '      Button Text',
+      '    </Button>',
+      '  );',
+      '};'
+    ].join('\n'),
+    options: ['props-aligned'],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 7, false),
+      line: 6,
+      column: 37
+    }]
+  }, {
+    code: [
       '<Provider',
       '  store',
       '  >',


### PR DESCRIPTION
Use the correctColumn attribute that is populated above.

I don't quite understand the error, but running with `--fix` I would still get errors that look like

"  247:37  error  The closing bracket must be aligned with the last prop (expected column 9)   react/jsx-closing-bracket-location"

But with this change, `--fix` does the right thing.