### PR TITLE
jsx-no-target-blank: Target only anchor elements

### DIFF
--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -21,6 +21,10 @@ module.exports = {
   create: function(context) {
     return {
       JSXAttribute: function(node) {
+        if (node.parent.name.name !== 'a') {
+          return;
+        }
+
         if (node.name.name === 'target' && node.value.value === '_blank') {
           var relFound = false;
           var attrs = node.parent.attributes;

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -29,7 +29,8 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {code: '<a randomTag></a>', parserOptions: parserOptions},
     {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>', parserOptions: parserOptions},
     {code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>', parserOptions: parserOptions},
-    {code: '<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>', parserOptions: parserOptions}
+    {code: '<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>', parserOptions: parserOptions},
+    {code: '<p target="_blank"></p>', parserOptions: parserOptions}
   ],
   invalid: [
     {code: '<a target="_blank"></a>', parserOptions: parserOptions,


### PR DESCRIPTION
This pull request seeks to resolve lint errors which are raised when the `jsx-no-target-blank` rule is enabled when `target="_blank"` is applied to anything other than an anchor element. The [documentation for this rule](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) clearly states that `<p target="_blank"></p>` is not considered an error, but adding this missing test case reveals that the rule applies to all elements.

We observed this in https://github.com/Automattic/wp-calypso/pull/7680 where we have custom components which handle the incoming `target` prop and apply the `rel` as necessary through custom render logic.