### PR TITLE
Do not recommend arrow functions in no-string-refs documentation

### DIFF
--- a/docs/rules/no-string-refs.md
+++ b/docs/rules/no-string-refs.md
@@ -6,7 +6,7 @@ Currently, two ways are supported by React to refer to components. The first one
 
 Invalid:
 
-```js
+```jsx
 var Hello = React.createClass({
  render: function() {
   return <div ref="hello">Hello, world.</div>;
@@ -14,7 +14,7 @@ var Hello = React.createClass({
 });
 ```
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     var component = this.refs.hello;
@@ -28,14 +28,17 @@ var Hello = React.createClass({
 
 Valid:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     var component = this.hello;
     // ...do something with component
   },
+  _helloRef(c){
+    this.hello = c;
+  },
   render() {
-    return <div ref={(c) => { this.hello = c; }}>Hello, world.</div>;
+    return <div ref={this._helloRef}>Hello, world.</div>;
   }
 });
 ```


### PR DESCRIPTION
See https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-bind.md

Apart from jsx-no-bind reasons ( #524 ) , this function would actually also **get called every render**, so it should be explicitly recommended. 

See https://github.com/facebook/react/blob/master/src/renderers/shared/stack/reconciler/ReactReconciler.js#L150-L165

If necessary, additional comments can be added regarding this explanation.