### PR TITLE
Add Pragma for createClass factory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You can also specify some settings that will be shared across all the plugin rul
 {
   "settings": {
     "react": {
+      "createClass": "createClass", // Regex for Component Factory to use, default to "createClass"
       "pragma": "React",  // Pragma to use, default to "React"
       "version": "15.0" // React version, default to the latest React stable release
     }

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -136,6 +136,7 @@ Components.prototype.length = function() {
 
 function componentRule(rule, context) {
 
+  var createClass = pragmaUtil.getCreateClassFromContext(context);
   var pragma = pragmaUtil.getFromContext(context);
   var sourceCode = context.getSourceCode();
   var components = new Components();
@@ -153,7 +154,7 @@ function componentRule(rule, context) {
       if (!node.parent) {
         return false;
       }
-      return new RegExp('^(' + pragma + '\\.)?createClass$').test(sourceCode.getText(node.parent.callee));
+      return new RegExp('^(' + pragma + '\\.)?' + createClass + '$').test(sourceCode.getText(node.parent.callee));
     },
 
     /**

--- a/lib/util/pragma.js
+++ b/lib/util/pragma.js
@@ -5,6 +5,21 @@
 'use strict';
 
 var JSX_ANNOTATION_REGEX = /^\*\s*@jsx\s+([^\s]+)/;
+// Does not check for reserved keywords or unicode characters
+var JS_IDENTIFIER_REGEX = /^[_$a-zA-Z][_$a-zA-Z0-9]*$/;
+
+
+function getCreateClassFromContext(context) {
+  var pragma = 'createClass';
+  // .eslintrc shared settings (http://eslint.org/docs/user-guide/configuring#adding-shared-settings)
+  if (context.settings.react && context.settings.react.createClass) {
+    pragma = context.settings.react.createClass;
+  }
+  if (!JS_IDENTIFIER_REGEX.test(pragma)) {
+    throw new Error('createClass pragma ' + pragma + 'is not a valid function name');
+  }
+  return pragma;
+}
 
 function getFromContext(context) {
   var pragma = 'React';
@@ -12,7 +27,10 @@ function getFromContext(context) {
   if (context.settings.react && context.settings.react.pragma) {
     pragma = context.settings.react.pragma;
   }
-  return pragma.split('.')[0];
+  if (!JS_IDENTIFIER_REGEX.test(pragma)) {
+    throw new Error('React pragma ' + pragma + 'is not a valid identifier');
+  }
+  return pragma;
 }
 
 function getFromNode(node) {
@@ -24,6 +42,7 @@ function getFromNode(node) {
 }
 
 module.exports = {
+  getCreateClassFromContext: getCreateClassFromContext,
   getFromContext: getFromContext,
   getFromNode: getFromNode
 };


### PR DESCRIPTION
Allows the the plugin to lint components created in a non-standard way with
configuration such as

```js
var MyComponent = SpecialReact.createSpecialClass({
  ...
});
```

with config looking like:
```json
{
  "settings": {
    "react": {
      "createClass": "createSpecialClass",
      "pragma": "SpecialReact", 
    }
  }
}
```