### PR TITLE
Add default for jsx-first-prop-new-line

### DIFF
--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -10,7 +10,7 @@ This rule checks whether the first property of all JSX elements is correctly pla
 * `always`: The first property should always be placed on a new line.
 * `never` : The first property should never be placed on a new line, e.g. should always be on the same line as the Component opening tag.
 * `multiline`: The first property should always be placed on a new line when the JSX tag takes up multiple lines.
-* `multiline-multiprop`: The first property should always be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties.
+* `multiline-multiprop`: The first property should always be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties. `default`
 
 The following patterns are considered warnings when configured `"always"`:
 

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -23,7 +23,7 @@ module.exports = {
   },
 
   create: function (context) {
-    var configuration = context.options[0];
+    var configuration = context.options[0] || 'multiline-multiprop';
 
     function isMultilineJSX(jsxNode) {
       return jsxNode.loc.start.line < jsxNode.loc.end.line;


### PR DESCRIPTION
Right now just enabling the rule does nothing, you actually have to pass in a value. 
This seems very counterintuitive to me.

If you feel the default should be something else I'm fine with whatever.
