### PR TITLE
Add backticks in forbid-prop-types documentation

### DIFF
--- a/docs/rules/forbid-prop-types.md
+++ b/docs/rules/forbid-prop-types.md
@@ -50,7 +50,7 @@ class Component extends React.Component {
 
 ### `forbid`
 
-An array of strings, with the names of React.PropType keys that are forbidden.
+An array of strings, with the names of `React.PropTypes` keys that are forbidden.
 
 ## When not to use
 


### PR DESCRIPTION
This is a reference to code, so we should use backticks.

I've also changed it to be "PropTypes" instead of "PropType" since
that is what you would see in code.