### PR TITLE
Case insensitive comparisons for no-target-blank

### DIFF
--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -25,12 +25,12 @@ module.exports = {
           return;
         }
 
-        if (node.name.name === 'target' && node.value.value === '_blank') {
+        if (node.name.name === 'target' && node.value.value.toLowerCase() === '_blank') {
           var relFound = false;
           var attrs = node.parent.attributes;
           for (var idx in attrs) {
             if (attrs[idx].name && attrs[idx].name.name === 'rel') {
-              var tags = attrs[idx].value.value.split(' ');
+              var tags = attrs[idx].value.value.toLowerCase().split(' ');
               if (tags.indexOf('noopener') >= 0 && tags.indexOf('noreferrer') >= 0) {
                 relFound = true;
                 break;

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -30,7 +30,8 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>', parserOptions: parserOptions},
     {code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>', parserOptions: parserOptions},
     {code: '<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>', parserOptions: parserOptions},
-    {code: '<p target="_blank"></p>', parserOptions: parserOptions}
+    {code: '<p target="_blank"></p>', parserOptions: parserOptions},
+    {code: '<a href="foobar" target="_BLANK" rel="NOOPENER noreferrer"></a>', parserOptions: parserOptions}
   ],
   invalid: [
     {code: '<a target="_blank"></a>', parserOptions: parserOptions,
@@ -40,6 +41,9 @@ ruleTester.run('jsx-no-target-blank', rule, {
      errors: [{message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'}]},
     {code: '<a target="_blank" rel="noopenernoreferrer"></a>', parserOptions: parserOptions,
+     errors: [{message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      ' see https://mathiasbynens.github.io/rel-noopener'}]},
+    {code: '<a target="_BLANK"></a>', parserOptions: parserOptions,
      errors: [{message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'}]}
   ]


### PR DESCRIPTION
`<a href="foo" target="_BLANK">` should also trigger no-target-blank.
Now it does.