### PR TITLE
Handle `undefined` tag

### DIFF
--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -48,7 +48,7 @@ module.exports = {
     return {
       JSXAttribute: function(node) {
         var tag = node.parent.name.name;
-        if (tag[0] !== tag[0].toUpperCase()) {
+        if (tag && tag[0] !== tag[0].toUpperCase()) {
           // This is a DOM node, not a Component, so exit.
           return;
         }


### PR DESCRIPTION
I have observed this error:

```
Cannot read property '0' of undefined
TypeError: Cannot read property '0' of undefined
    at EventEmitter.JSXAttribute (/Users/patrick/sigopt-api/node_modules/eslint-plugin-react/lib/rules/forbid-component-props.js:51:16)
    at emitOne (events.js:101:20)
    at EventEmitter.emit (events.js:188:7)
    at NodeEventGenerator.enterNode (/Users/patrick/sigopt-api/node_modules/eslint/lib/util/node-event-generator.js:40:22)
    at CodePathAnalyzer.enterNode (/Users/patrick/sigopt-api/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:608:23)
    at CommentEventGenerator.enterNode (/Users/patrick/sigopt-api/node_modules/eslint/lib/util/comment-event-generator.js:97:23)
    at Controller.enter (/Users/patrick/sigopt-api/node_modules/eslint/lib/eslint.js:918:36)
    at Controller.__execute (/Users/patrick/sigopt-api/node_modules/eslint/node_modules/estraverse/estraverse.js:397:31)
    at Controller.traverse (/Users/patrick/sigopt-api/node_modules/eslint/node_modules/estraverse/estraverse.js:501:28)
    at Controller.Traverser.contMakefile:37: recipe for target 'eslint' failed
```