### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,18 +149,6 @@ To enable this configuration use the `extends` property in your `.eslintrc` conf
 }
 ```
 
-This plugin also exports an `all` configuration that includes every available rule.
-This pairs well with the `eslint:all` rule.
-
-```js
-{
-  "plugins": [
-    "react"
-  ],
-  "extends": ["eslint:all", "plugin:react/all"]
-}
-```
-
 See [ESLint documentation](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information about extending configuration files.
 
 The rules enabled in this configuration are:
@@ -182,6 +170,18 @@ The rules enabled in this configuration are:
 * [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md)
 
 **Note**: This configuration will also enable JSX in [parser options](http://eslint.org/docs/user-guide/configuring#specifying-parser-options).
+
+This plugin also exports an `all` configuration that includes every available rule.
+This pairs well with the `eslint:all` rule.
+
+```js
+{
+  "plugins": [
+    "react"
+  ],
+  "extends": ["eslint:all", "plugin:react/all"]
+}
+```
 
 # License
 


### PR DESCRIPTION
When I added the block about the `all` configuration, it was in a place that didn't make sense because it broke up the description of the `recommended` configuration