### PR TITLE
Reference right prop for ListItem

### DIFF
--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -99,7 +99,7 @@ var ListItem = React.createClass({
     );
   },
   _onClick() {
-    this.props.onItemClick(this.props.item.id);
+    this.props.onItemClick(this.props.key);
   }
 });
 ```


### PR DESCRIPTION
It seems to me that in the `ListItem` component, the referred prop should be `key` as the example above is using `<ListItem key...`.