### PR TITLE
jsx-first-prop-new-line: add multiline-multiprop option

### DIFF
--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -7,7 +7,8 @@ Ensure correct position of the first property.
 This rule checks whether the first property of all JSX elements is correctly placed. There are three possible configurations:
 * `always`: The first property should always be placed on a new line.
 * `never` : The first property should never be placed on a new line, e.g. should always be on the same line as the Component opening tag.
-* `multiline`: The first property should always be placed on a new line when the properties are spread over multiple lines.
+* `multiline`: The first property should always be placed on a new line when the JSX tag takes up multiple lines.
+* `multiline-multiprop`: The first property should always be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties.
 
 The following patterns are considered warnings when configured `"always"`:
 
@@ -58,6 +59,11 @@ The following patterns are considered warnings when configured `"multiline"`:
     prop />
 ```
 
+```jsx
+<Hello foo={{
+}} />
+```
+
 The following patterns are not considered warnings when configured `"multiline"`:
 
 ```js
@@ -66,6 +72,27 @@ The following patterns are not considered warnings when configured `"multiline"`
 <Hello
     personal={true}
     foo="bar"
+/>
+```
+
+The following patterns are considered warnings when configured `"multiline-multiprop"`:
+
+```jsx
+<Hello foo={{
+    }}
+    bar />
+```
+
+The following patterns are not considered warnings when configured `"multiline-multiprop"`:
+
+```jsx
+<Hello foo={{
+}} />
+
+<Hello
+    foo={{
+    }}
+    bar
 />
 ```
 

--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -12,7 +12,7 @@ This rule checks whether the first property of all JSX elements is correctly pla
 
 The following patterns are considered warnings when configured `"always"`:
 
-```js
+```jsx
 <Hello personal={true} />
 
 <Hello personal={true}
@@ -22,7 +22,7 @@ The following patterns are considered warnings when configured `"always"`:
 
 The following patterns are not considered warnings when configured `"always"`:
 
-```js
+```jsx
 <Hello
     personal />
 
@@ -33,7 +33,7 @@ The following patterns are not considered warnings when configured `"always"`:
 
 The following patterns are considered warnings when configured `"never"`:
 
-```js
+```jsx
 <Hello
     personal />
 
@@ -44,7 +44,7 @@ The following patterns are considered warnings when configured `"never"`:
 
 The following patterns are not considered warnings when configured `"never"`:
 
-```js
+```jsx
 <Hello personal={true} />
 
 <Hello personal={true}
@@ -54,7 +54,7 @@ The following patterns are not considered warnings when configured `"never"`:
 
 The following patterns are considered warnings when configured `"multiline"`:
 
-```js
+```jsx
 <Hello personal
     prop />
 ```
@@ -66,7 +66,7 @@ The following patterns are considered warnings when configured `"multiline"`:
 
 The following patterns are not considered warnings when configured `"multiline"`:
 
-```js
+```jsx
 <Hello personal={true} />
 
 <Hello

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -17,7 +17,7 @@ module.exports = {
     },
 
     schema: [{
-      enum: ['always', 'never', 'multiline']
+      enum: ['always', 'never', 'multiline', 'multiline-multiprop']
     }]
   },
 
@@ -30,7 +30,11 @@ module.exports = {
 
     return {
       JSXOpeningElement: function (node) {
-        if ((configuration === 'multiline' && isMultilineJSX(node)) || (configuration === 'always')) {
+        if (
+          (configuration === 'multiline' && isMultilineJSX(node)) ||
+          (configuration === 'multiline-multiprop' && isMultilineJSX(node) && node.attributes.length > 1) ||
+          (configuration === 'always')
+        ) {
           node.attributes.forEach(function(decl) {
             if (decl.loc.start.line === node.loc.start.line) {
               context.report({

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -91,6 +91,39 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       parser: parserOptions
     },
     {
+      code: [
+        '<Foo bar />'
+      ].join('\n'),
+      options: ['multiline-multiprop'],
+      parser: parserOptions
+    },
+    {
+      code: [
+        '<Foo bar baz />'
+      ].join('\n'),
+      options: ['multiline-multiprop'],
+      parser: parserOptions
+    },
+    {
+      code: [
+        '<Foo prop={{',
+        '}} />'
+      ].join('\n'),
+      options: ['multiline-multiprop'],
+      parser: parserOptions
+    },
+    {
+      code: [
+        '<Foo ',
+        '  foo={{',
+        '  }}',
+        '  bar',
+        '/>'
+      ].join('\n'),
+      options: ['multiline-multiprop'],
+      parser: parserOptions
+    },
+    {
       code: '<Foo />',
       options: ['always'],
       parser: parserOptions
@@ -143,6 +176,24 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       ].join('\n'),
       options: ['never'],
       errors: [{message: 'Property should be placed on the same line as the component declaration'}],
+      parser: parserOptions
+    },
+    {
+      code: [
+        '<Foo prop={{',
+        '}} />'
+      ].join('\n'),
+      options: ['multiline'],
+      errors: [{message: 'Property should be placed on a new line'}],
+      parser: parserOptions
+    },
+    {
+      code: [
+        '<Foo bar={{',
+        '}} baz />'
+      ].join('\n'),
+      options: ['multiline-multiprop'],
+      errors: [{message: 'Property should be placed on a new line'}],
       parser: parserOptions
     }
   ]


### PR DESCRIPTION
addresses another part of https://github.com/yannickcr/eslint-plugin-react/issues/878
