### PR TITLE
Add ES6 import example to "jsx in scope" docs

### DIFF
--- a/docs/rules/react-in-jsx-scope.md
+++ b/docs/rules/react-in-jsx-scope.md
@@ -23,6 +23,12 @@ var Hello = <div>Hello {this.props.name}</div>;
 The following patterns are not considered warnings:
 
 ```js
+import React from 'react';
+
+var Hello = <div>Hello {this.props.name}</div>;
+```
+
+```js
 var React = require('react');
 
 var Hello = <div>Hello {this.props.name}</div>;


### PR DESCRIPTION
This way beginners using ES6 today won’t be confused about using something called "require" which they might be seeing for the first time.