### PR TITLE
jsx-wrap-multilines check arrow functions without block body

### DIFF
--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -1,6 +1,6 @@
 # Prevent missing parentheses around multiline JSX (jsx-wrap-multilines)
 
-Wrapping multiline JSX in parentheses can improve readability and/or convenience. It optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, `"declaration"`, `"assignment"`, and `"return"` syntax is checked, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior (become enabled).
+Wrapping multiline JSX in parentheses can improve readability and/or convenience. It optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, `"declaration"`, `"assignment"`, `"return"`, and `"arrow"` syntax is checked, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior (become enabled).
 
 **Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
@@ -41,6 +41,11 @@ hello = <div>
 
 // When [1, {declaration: true, assignment: false, return: true}]
 var world = <div>
+  <p>World</p>
+</div>
+
+// When [1, {arrow: false}]
+var hello = () => <div>
   <p>World</p>
 </div>
 ```

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -11,7 +11,8 @@
 var DEFAULTS = {
   declaration: true,
   assignment: true,
-  return: true
+  return: true,
+  arrow: true
 };
 
 // ------------------------------------------------------------------------------
@@ -37,6 +38,9 @@ module.exports = {
           type: 'boolean'
         },
         return: {
+          type: 'boolean'
+        },
+        arrow: {
           type: 'boolean'
         }
       },
@@ -106,6 +110,14 @@ module.exports = {
       ReturnStatement: function(node) {
         if (isEnabled('return')) {
           check(node.argument);
+        }
+      },
+
+      'ArrowFunctionExpression:exit': function (node) {
+        var arrowBody = node.body;
+
+        if (isEnabled('arrow') && arrowBody.type !== 'BlockStatement') {
+          check(arrowBody);
         }
       }
     };

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -73,6 +73,18 @@ var ASSIGNMENT_NO_PAREN = '\
     <p>Hello</p>\n\
   </div>;';
 
+var ARROW_SINGLE_LINE = 'var hello = () => <p>Hello</p>;';
+
+var ARROW_PAREN = '\
+  var hello = () => (<div>\n\
+    <p>Hello</p>\n\
+  </div>);';
+
+var ARROW_NO_PAREN = '\
+  var hello = () => <div>\n\
+    <p>Hello</p>\n\
+  </div>;';
+
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -112,6 +124,18 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: ASSIGNMENT_NO_PAREN,
       options: [{assignment: false}],
       parserOptions: parserOptions
+    }, {
+      code: ARROW_PAREN,
+      options: [],
+      parserOptions: parserOptions
+    }, {
+      code: ARROW_SINGLE_LINE,
+      options: [],
+      parserOptions: parserOptions
+    }, {
+      code: ARROW_NO_PAREN,
+      options: [{arrow: false}],
+      parserOptions: parserOptions
     }
   ],
 
@@ -148,6 +172,12 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       output: ASSIGNMENT_PAREN,
       parserOptions: parserOptions,
       options: [{assignment: true}],
+      errors: [{message: 'Missing parentheses around multilines JSX'}]
+    }, {
+      code: ARROW_NO_PAREN,
+      output: ARROW_PAREN,
+      parserOptions: parserOptions,
+      options: [{arrow: true}],
       errors: [{message: 'Missing parentheses around multilines JSX'}]
     }
   ]


### PR DESCRIPTION
Aka "lambdas"

Close #790

I will duplicate issue desc here:

Given this code, check should not pass

```jsx
const Grade = ({ grade }) =>
  <View style={styles.gradeContainer}>
    <Text style={styles.grade}>{grade}</Text>
  </View>;
```

For this code, check should pass:

```jsx
const Grade = ({ grade }) => (
  <View style={styles.gradeContainer}>
    <Text style={styles.grade}>{grade}</Text>
  </View>
);
```

I leaved this behaviour by-default, but it can break backward compatibility?

May be It should be turned off by default?
