### PR TITLE
Fixes a few false positive failures in the `no-unused-prop-types` rule

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -175,6 +175,53 @@ module.exports = {
     }
 
     /**
+     * Returns true if the given node is a React Component lifecycle method
+     * @param {ASTNode} node The AST node being checked.
+     * @return {Boolean} True if the node is a lifecycle method
+     */
+    function isNodeALifeCycleMethod(node) {
+      var nodeKeyName = (node.key || {}).name;
+      return (
+        node.kind === 'constructor' ||
+        nodeKeyName === 'componentWillReceiveProps' ||
+        nodeKeyName === 'shouldComponentUpdate' ||
+        nodeKeyName === 'componentWillUpdate' ||
+        nodeKeyName === 'componentDidUpdate'
+      );
+    }
+
+    /**
+     * Returns true if the given node is inside a React Component lifecycle
+     * method.
+     * @param {ASTNode} node The AST node being checked.
+     * @return {Boolean} True if the node is inside a lifecycle method
+     */
+    function isInLifeCycleMethod(node) {
+      if (node.type === 'MethodDefinition' && isNodeALifeCycleMethod(node)) {
+        return true;
+      }
+
+      if (node.parent) {
+        return isInLifeCycleMethod(node.parent);
+      }
+
+      return false;
+    }
+
+    /**
+     * Checks if a prop init name matches common naming patterns
+     * @param {ASTNode} node The AST node being checked.
+     * @returns {Boolean} True if the prop name matches
+     */
+    function isPropAttributeName (node) {
+      return (
+        node.init.name === 'props' ||
+        node.init.name === 'nextProps' ||
+        node.init.name === 'prevProps'
+      );
+    }
+
+    /**
      * Checks if a prop is used
      * @param {ASTNode} node The AST node being checked.
      * @param {Object} prop Declared prop object
@@ -536,11 +583,14 @@ module.exports = {
               node.id.properties[i].value.type === 'ObjectPattern'
             );
             // let {firstname} = props
-            var statelessDestructuring = node.init.name === 'props' && utils.getParentStatelessComponent();
+            var genericDestructuring = isPropAttributeName(node) && (
+                utils.getParentStatelessComponent() ||
+                isInLifeCycleMethod(node)
+            );
 
             if (thisDestructuring) {
               properties = node.id.properties[i].value.properties;
-            } else if (statelessDestructuring) {
+            } else if (genericDestructuring) {
               properties = node.id.properties;
             } else {
               continue;
@@ -776,7 +826,10 @@ module.exports = {
         // let {props: {firstname}} = this
         var thisDestructuring = destructuring && node.init.type === 'ThisExpression';
         // let {firstname} = props
-        var statelessDestructuring = destructuring && node.init.name === 'props' && utils.getParentStatelessComponent();
+        var statelessDestructuring = destructuring && isPropAttributeName(node) && (
+            utils.getParentStatelessComponent() ||
+            isInLifeCycleMethod(node)
+        );
 
         if (!thisDestructuring && !statelessDestructuring) {
           return;
@@ -828,6 +881,18 @@ module.exports = {
 
         if (i >= 0) {
           markPropTypesAsDeclared(node, node.value.body.body[i].argument);
+        }
+      },
+
+      ObjectPattern: function(node) {
+        // If the object pattern is a destructured props object in a lifecycle
+        // method -- mark it for used props.
+        if (isNodeALifeCycleMethod(node.parent.parent)) {
+          node.properties.forEach(function(property, i) {
+            if (i === 0) {
+              markPropTypesAsUsed(node.parent);
+            }
+          });
         }
       },
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1208,6 +1208,180 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       options: [{skipShapeProps: true}],
       parser: 'babel-eslint'
+    }, {
+      // Destructured props in componentWillReceiveProps shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentWillReceiveProps (nextProps) {',
+        '    const {something} = nextProps;',
+        '    doSomething(something);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      // Destructured function props in componentWillReceiveProps shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentWillReceiveProps ({something}) {',
+        '    doSomething(something);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      // Destructured props in the constructor shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  constructor (props) {',
+        '    super(props);',
+        '    const {something} = props;',
+        '    doSomething(something);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured function props in the constructor shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  constructor ({something}) {',
+        '    super({something});',
+        '    doSomething(something);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured props in the `componentWillReceiveProps` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentWillReceiveProps (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured function props in the `componentWillReceiveProps` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentWillReceiveProps ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured props in the `shouldComponentUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  shouldComponentUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured function props in the `shouldComponentUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  shouldComponentUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured props in the `componentWillUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentWillUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured function props in the `componentWillUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentWillUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured props in the `componentDidUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentDidUpdate (prevProps, nextState) {',
+        '    const {something} = prevProps;',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // Destructured function props in the `componentDidUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentDidUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
     }
   ],
 
@@ -1975,6 +2149,193 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint',
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  constructor (props) {',
+        '    super(props);',
+        '    const {something} = props;',
+        '    doSomething(something);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  constructor ({something}) {',
+        '    super({something});',
+        '    doSomething(something);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  componentWillReceiveProps (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  componentWillReceiveProps ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  shouldComponentUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  shouldComponentUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  componentWillUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  componentWillUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  componentDidUpdate (prevProps, prevState) {',
+        '    const {something} = prevProps;',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  componentDidUpdate ({something}, prevState) {',
+        '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
       }]
     }/* , {
       // Enable this when the following issue is fixed


### PR DESCRIPTION
Fixes several false positives failures in the `no-unused-prop-types` rules:

- Ensures destructured props in component lifecycle methods are properly counted towards used props 
- Ensure common `nextProps` and `prevProps` property names in lifecycle methods are correctly counted towards used props
- Fixes https://github.com/yannickcr/eslint-plugin-react/issues/801