### PR TITLE
Remove rules deprecated options

### DIFF
--- a/docs/rules/jsx-uses-react.md
+++ b/docs/rules/jsx-uses-react.md
@@ -7,6 +7,7 @@ If you are using the @jsx pragma this rule will mark the designated variable and
 
 This rule has no effect if the `no-unused-vars` rule is not enabled.
 
+You can use the [shared settings](/README.md#configuration) to specify a custom pragma.
 
 ## Rule Details
 
@@ -39,28 +40,6 @@ var Foo = require('foo');
 
 var Hello = <div>Hello {this.props.name}</div>;
 ```
-
-## Rule Options
-
-```js
-...
-"jsx-uses-react": [<enabled>, { "pragma": <string> }]
-...
-```
-
-### `pragma`
-
-**Deprecation notice**: This option is deprecated, please use the [shared settings](/README.md#configuration) to specify a custom pragma.
-
-As an alternative to specifying the above pragma in each source file, you can specify
-this configuration option:
-
-```js
-var Foo = require('Foo');
-
-var Hello = <div>Hello {this.props.name}</div>;
-```
-
 
 ## When Not To Use It
 

--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -1,6 +1,6 @@
 # Prevent usage of deprecated methods (no-deprecated)
 
-Several methods are deprecated between React versions. This rule will warn you if you try to use a deprecated method.
+Several methods are deprecated between React versions. This rule will warn you if you try to use a deprecated method. Use the [shared settings](/README.md#configuration) to specify the React version.
 
 ## Rule Details
 
@@ -25,16 +25,4 @@ ReactDOM.render(<MyComponent />, root);
 
 // When [1, {"react": "0.13.0"}]
 ReactDOM.findDOMNode(this.refs.foo);
-```
-
-## Rule Options
-
-**Deprecation notice**: This option is deprecated, please use the [shared settings](/README.md#configuration) to specify the React version.
-
-By default this rule will warn to every methods marked as deprecated. You can limit it to an older React version if you are not using the latest one:
-
-```js
-"rules": {
-  "react/no-deprecated": [1, {"react": "0.12.0"}] // Will warn for every deprecated methods in React 0.12.0 and below
-}
 ```

--- a/lib/rules/jsx-uses-react.js
+++ b/lib/rules/jsx-uses-react.js
@@ -33,12 +33,4 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [{
-  type: 'object',
-  properties: {
-    pragma: {
-      type: 'string'
-    }
-  },
-  additionalProperties: false
-}];
+module.exports.schema = [];

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -99,13 +99,4 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [{
-  type: 'object',
-  properties: {
-    react: {
-      type: 'string',
-      pattern: '^[0-9]+\.[0-9]+(\.[0-9]+)?$'
-    }
-  },
-  additionalProperties: false
-}];
+module.exports.schema = [];

--- a/lib/util/pragma.js
+++ b/lib/util/pragma.js
@@ -11,9 +11,6 @@ function getFromContext(context) {
   // .eslintrc shared settings (http://eslint.org/docs/user-guide/configuring#adding-shared-settings)
   if (context.settings.react && context.settings.react.pragma) {
     pragma = context.settings.react.pragma;
-  // Deprecated pragma option, here for backward compatibility
-  } else if (context.options[0] && context.options[0].pragma) {
-    pragma = context.options[0].pragma;
   }
   return pragma.split('.')[0];
 }

--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -9,9 +9,6 @@ function getFromContext(context) {
   // .eslintrc shared settings (http://eslint.org/docs/user-guide/configuring#adding-shared-settings)
   if (context.settings.react && context.settings.react.version) {
     confVer = context.settings.react.version;
-  // Deprecated react option, here for backward compatibility
-  } else if (context.options[0] && context.options[0].react) {
-    confVer = context.options[0].react;
   }
   confVer = /^[0-9]+\.[0-9]+$/.test(confVer) ? confVer + '.0' : confVer;
   return confVer.split('.').map(function(part) {

--- a/tests/lib/rules/jsx-uses-react.js
+++ b/tests/lib/rules/jsx-uses-react.js
@@ -37,7 +37,6 @@ ruleTester.run('no-unused-vars', rule, {
     {code: '/*eslint jsx-uses-react:1*/ var React; <div />;', parserOptions: parserOptions},
     {code: '/*eslint jsx-uses-react:1*/ var React; (function () { <div /> })();', parserOptions: parserOptions},
     {code: '/*eslint jsx-uses-react:1*/ /** @jsx Foo */ var Foo; <div />;', parserOptions: parserOptions},
-    {code: '/*eslint jsx-uses-react:[1,{"pragma":"Foo"}]*/ var Foo; <div />;', parserOptions: parserOptions},
     {code: '/*eslint jsx-uses-react:1*/ var Foo; <div />;', settings: settings, parserOptions: parserOptions}
   ],
   invalid: [

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -12,12 +12,6 @@
 var rule = require('../../../lib/rules/no-deprecated');
 var RuleTester = require('eslint').RuleTester;
 
-var settings = {
-  react: {
-    pragma: 'Foo'
-  }
-};
-
 require('babel-eslint');
 
 // ------------------------------------------------------------------------------
@@ -38,26 +32,24 @@ ruleTester.run('no-deprecated', rule, {
     'ReactDOMServer.renderToString(element);',
     'ReactDOMServer.renderToStaticMarkup(element);',
     // Deprecated in a later version
-    {code: 'React.renderComponent()', options: [{react: '0.11.0'}]},
     {code: 'React.renderComponent()', settings: {react: {version: '0.11.0'}}}
   ],
 
   invalid: [{
     code: 'React.renderComponent()',
-    options: [{react: '0.12.0'}],
+    settings: {react: {version: '0.12.0'}},
     errors: [{
       message: 'React.renderComponent is deprecated since React 0.12.0, use React.render instead'
     }]
   }, {
     code: 'Foo.renderComponent()',
-    options: [{react: '0.12.0'}],
-    settings: settings,
+    settings: {react: {pragma: 'Foo', version: '0.12.0'}},
     errors: [{
       message: 'Foo.renderComponent is deprecated since React 0.12.0, use Foo.render instead'
     }]
   }, {
     code: '/** @jsx Foo */ Foo.renderComponent()',
-    options: [{react: '0.12.0'}],
+    settings: {react: {version: '0.12.0'}},
     errors: [{
       message: 'Foo.renderComponent is deprecated since React 0.12.0, use Foo.render instead'
     }]


### PR DESCRIPTION
These options were deprecated in a previous release. Now that we are preparing for a major version bump, we want to clear them out. 

Addresses #686.