### PR TITLE
Allow skipping prop-types validation when not declared

### DIFF
--- a/docs/rules/prop-types.md
+++ b/docs/rules/prop-types.md
@@ -109,6 +109,7 @@ This rule can take one argument to ignore some specific props during validation.
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
 * `ignore`: optional array of props name to ignore during validation.
 * `customValidators`: optional array of validators used for propTypes validation.
+* `skipUndeclared`: only error on components that have a propTypes block declared
 
 ### As for "exceptions"
 

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -42,6 +42,9 @@ module.exports = {
           items: {
             type: 'string'
           }
+        },
+        skipUndeclared: {
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -54,6 +57,7 @@ module.exports = {
     var configuration = context.options[0] || {};
     var ignored = configuration.ignore || [];
     var customValidators = configuration.customValidators || [];
+    var skipUndeclared = configuration.skipUndeclared || false;
     // Used to track the type annotations in scope.
     // Necessary because babel's scopes do not track type annotations.
     var stack = null;
@@ -134,7 +138,6 @@ module.exports = {
      * @returns {Boolean} True if we are declaring a prop, false if not.
      */
     function isPropTypesDeclaration(node) {
-
       // Special case for class properties
       // (babel-eslint does not expose property name so we have to rely on tokens)
       if (node && node.type === 'ClassProperty') {
@@ -179,10 +182,12 @@ module.exports = {
      * @returns {Boolean} True if the component must be validated, false if not.
      */
     function mustBeValidated(component) {
+      var isSkippedByConfig = (typeof component.declaredPropTypes === 'undefined' && skipUndeclared);
       return Boolean(
         component &&
         component.usedPropTypes &&
-        !component.ignorePropsValidation
+        !component.ignorePropsValidation &&
+        !isSkippedByConfig
       );
     }
 

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -182,7 +182,7 @@ module.exports = {
      * @returns {Boolean} True if the component must be validated, false if not.
      */
     function mustBeValidated(component) {
-      var isSkippedByConfig = (typeof component.declaredPropTypes === 'undefined' && skipUndeclared);
+      var isSkippedByConfig = skipUndeclared && typeof component.declaredPropTypes === 'undefined';
       return Boolean(
         component &&
         component.usedPropTypes &&

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1305,6 +1305,42 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  render: function() {',
+        '    return <div>{this.props.name}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      options: [{skipUndeclared: true}],
+      parserOptions: parserOptions
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  propTypes: {',
+        '    name: React.PropTypes.object.isRequired',
+        '  },',
+        '  render: function() {',
+        '    return <div>{this.props.name}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      options: [{skipUndeclared: true}],
+      parserOptions: parserOptions
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  propTypes: {',
+        '    name: React.PropTypes.object.isRequired',
+        '  },',
+        '  render: function() {',
+        '    return <div>{this.props.name}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      options: [{skipUndeclared: false}],
+      parserOptions: parserOptions
     }
   ],
 
@@ -2311,6 +2347,37 @@ ruleTester.run('prop-types', rule, {
         line: 4,
         column: 27,
         type: 'Property'
+      }]
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  propTypes: {},',
+        '  render: function() {',
+        '    return <div>{this.props.firstname}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      options: [{skipUndeclared: true}],
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'firstname\' is missing in props validation',
+        line: 4,
+        column: 29
+      }]
+    }, {
+      code: [
+        'var Hello = React.createClass({',
+        '  render: function() {',
+        '    return <div>{this.props.firstname}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      options: [{skipUndeclared: false}],
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'firstname\' is missing in props validation',
+        line: 3,
+        column: 29
       }]
     }
   ]

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -2418,6 +2418,22 @@ ruleTester.run('prop-types', rule, {
       }]
     }, {
       code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    return <div>{this.props.firstname}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {};'
+      ].join('\n'),
+      options: [{skipUndeclared: true}],
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'firstname\' is missing in props validation',
+        line: 3,
+        column: 29
+      }]
+    }, {
+      code: [
         'var Hello = React.createClass({',
         '  render: function() {',
         '    return <div>{this.props.firstname}</div>;',

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1318,6 +1318,26 @@ ruleTester.run('prop-types', rule, {
     }, {
       code: [
         'var Hello = React.createClass({',
+        '  render: function() {',
+        '    return <div>{this.props.name}</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      options: [{skipUndeclared: true}],
+      parserOptions: parserOptions
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    return <div>{this.props.name}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      options: [{skipUndeclared: true}],
+      parserOptions: parserOptions
+    }, {
+      code: [
+        'var Hello = React.createClass({',
         '  propTypes: {',
         '    name: React.PropTypes.object.isRequired',
         '  },',
@@ -2362,6 +2382,38 @@ ruleTester.run('prop-types', rule, {
       errors: [{
         message: '\'firstname\' is missing in props validation',
         line: 4,
+        column: 29
+      }]
+    }, {
+      code: [
+        'var Hello = function(props) {',
+        '  return <div>{props.firstname}</div>;',
+        '};',
+        'Hello.propTypes = {}'
+      ].join('\n'),
+      options: [{skipUndeclared: true}],
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'firstname\' is missing in props validation',
+        line: 2,
+        column: 22
+      }]
+    }, {
+      code: [
+        'class Hello extends React.Component {',
+        '  static get propTypes() {',
+        '    return {};',
+        '  }',
+        '  render() {',
+        '    return <div>{this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      options: [{skipUndeclared: true}],
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'firstname\' is missing in props validation',
+        line: 6,
         column: 29
       }]
     }, {


### PR DESCRIPTION
Adding the `prop-types` rule can be a daunting task for
projects that have not been consistent about using prop
types to begin with.

This allows users to slowly opt-in to prop-types validation
by only erroring on "incomplete" propTypes declarations.