### PR TITLE
Add jsx-closing-bracket-atomic rule (Fixes #693)

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ var rules = {
   'jsx-no-literals': require('./lib/rules/jsx-no-literals'),
   'jsx-indent-props': require('./lib/rules/jsx-indent-props'),
   'jsx-indent': require('./lib/rules/jsx-indent'),
+  'jsx-closing-bracket-atomic': require('./lib/rules/jsx-closing-bracket-atomic'),
   'jsx-closing-bracket-location': require('./lib/rules/jsx-closing-bracket-location'),
   'jsx-space-before-closing': require('./lib/rules/jsx-space-before-closing'),
   'no-direct-mutation-state': require('./lib/rules/no-direct-mutation-state'),

--- a/lib/rules/jsx-closing-bracket-atomic.js
+++ b/lib/rules/jsx-closing-bracket-atomic.js
@@ -1,0 +1,39 @@
+/**
+ * @fileoverview Ensures the "/>" and "</" closing indicators are written as a single token
+ * @author Diogo Franco (Kovensky)
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Constants
+// ------------------------------------------------------------------------------
+
+var MESSAGE = 'JSX tag closing has embedded whitespace';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = function(context) {
+  return {
+    JSXOpeningElement: function(node) {
+      if (node.selfClosing) {
+        var sourceCode = context.getSourceCode();
+        var sourceText = sourceCode.getText(node);
+        if (sourceText.lastIndexOf('/>') !== sourceText.length - 2) {
+          context.report(node, MESSAGE);
+        }
+      }
+    },
+    JSXClosingElement: function(node) {
+      var sourceCode = context.getSourceCode();
+      var sourceText = sourceCode.getText(node);
+      if (sourceText.indexOf('</') !== 0) {
+        context.report(node, MESSAGE);
+      }
+    }
+  };
+
+};
+
+module.exports.schema = [];

--- a/lib/rules/jsx-closing-bracket-atomic.js
+++ b/lib/rules/jsx-closing-bracket-atomic.js
@@ -8,7 +8,8 @@
 // Constants
 // ------------------------------------------------------------------------------
 
-var MESSAGE = 'JSX tag closing has embedded whitespace';
+var MESSAGE_SELF_CLOSING = 'Self-closing JSX elements must not have whitespace between the `/` and the `>`';
+var MESSAGE_CLOSING = 'JSX closing tags must not have whitespace between the `<` and the `/`';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -21,7 +22,7 @@ module.exports = function(context) {
         var sourceCode = context.getSourceCode();
         var sourceText = sourceCode.getText(node);
         if (sourceText.lastIndexOf('/>') !== sourceText.length - 2) {
-          context.report(node, MESSAGE);
+          context.report(node, MESSAGE_SELF_CLOSING);
         }
       }
     },
@@ -29,7 +30,7 @@ module.exports = function(context) {
       var sourceCode = context.getSourceCode();
       var sourceText = sourceCode.getText(node);
       if (sourceText.indexOf('</') !== 0) {
-        context.report(node, MESSAGE);
+        context.report(node, MESSAGE_CLOSING);
       }
     }
   };

--- a/tests/lib/rules/jsx-closing-bracket-atomic.js
+++ b/tests/lib/rules/jsx-closing-bracket-atomic.js
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Tests for jsx-closing-bracket-atomic
+ * @author Diogo Franco (Kovensky)
+ */
+
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/jsx-closing-bracket-atomic');
+var RuleTester = require('eslint').RuleTester;
+
+var parserOptions = {
+  ecmaVersion: 6,
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('jsx-closing-bracket-atomic', rule, {
+  valid: [
+    {code: '<App/>;', parserOptions: parserOptions},
+    {code: '<App />;', parserOptions: parserOptions},
+    {code: '<div className="bar"></div>;', parserOptions: parserOptions},
+    {code: '<div className="bar"></ div>;', parserOptions: parserOptions}
+  ],
+  invalid: [{
+    code: '<App/ >;',
+    errors: [{message: 'JSX tag closing has embedded whitespace'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App/',
+      '>'
+    ].join('\n'),
+    errors: [{message: 'JSX tag closing has embedded whitespace'}],
+    parserOptions: parserOptions
+  }, {
+    code: '<div className="bar">< /div>;',
+    errors: [{message: 'JSX tag closing has embedded whitespace'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<div className="bar"><',
+      '/div>;'
+    ].join('\n'),
+    errors: [{message: 'JSX tag closing has embedded whitespace'}],
+    parserOptions: parserOptions
+  }]
+});

--- a/tests/lib/rules/jsx-closing-bracket-atomic.js
+++ b/tests/lib/rules/jsx-closing-bracket-atomic.js
@@ -33,25 +33,25 @@ ruleTester.run('jsx-closing-bracket-atomic', rule, {
   ],
   invalid: [{
     code: '<App/ >;',
-    errors: [{message: 'JSX tag closing has embedded whitespace'}],
+    errors: [{message: 'Self-closing JSX elements must not have whitespace between the `/` and the `>`'}],
     parserOptions: parserOptions
   }, {
     code: [
       '<App/',
       '>'
     ].join('\n'),
-    errors: [{message: 'JSX tag closing has embedded whitespace'}],
+    errors: [{message: 'Self-closing JSX elements must not have whitespace between the `/` and the `>`'}],
     parserOptions: parserOptions
   }, {
     code: '<div className="bar">< /div>;',
-    errors: [{message: 'JSX tag closing has embedded whitespace'}],
+    errors: [{message: 'JSX closing tags must not have whitespace between the `<` and the `/`'}],
     parserOptions: parserOptions
   }, {
     code: [
       '<div className="bar"><',
       '/div>;'
     ].join('\n'),
-    errors: [{message: 'JSX tag closing has embedded whitespace'}],
+    errors: [{message: 'JSX closing tags must not have whitespace between the `<` and the `/`'}],
     parserOptions: parserOptions
   }]
 });


### PR DESCRIPTION
Minimal working implementation. This is probably missing things :)

I also don't really like the error message, but I couldn't think of a better one.