### PR TITLE
Handle spread props in no-children-prop rule

### DIFF
--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -54,7 +54,7 @@ module.exports = {
 
         var props = node.arguments[1].properties;
         var childrenProp = props.find(function(prop) {
-          return prop.key.name === 'children';
+          return prop.key && prop.key.name === 'children';
         });
 
         if (childrenProp) {

--- a/tests/lib/rules/no-children-prop.js
+++ b/tests/lib/rules/no-children-prop.js
@@ -15,6 +15,7 @@ var RuleTester = require('eslint').RuleTester;
 var parserOptions = {
   ecmaVersion: 6,
   ecmaFeatures: {
+    experimentalObjectRestSpread: true,
     jsx: true
   }
 };
@@ -170,6 +171,14 @@ ruleTester.run('no-children-prop', rule, {
     {
       code: 'React.createElement(MyComponent, {className: "class-name"}, "Children");',
       parserOptions: parserOptions
+    },
+    {
+      code: '<MyComponent className="class-name" {...props} />;',
+      parserOptions: parserOptions
+    },
+    {
+      code: 'React.createElement(MyComponent, {className: "class-name", ...props});',
+      parserOptions: parserOptions
     }
   ],
   invalid: [
@@ -230,6 +239,16 @@ ruleTester.run('no-children-prop', rule, {
     },
     {
       code: 'React.createElement(MyComponent, {children: "Children", className: "class-name"});',
+      errors: [{message: CREATE_ELEMENT_ERROR}],
+      parserOptions: parserOptions
+    },
+    {
+      code: '<MyComponent {...props} children="Children" />;',
+      errors: [{message: JSX_ERROR}],
+      parserOptions: parserOptions
+    },
+    {
+      code: 'React.createElement(MyComponent, {...props, children: "Children"})',
       errors: [{message: CREATE_ELEMENT_ERROR}],
       parserOptions: parserOptions
     }


### PR DESCRIPTION
Nodes of type `ExperimentalSpreadProperty` don’t have a `key` property, causing the `no-children-prop` to raise a “Cannot read property ‘name’ of undefined” error.

Code such as:

```
return React.createElement(
  elementType,
  { className: classNames, ...otherProps },
  children
)
```

will trigger the error.