### PR TITLE
Add JSXExpressionContainer support for jsx-indent rule

### DIFF
--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -176,6 +176,13 @@ module.exports = {
         }
         var peerElementIndent = getNodeIndent(node.parent.openingElement);
         checkNodesIndent(node, peerElementIndent);
+      },
+      JSXExpressionContainer: function(node) {
+        if (!node.parent) {
+          return;
+        }
+        var parentNodeIndent = getNodeIndent(node.parent);
+        checkNodesIndent(node, parentNodeIndent + indentSize);
       }
     };
 

--- a/tests/lib/rules/jsx-indent.js
+++ b/tests/lib/rules/jsx-indent.js
@@ -162,5 +162,29 @@ ruleTester.run('jsx-indent', rule, {
     options: [2],
     parserOptions: parserOptions,
     errors: [{message: 'Expected indentation of 4 space characters but found 0.'}]
+  }, {
+    code: [
+      '<App>',
+      '   {test}',
+      '</App>'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [
+      {message: 'Expected indentation of 4 space characters but found 3.'}
+    ]
+  }, {
+    code: [
+      '<App>',
+      '    {options.map((option, index) => (',
+      '        <option key={index} value={option.key}>',
+      '           {option.name}',
+      '        </option>',
+      '    ))}',
+      '</App>'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [
+      {message: 'Expected indentation of 12 space characters but found 11.'}
+    ]
   }]
 });

--- a/tests/lib/rules/jsx-indent.js
+++ b/tests/lib/rules/jsx-indent.js
@@ -186,5 +186,32 @@ ruleTester.run('jsx-indent', rule, {
     errors: [
       {message: 'Expected indentation of 12 space characters but found 11.'}
     ]
+  }, {
+    code: [
+      '<App>',
+      '{test}',
+      '</App>'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: ['tab'],
+    errors: [
+      {message: 'Expected indentation of 1 tab character but found 0.'}
+    ]
+  }, {
+    code: [
+      '<App>',
+      '\t{options.map((option, index) => (',
+      '\t\t<option key={index} value={option.key}>',
+      '\t\t{option.name}',
+      '\t\t</option>',
+      '\t))}',
+      '</App>'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: ['tab'],
+    errors: [
+      {message: 'Expected indentation of 3 tab characters but found 2.'}
+    ]
   }]
 });
+


### PR DESCRIPTION
Right now jsx-indent linter won't catch cases like:
```
<App>
   {test}
</App>
```
This diff will add support for JSXExpressionContainer