### PR TITLE
Add rule to forbid className and style being passed to Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Finally, enable all of the rules that you would like to use.  Use [our preset](#
 # List of supported rules
 
 * [react/display-name](docs/rules/display-name.md): Prevent missing `displayName` in a React component definition
+* [react/forbid-component-props](docs/rules/forbid-component-props.md): Forbid certain props on Components
 * [react/forbid-prop-types](docs/rules/forbid-prop-types.md): Forbid certain propTypes
 * [react/no-danger](docs/rules/no-danger.md): Prevent usage of dangerous JSX properties
 * [react/no-deprecated](docs/rules/no-deprecated.md): Prevent usage of deprecated methods

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -1,0 +1,44 @@
+# Forbid certain props on Components (forbid-component-props)
+
+By default this rule prevents passing of [props that add lots of complexity](https://medium.com/brigade-engineering/don-t-pass-css-classes-between-components-e9f7ab192785) (`className`, `style`) to Components. This rule only applies to Components (e.g. `<Foo />`) and not DOM nodes (e.g. `<div />`). The list of forbidden props can be customized with the `forbid` option.
+
+## Rule Details
+
+This rule checks all JSX elements and verifies that no forbidden props are used
+on Components. This rule is off by default.
+
+The following patterns are considered warnings:
+
+```jsx
+<Hello className='foo' />
+```
+
+```jsx
+<Hello style={{color: 'red'}} />
+```
+
+The following patterns are not considered warnings:
+
+```jsx
+<Hello name='Joe' />
+```
+
+```jsx
+<div className='foo' />
+```
+
+```jsx
+<div style={{color: 'red'}} />
+```
+
+## Rule Options
+
+```js
+...
+"forbid-component-props": [<enabled>, { "forbid": [<string>] }]
+...
+```
+
+### `forbid`
+
+An array of strings, with the names of props that are forbidden.

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -41,4 +41,4 @@ The following patterns are not considered warnings:
 
 ### `forbid`
 
-An array of strings, with the names of props that are forbidden.
+An array of strings, with the names of props that are forbidden. The default value of this option is `['className', 'style']`.

--- a/docs/rules/forbid-prop-types.md
+++ b/docs/rules/forbid-prop-types.md
@@ -50,7 +50,7 @@ class Component extends React.Component {
 
 ### `forbid`
 
-An array of strings, with the names of `React.PropTypes` keys that are forbidden.
+An array of strings, with the names of `React.PropTypes` keys that are forbidden. The default value for this option is `['any', 'array', 'object']`.
 
 ## When not to use
 

--- a/index.js
+++ b/index.js
@@ -40,6 +40,7 @@ var rules = {
   'jsx-closing-bracket-location': require('./lib/rules/jsx-closing-bracket-location'),
   'jsx-space-before-closing': require('./lib/rules/jsx-space-before-closing'),
   'no-direct-mutation-state': require('./lib/rules/no-direct-mutation-state'),
+  'forbid-component-props': require('./lib/rules/forbid-component-props'),
   'forbid-prop-types': require('./lib/rules/forbid-prop-types'),
   'prefer-es6-class': require('./lib/rules/prefer-es6-class'),
   'jsx-key': require('./lib/rules/jsx-key'),

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -14,46 +14,52 @@ var DEFAULTS = ['className', 'style'];
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-module.exports = function(context) {
+module.exports = {
+  meta: {
+    docs: {},
 
-  function isForbidden(prop) {
-    var configuration = context.options[0] || {};
-
-    var forbid = configuration.forbid || DEFAULTS;
-    return forbid.indexOf(prop) >= 0;
-  }
-
-  return {
-    JSXAttribute: function(node) {
-      var tag = node.parent.name.name;
-      if (tag[0] !== tag[0].toUpperCase()) {
-        // This is a DOM node, not a Component, so exit.
-        return;
-      }
-
-      var prop = node.name.name;
-
-      if (!isForbidden(prop)) {
-        return;
-      }
-
-      context.report({
-        node: node,
-        message: 'Prop `' + prop + '` is forbidden on Components'
-      });
-    }
-  };
-};
-
-module.exports.schema = [{
-  type: 'object',
-  properties: {
-    forbid: {
-      type: 'array',
-      items: {
-        type: 'string'
-      }
-    }
+    schema: [{
+      type: 'object',
+      properties: {
+        forbid: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        }
+      },
+      additionalProperties: true
+    }]
   },
-  additionalProperties: true
-}];
+
+  create: function(context) {
+
+    function isForbidden(prop) {
+      var configuration = context.options[0] || {};
+
+      var forbid = configuration.forbid || DEFAULTS;
+      return forbid.indexOf(prop) >= 0;
+    }
+
+    return {
+      JSXAttribute: function(node) {
+        var tag = node.parent.name.name;
+        if (tag[0] !== tag[0].toUpperCase()) {
+          // This is a DOM node, not a Component, so exit.
+          return;
+        }
+
+        var prop = node.name.name;
+
+        if (!isForbidden(prop)) {
+          return;
+        }
+
+        context.report({
+          node: node,
+          message: 'Prop `' + prop + '` is forbidden on Components'
+        });
+      }
+    };
+  }
+};

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Forbid certain props on components
+ * @author Joe Lencioni
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Constants
+// ------------------------------------------------------------------------------
+
+var DEFAULTS = ['className', 'style'];
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+  function isForbidden(prop) {
+    var configuration = context.options[0] || {};
+
+    var forbid = configuration.forbid || DEFAULTS;
+    return forbid.indexOf(prop) >= 0;
+  }
+
+  return {
+    JSXAttribute: function(node) {
+      var tag = node.parent.name.name;
+      if (tag[0] !== tag[0].toUpperCase()) {
+        // This is a DOM node, not a Component, so exit.
+        return;
+      }
+
+      var prop = node.name.name;
+
+      if (!isForbidden(prop)) {
+        return;
+      }
+
+      context.report({
+        node: node,
+        message: 'Prop `' + prop + '` is forbidden on Components'
+      });
+    }
+  };
+};
+
+module.exports.schema = [{
+  type: 'object',
+  properties: {
+    forbid: {
+      type: 'array',
+      items: {
+        type: 'string'
+      }
+    }
+  },
+  additionalProperties: true
+}];

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -1,0 +1,153 @@
+/**
+ * @fileoverview Tests for forbid-component-props
+ */
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/forbid-component-props');
+var RuleTester = require('eslint').RuleTester;
+
+var parserOptions = {
+  ecmaVersion: 6,
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true
+  }
+};
+
+require('babel-eslint');
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+var CLASSNAME_ERROR_MESSAGE = 'Prop `className` is forbidden on Components';
+var STYLE_ERROR_MESSAGE = 'Prop `style` is forbidden on Components';
+
+var ruleTester = new RuleTester();
+ruleTester.run('forbid-component-props', rule, {
+
+  valid: [{
+    code: [
+      'var First = React.createClass({',
+      '  render: function() {',
+      '    return <div className="foo" />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  render: function() {',
+      '    return <div style={{color: "red"}} />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{forbid: ['style']}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo bar="baz" />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo className="bar" />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{forbid: ['style']}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo className="bar" />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{forbid: ['style', 'foo']}],
+    parserOptions: parserOptions
+  }],
+
+  invalid: [{
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo className="bar" />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: CLASSNAME_ERROR_MESSAGE,
+      line: 4,
+      column: 17,
+      type: 'JSXAttribute'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo style={{color: "red"}} />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: STYLE_ERROR_MESSAGE,
+      line: 4,
+      column: 17,
+      type: 'JSXAttribute'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo className="bar" />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: [{forbid: ['className', 'style']}],
+    errors: [{
+      message: CLASSNAME_ERROR_MESSAGE,
+      line: 4,
+      column: 17,
+      type: 'JSXAttribute'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo style={{color: "red"}} />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: [{forbid: ['className', 'style']}],
+    errors: [{
+      message: STYLE_ERROR_MESSAGE,
+      line: 4,
+      column: 17,
+      type: 'JSXAttribute'
+    }]
+  }]
+});


### PR DESCRIPTION
Passing `className` or `style` to your Components is a source of much
hidden complexity that can be solved either by using a wrapper to add
styling or by adding props for specific styling. This rule aims at
preventing these props from being passed to your Components, to help
minimize hidden complexity.

The original issue proposed having this rule check propTypes. I
considered that route, but I worry that it won't be as effective for
people who do not have every prop used by the component listed in the
propTypes. Additionally, propTypes seem to have waning interest from the
React team in favor of Flow annotations, so I think in the long run
checking for this at the callsite will be more stable.

More information can be found by reading:

  https://medium.com/brigade-engineering/don-t-pass-css-classes-between-components-e9f7ab192785

Also:

  https://twitter.com/sebmarkbage/status/598971268403073024

Fixes #314

cc: @janpaul123 @sebmarkbage