### PR TITLE
Make prefer-stateless-function PureComponent aware

### DIFF
--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -16,7 +16,7 @@ If none of these elements are found, the rule will warn you to write this compon
 
 The following pattern is considered a warning:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>Hello {this.props.name}</div>;
@@ -26,7 +26,7 @@ var Hello = React.createClass({
 
 The following pattern is not considered a warning:
 
-```js
+```jsx
 const Foo = function(props) {
   return <div>{props.foo}</div>;
 };
@@ -34,7 +34,7 @@ const Foo = function(props) {
 
 The following pattern is not considered a warning in React <15.0.0:
 
-```js
+```jsx
 class Foo extends React.Component {
   render() {
     if (!this.props.foo) {
@@ -45,9 +45,25 @@ class Foo extends React.Component {
 }
 ```
 
-The following pattern is not considered a warning:
+
+## Rule Options
 
 ```js
+...
+"prefer-stateless-function": [<enabled>, { "ignorePureComponent": <ignorePureComponent> }]
+...
+```
+
+* `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
+* `ignorePureComponent`: optional boolean set to `true` to ignore components extending from `React.PureComponent` (default to `false`).
+
+### `ignorePureComponent`
+
+When `true` the rule will ignore Components extending from `React.PureComponent` that use `this.props` or `this.context`.
+
+The following patterns is considered okay and does not cause warnings:
+
+```jsx
 class Foo extends React.PureComponent {
   render() {
     return <div>{this.props.foo}</div>;
@@ -55,3 +71,12 @@ class Foo extends React.PureComponent {
 }
 ```
 
+The following pattern is considered a warning because it's not using props or context:
+
+```jsx
+class Foo extends React.PureComponent {
+  render() {
+    return <div>Bar</div>;
+  }
+}
+```

--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -8,12 +8,13 @@ This rule will check your class based React components for
 
 * methods/properties other than `displayName`, `propTypes`, `render` and useless constructor (same detection as ESLint [no-useless-constructor rule](http://eslint.org/docs/rules/no-useless-constructor))
 * instance property other than `this.props` and `this.context`
+* extension of `React.PureComponent` ()
 * presence of `ref` attribute in JSX
 * `render` method that return anything but JSX: `undefined`, `null`, etc. (only in React <15.0.0, see [shared settings](https://github.com/yannickcr/eslint-plugin-react/blob/master/README.md#configuration) for React version configuration)
 
-If none of these 4 elements are found, the rule will warn you to write this component as a pure function.
+If none of these elements are found, the rule will warn you to write this component as a pure function.
 
-The following pattern is considered warnings:
+The following pattern is considered a warning:
 
 ```js
 var Hello = React.createClass({
@@ -23,7 +24,7 @@ var Hello = React.createClass({
 });
 ```
 
-The following pattern is not considered warnings:
+The following pattern is not considered a warning:
 
 ```js
 const Foo = function(props) {
@@ -31,7 +32,7 @@ const Foo = function(props) {
 };
 ```
 
-The following pattern is not considered warning in React <15.0.0:
+The following pattern is not considered a warning in React <15.0.0:
 
 ```js
 class Foo extends React.Component {
@@ -43,3 +44,14 @@ class Foo extends React.Component {
   }
 }
 ```
+
+The following pattern is not considered a warning:
+
+```js
+class Foo extends React.PureComponent {
+  render() {
+    return <div>{this.props.foo}</div>;
+  }
+}
+```
+

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -43,7 +43,7 @@ module.exports = {
      * @returns {Boolean} True if the component is ignored, false if not.
      */
     function isIgnored(component) {
-      return ignoreStateless === true && /Function/.test(component.node.type);
+      return ignoreStateless && /Function/.test(component.node.type);
     }
 
     // --------------------------------------------------------------------------

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -7,7 +7,6 @@
 'use strict';
 
 var Components = require('../util/Components');
-var pragmaUtil = require('../util/pragma');
 var versionUtil = require('../util/version');
 
 // ------------------------------------------------------------------------------
@@ -21,13 +20,22 @@ module.exports = {
       category: 'Stylistic Issues',
       recommended: false
     },
-    schema: []
+    schema: [{
+      type: 'object',
+      properties: {
+        ignorePureComponents: {
+          default: false,
+          type: 'boolean'
+        }
+      },
+      additionalProperties: false
+    }]
   },
 
   create: Components.detect(function(context, components, utils) {
 
-    var pragma = pragmaUtil.getFromContext(context);
-    var pureComponentRegExp = new RegExp('^(' + pragma + '\\.)?PureComponent$');
+    var configuration = context.options[0] || {};
+    var ignorePureComponents = configuration.ignorePureComponents || false;
 
     var sourceCode = context.getSourceCode();
 
@@ -67,19 +75,6 @@ module.exports = {
           return [];
       }
     }
-
-    /**
-     * Checks to see if our component extends React.PureComponent
-     * @param {ASTNode} node The AST node being checked.
-     * @returns {Boolean} True if node extends React.PureComponent, false if not.
-     */
-    var isPureComponent = function (node) {
-      if (node.superClass) {
-        return pureComponentRegExp.test(sourceCode.getText(node.superClass));
-      }
-
-      return false;
-    };
 
     /**
      * Checks whether a given array of statements is a single call of `super`.
@@ -282,10 +277,9 @@ module.exports = {
 
     return {
       ClassDeclaration: function (node) {
-        if (!isPureComponent(node)) {
-          return;
+        if (ignorePureComponents && utils.isPureComponent(node)) {
+          markSCUAsDeclared(node);
         }
-        markSCUAsDeclared(node);
       },
 
       // Mark `this` destructuring as a usage of `this`

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -7,6 +7,7 @@
 'use strict';
 
 var Components = require('../util/Components');
+var pragmaUtil = require('../util/pragma');
 var versionUtil = require('../util/version');
 
 // ------------------------------------------------------------------------------
@@ -24,6 +25,9 @@ module.exports = {
   },
 
   create: Components.detect(function(context, components, utils) {
+
+    var pragma = pragmaUtil.getFromContext(context);
+    var pureComponentRegExp = new RegExp('^(' + pragma + '\\.)?PureComponent$');
 
     var sourceCode = context.getSourceCode();
 
@@ -63,6 +67,19 @@ module.exports = {
           return [];
       }
     }
+
+    /**
+     * Checks to see if our component extends React.PureComponent
+     * @param {ASTNode} node The AST node being checked.
+     * @returns {Boolean} True if node extends React.PureComponent, false if not.
+     */
+    var isPureComponent = function (node) {
+      if (node.superClass) {
+        return pureComponentRegExp.test(sourceCode.getText(node.superClass));
+      }
+
+      return false;
+    };
 
     /**
      * Checks whether a given array of statements is a single call of `super`.
@@ -214,12 +231,32 @@ module.exports = {
     }
 
     /**
+     * Mark component as pure as declared
+     * @param {ASTNode} node The AST node being checked.
+     */
+    var markSCUAsDeclared = function (node) {
+      components.set(node, {
+        hasSCU: true
+      });
+    };
+
+    /**
      * Mark a setState as used
      * @param {ASTNode} node The AST node being checked.
      */
     function markThisAsUsed(node) {
       components.set(node, {
         useThis: true
+      });
+    }
+
+    /**
+     * Mark a props or context as used
+     * @param {ASTNode} node The AST node being checked.
+     */
+    function markPropsOrContextAsUsed(node) {
+      components.set(node, {
+        usePropsOrContext: true
       });
     }
 
@@ -244,6 +281,13 @@ module.exports = {
     }
 
     return {
+      ClassDeclaration: function (node) {
+        if (!isPureComponent(node)) {
+          return;
+        }
+        markSCUAsDeclared(node);
+      },
+
       // Mark `this` destructuring as a usage of `this`
       VariableDeclarator: function(node) {
         // Ignore destructuring on other than `this`
@@ -256,6 +300,7 @@ module.exports = {
           return name !== 'props' && name !== 'context';
         });
         if (!useThis) {
+          markPropsOrContextAsUsed(node);
           return;
         }
         markThisAsUsed(node);
@@ -264,11 +309,13 @@ module.exports = {
       // Mark `this` usage
       MemberExpression: function(node) {
         // Ignore calls to `this.props` and `this.context`
-        if (
-          node.object.type !== 'ThisExpression' ||
+        if (node.object.type !== 'ThisExpression') {
+          return;
+        } else if (
           (node.property.name || node.property.value) === 'props' ||
           (node.property.name || node.property.value) === 'context'
         ) {
+          markPropsOrContextAsUsed(node);
           return;
         }
         markThisAsUsed(node);
@@ -319,6 +366,10 @@ module.exports = {
             list[component].invalidReturn ||
             (!utils.isES5Component(list[component].node) && !utils.isES6Component(list[component].node))
           ) {
+            continue;
+          }
+
+          if (list[component].hasSCU && list[component].usePropsOrContext) {
             continue;
           }
 

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -5,7 +5,6 @@
 'use strict';
 
 var Components = require('../util/Components');
-var pragmaUtil = require('../util/pragma');
 
 module.exports = {
   meta: {
@@ -29,14 +28,10 @@ module.exports = {
     }]
   },
 
-  create: Components.detect(function (context, components) {
+  create: Components.detect(function (context, components, utils) {
     var MISSING_MESSAGE = 'Component is not optimized. Please add a shouldComponentUpdate method.';
     var configuration = context.options[0] || {};
     var allowDecorators = configuration.allowDecorators || [];
-
-    var pragma = pragmaUtil.getFromContext(context);
-    var pureComponentRegExp = new RegExp('^(' + pragma + '\\.)?PureComponent$');
-    var sourceCode = context.getSourceCode();
 
     /**
      * Checks to see if our component is decorated by PureRenderMixin via reactMixin
@@ -84,19 +79,6 @@ module.exports = {
             }
           }
         }
-      }
-
-      return false;
-    };
-
-    /**
-     * Checks to see if our component extends React.PureComponent
-     * @param {ASTNode} node The AST node being checked.
-     * @returns {Boolean} True if node extends React.PureComponent, false if not.
-     */
-    var isPureComponent = function (node) {
-      if (node.superClass) {
-        return pureComponentRegExp.test(sourceCode.getText(node.superClass));
       }
 
       return false;
@@ -186,7 +168,7 @@ module.exports = {
       },
 
       ClassDeclaration: function (node) {
-        if (!(hasPureRenderDecorator(node) || hasCustomDecorator(node) || isPureComponent(node))) {
+        if (!(hasPureRenderDecorator(node) || hasCustomDecorator(node) || utils.isPureComponent(node))) {
           return;
         }
         markSCUAsDeclared(node);

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -200,6 +200,19 @@ function componentRule(rule, context) {
     },
 
     /**
+     * Checks to see if our component extends React.PureComponent
+     *
+     * @param {ASTNode} node The AST node being checked.
+     * @returns {Boolean} True if node extends React.PureComponent, false if not
+     */
+    isPureComponent: function (node) {
+      if (node.superClass) {
+        return new RegExp('^(' + pragma + '\\.)?PureComponent$').test(sourceCode.getText(node.superClass));
+      }
+      return false;
+    },
+
+    /**
      * Check if the node is returning JSX
      *
      * @param {ASTNode} ASTnode The AST node being checked

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -39,6 +39,26 @@ ruleTester.run('prefer-stateless-function', rule, {
       code: 'const Foo = ({foo}) => <div>{foo}</div>;',
       parserOptions: parserOptions
     }, {
+      // Extends from PureComponent and uses props
+      code: [
+        'class Foo extends React.PureComponent {',
+        '  render() {',
+        '    return <div>{this.props.foo}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parserOptions: parserOptions
+    }, {
+      // Extends from PureComponent and uses context
+      code: [
+        'class Foo extends React.PureComponent {',
+        '  render() {',
+        '    return <div>{this.context.foo}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parserOptions: parserOptions
+    }, {
       // Has a lifecyle method
       code: [
         'class Foo extends React.Component {',
@@ -252,6 +272,19 @@ ruleTester.run('prefer-stateless-function', rule, {
         'class Foo extends React.Component {',
         '  render() {',
         '    return <div>{this[\'props\'].foo}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parserOptions: parserOptions,
+      errors: [{
+        message: 'Component should be written as a pure function'
+      }]
+    }, {
+      // Only extend PureComponent without use of props or context
+      code: [
+        'class Foo extends React.PureComponent {',
+        '  render() {',
+        '    return <div>foo</div>;',
         '  }',
         '}'
       ].join('\n'),

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -47,7 +47,10 @@ ruleTester.run('prefer-stateless-function', rule, {
         '  }',
         '}'
       ].join('\n'),
-      parserOptions: parserOptions
+      parserOptions: parserOptions,
+      options: [{
+        ignorePureComponents: true
+      }]
     }, {
       // Extends from PureComponent and uses context
       code: [
@@ -57,7 +60,10 @@ ruleTester.run('prefer-stateless-function', rule, {
         '  }',
         '}'
       ].join('\n'),
-      parserOptions: parserOptions
+      parserOptions: parserOptions,
+      options: [{
+        ignorePureComponents: true
+      }]
     }, {
       // Has a lifecyle method
       code: [
@@ -285,6 +291,22 @@ ruleTester.run('prefer-stateless-function', rule, {
         'class Foo extends React.PureComponent {',
         '  render() {',
         '    return <div>foo</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parserOptions: parserOptions,
+      options: [{
+        ignorePureComponents: true
+      }],
+      errors: [{
+        message: 'Component should be written as a pure function'
+      }]
+    }, {
+      // Extends from PureComponent but no ignorePureComponents option
+      code: [
+        'class Foo extends React.PureComponent {',
+        '  render() {',
+        '    return <div>{this.props.foo}</div>;',
         '  }',
         '}'
       ].join('\n'),


### PR DESCRIPTION
prefer-stateless-function should not return a warning when the user uses `PureComponent` to opt in for free optimisations with `shouldComponentUpdate` and is using props or context. 

Current false positive: 

```{js}
class Foo extends React.PureComponent {
  render() {
    return <div>{this.props.foo}</div>;
  }
}
```

I first only added the same `isPureComponent` check as [require-optimization](https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/require-optimization.js#L92) does. But realized that components that are extending form PureComponent but don't use `this.props` or `this.context` should be written as a pure function as well. So I had to change the existing checks a bit to check that too. 

Yeah I know, I could have first reacted to the discussion at #777, but I thought it would be cool to find out how all the 'rules' in eslint work by trying to fix this issue. Hope you agree about the false positive. I think this case is different from #777 because that case it not using props or context at all.

Please correct any formatting fails, first contribution here.


