### PR TITLE
jsx-first-prop-new-line: autofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Finally, enable all of the rules that you would like to use.  Use [our preset](#
 * [react/jsx-curly-spacing](docs/rules/jsx-curly-spacing.md): Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
 * [react/jsx-equals-spacing](docs/rules/jsx-equals-spacing.md): Enforce or disallow spaces around equal signs in JSX attributes (fixable)
 * [react/jsx-filename-extension](docs/rules/jsx-filename-extension.md): Restrict file extensions that may contain JSX
-* [react/jsx-first-prop-new-line](docs/rules/jsx-first-prop-new-line.md): Enforce position of the first prop in JSX
+* [react/jsx-first-prop-new-line](docs/rules/jsx-first-prop-new-line.md): Enforce position of the first prop in JSX (fixable)
 * [react/jsx-handler-names](docs/rules/jsx-handler-names.md): Enforce event handler naming conventions in JSX
 * [react/jsx-indent](docs/rules/jsx-indent.md): Validate JSX indentation
 * [react/jsx-indent-props](docs/rules/jsx-indent-props.md): Validate props indentation in JSX (fixable)

--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -2,6 +2,8 @@
 
 Ensure correct position of the first property.
 
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+
 ## Rule Details
 
 This rule checks whether the first property of all JSX elements is correctly placed. There are three possible configurations:
@@ -9,6 +11,12 @@ This rule checks whether the first property of all JSX elements is correctly pla
 * `never` : The first property should never be placed on a new line, e.g. should always be on the same line as the Component opening tag.
 * `multiline`: The first property should always be placed on a new line when the JSX tag takes up multiple lines.
 * `multiline-multiprop`: The first property should always be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties.
+
+In order to utilise autofix, please specify the indentation style as an additional argument in your configuration:
+
+```json
+"jsx-first-prop-new-line": ["always", 2]
+```
 
 The following patterns are considered warnings when configured `"always"`:
 

--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -2,7 +2,7 @@
 
 Ensure correct position of the first property.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line. However, fix does not include indentation. Please rerun lint to correct those errors.
 
 ## Rule Details
 
@@ -11,12 +11,6 @@ This rule checks whether the first property of all JSX elements is correctly pla
 * `never` : The first property should never be placed on a new line, e.g. should always be on the same line as the Component opening tag.
 * `multiline`: The first property should always be placed on a new line when the JSX tag takes up multiple lines.
 * `multiline-multiprop`: The first property should always be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties.
-
-In order to utilise autofix, please specify the indentation style as an additional argument in your configuration:
-
-```json
-"jsx-first-prop-new-line": ["always", 2]
-```
 
 The following patterns are considered warnings when configured `"always"`:
 

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -36,7 +36,7 @@ module.exports = {
           (configuration === 'multiline-multiprop' && isMultilineJSX(node) && node.attributes.length > 1) ||
           (configuration === 'always')
         ) {
-          node.attributes.forEach(function(decl) {
+          node.attributes.some(function(decl) {
             if (decl.loc.start.line === node.loc.start.line) {
               context.report({
                 node: decl,
@@ -46,6 +46,7 @@ module.exports = {
                 }
               });
             }
+            return true;
           });
         } else if (configuration === 'never' && node.attributes.length > 0) {
           var firstNode = node.attributes[0];

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -15,6 +15,7 @@ module.exports = {
       category: 'Stylistic Issues',
       recommended: false
     },
+    fixable: 'code',
 
     schema: [{
       enum: ['always', 'never', 'multiline', 'multiline-multiprop']
@@ -39,7 +40,10 @@ module.exports = {
             if (decl.loc.start.line === node.loc.start.line) {
               context.report({
                 node: decl,
-                message: 'Property should be placed on a new line'
+                message: 'Property should be placed on a new line',
+                fix: function(fixer) {
+                  return fixer.insertTextAfter(node.name, '\n');
+                }
               });
             }
           });
@@ -48,7 +52,10 @@ module.exports = {
           if (node.loc.start.line < firstNode.loc.start.line) {
             context.report({
               node: firstNode,
-              message: 'Property should be placed on the same line as the component declaration'
+              message: 'Property should be placed on the same line as the component declaration',
+              fix: function(fixer) {
+                return fixer.replaceTextRange([node.name.end, firstNode.start], ' ');
+              }
             });
             return;
           }

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -25,7 +25,6 @@ module.exports = {
 
   create: function (context) {
     var configuration = context.options[0];
-    var extraColumnStart = 0;
     var indentType = 'space';
     var indentSize = 2;
     var sourceCode = context.getSourceCode();
@@ -40,27 +39,14 @@ module.exports = {
       }
     }
 
-    function getNodeIndent(node, byLastLine, excludeCommas) {
-      byLastLine = byLastLine || false;
-      excludeCommas = excludeCommas || false;
-
-      var src = sourceCode.getText(node, node.loc.start.column + extraColumnStart);
-      var lines = src.split('\n');
-      if (byLastLine) {
-        src = lines[lines.length - 1];
-      } else {
-        src = lines[0];
-      }
-
-      var skip = excludeCommas ? ',' : '';
-
+    function getNodeIndent(node) {
+      var src = sourceCode.getText(node, node.loc.start.column).split('\n')[0];
       var regExp;
       if (indentType === 'space') {
-        regExp = new RegExp('^[ ' + skip + ']+');
+        regExp = new RegExp('^[ ]+');
       } else {
-        regExp = new RegExp('^[\t' + skip + ']+');
+        regExp = new RegExp('^[\t' + ']+');
       }
-
       var indent = regExp.exec(src);
       return indent ? indent[0].length : 0;
     }
@@ -82,8 +68,7 @@ module.exports = {
                 node: decl,
                 message: 'Property should be placed on a new line',
                 fix: function(fixer) {
-                  var nodeIndent = getNodeIndent(node, false, false);
-                  var neededIndent = nodeIndent + indentSize;
+                  var neededIndent = getNodeIndent(node) + indentSize;
                   var insert = '\n' + Array(neededIndent + 1).join(indentType === 'space' ? ' ' : '\t');
                   return fixer.replaceTextRange([node.name.end, decl.start], insert);
                 }

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -20,10 +20,50 @@ module.exports = {
     schema: [{
       enum: ['always', 'never', 'multiline', 'multiline-multiprop']
     }]
+
   },
 
   create: function (context) {
     var configuration = context.options[0];
+    var extraColumnStart = 0;
+    var indentType = 'space';
+    var indentSize = 2;
+    var sourceCode = context.getSourceCode();
+
+    if (context.options.length > 1) {
+      if (context.options[1] === 'tab') {
+        indentSize = 1;
+        indentType = 'tab';
+      } else if (typeof context.options[1] === 'number') {
+        indentSize = context.options[1];
+        indentType = 'space';
+      }
+    }
+
+    function getNodeIndent(node, byLastLine, excludeCommas) {
+      byLastLine = byLastLine || false;
+      excludeCommas = excludeCommas || false;
+
+      var src = sourceCode.getText(node, node.loc.start.column + extraColumnStart);
+      var lines = src.split('\n');
+      if (byLastLine) {
+        src = lines[lines.length - 1];
+      } else {
+        src = lines[0];
+      }
+
+      var skip = excludeCommas ? ',' : '';
+
+      var regExp;
+      if (indentType === 'space') {
+        regExp = new RegExp('^[ ' + skip + ']+');
+      } else {
+        regExp = new RegExp('^[\t' + skip + ']+');
+      }
+
+      var indent = regExp.exec(src);
+      return indent ? indent[0].length : 0;
+    }
 
     function isMultilineJSX(jsxNode) {
       return jsxNode.loc.start.line < jsxNode.loc.end.line;
@@ -42,7 +82,10 @@ module.exports = {
                 node: decl,
                 message: 'Property should be placed on a new line',
                 fix: function(fixer) {
-                  return fixer.insertTextAfter(node.name, '\n');
+                  var nodeIndent = getNodeIndent(node, false, false);
+                  var neededIndent = nodeIndent + indentSize;
+                  var insert = '\n' + Array(neededIndent + 1).join(indentType === 'space' ? ' ' : '\t');
+                  return fixer.replaceTextRange([node.name.end, decl.start], insert);
                 }
               });
             }

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -20,36 +20,10 @@ module.exports = {
     schema: [{
       enum: ['always', 'never', 'multiline', 'multiline-multiprop']
     }]
-
   },
 
   create: function (context) {
     var configuration = context.options[0];
-    var indentType = 'space';
-    var indentSize = 2;
-    var sourceCode = context.getSourceCode();
-
-    if (context.options.length > 1) {
-      if (context.options[1] === 'tab') {
-        indentSize = 1;
-        indentType = 'tab';
-      } else if (typeof context.options[1] === 'number') {
-        indentSize = context.options[1];
-        indentType = 'space';
-      }
-    }
-
-    function getNodeIndent(node) {
-      var src = sourceCode.getText(node, node.loc.start.column).split('\n')[0];
-      var regExp;
-      if (indentType === 'space') {
-        regExp = new RegExp('^[ ]+');
-      } else {
-        regExp = new RegExp('^[\t' + ']+');
-      }
-      var indent = regExp.exec(src);
-      return indent ? indent[0].length : 0;
-    }
 
     function isMultilineJSX(jsxNode) {
       return jsxNode.loc.start.line < jsxNode.loc.end.line;
@@ -68,9 +42,7 @@ module.exports = {
                 node: decl,
                 message: 'Property should be placed on a new line',
                 fix: function(fixer) {
-                  var neededIndent = getNodeIndent(node) + indentSize;
-                  var insert = '\n' + Array(neededIndent + 1).join(indentType === 'space' ? ' ' : '\t');
-                  return fixer.replaceTextRange([node.name.end, decl.start], insert);
+                  return fixer.replaceTextRange([node.name.end, decl.start], '\n');
                 }
               });
             }

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -153,6 +153,10 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
   invalid: [
     {
       code: '<Foo prop="one" />',
+      output: [
+        '<Foo',
+        ' prop="one" />'
+      ].join('\n'),
       options: ['always'],
       errors: [{message: 'Property should be placed on a new line'}],
       parser: parserOptions
@@ -160,6 +164,12 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
     {
       code: [
         '<Foo propOne="one"',
+        '  propTwo="two"',
+        '/>'
+      ].join('\n'),
+      output: [
+        '<Foo',
+        ' propOne="one"',
         '  propTwo="two"',
         '/>'
       ].join('\n'),
@@ -171,6 +181,11 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       code: [
         '<Foo',
         ' propOne="one"',
+        ' propTwo="two"',
+        '/>'
+      ].join('\n'),
+      output: [
+        '<Foo propOne="one"',
         ' propTwo="two"',
         '/>'
       ].join('\n'),

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -155,7 +155,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       code: '<Foo prop="one" />',
       output: [
         '<Foo',
-        ' prop="one" />'
+        '  prop="one" />'
       ].join('\n'),
       options: ['always'],
       errors: [{message: 'Property should be placed on a new line'}],
@@ -169,7 +169,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       ].join('\n'),
       output: [
         '<Foo',
-        ' propOne="one"',
+        '  propOne="one"',
         '  propTwo="two"',
         '/>'
       ].join('\n'),
@@ -179,14 +179,30 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
     },
     {
       code: [
+        '    <Foo propOne="one"',
+        '        propTwo="two"',
+        '    />'
+      ].join('\n'),
+      output: [
+        '    <Foo',
+        '        propOne="one"',
+        '        propTwo="two"',
+        '    />'
+      ].join('\n'),
+      options: ['always', 4],
+      errors: [{message: 'Property should be placed on a new line'}],
+      parser: parserOptions
+    },
+    {
+      code: [
         '<Foo',
-        ' propOne="one"',
-        ' propTwo="two"',
+        '  propOne="one"',
+        '  propTwo="two"',
         '/>'
       ].join('\n'),
       output: [
         '<Foo propOne="one"',
-        ' propTwo="two"',
+        '  propTwo="two"',
         '/>'
       ].join('\n'),
       options: ['never'],

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -155,7 +155,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       code: '<Foo prop="one" />',
       output: [
         '<Foo',
-        '  prop="one" />'
+        'prop="one" />'
       ].join('\n'),
       options: ['always'],
       errors: [{message: 'Property should be placed on a new line'}],
@@ -169,43 +169,11 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       ].join('\n'),
       output: [
         '<Foo',
-        '  propOne="one"',
+        'propOne="one"',
         '  propTwo="two"',
         '/>'
       ].join('\n'),
       options: ['always'],
-      errors: [{message: 'Property should be placed on a new line'}],
-      parser: parserOptions
-    },
-    {
-      code: [
-        '    <Foo propOne="one"',
-        '        propTwo="two"',
-        '    />'
-      ].join('\n'),
-      output: [
-        '    <Foo',
-        '        propOne="one"',
-        '        propTwo="two"',
-        '    />'
-      ].join('\n'),
-      options: ['always', 4],
-      errors: [{message: 'Property should be placed on a new line'}],
-      parser: parserOptions
-    },
-    {
-      code: [
-        '\t<Foo propOne="one"',
-        '\t\tpropTwo="two"',
-        '\t/>'
-      ].join('\n'),
-      output: [
-        '\t<Foo',
-        '\t\tpropOne="one"',
-        '\t\tpropTwo="two"',
-        '\t/>'
-      ].join('\n'),
-      options: ['always', 'tab'],
       errors: [{message: 'Property should be placed on a new line'}],
       parser: parserOptions
     },

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -195,6 +195,22 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
     },
     {
       code: [
+        '\t<Foo propOne="one"',
+        '\t\tpropTwo="two"',
+        '\t/>'
+      ].join('\n'),
+      output: [
+        '\t<Foo',
+        '\t\tpropOne="one"',
+        '\t\tpropTwo="two"',
+        '\t/>'
+      ].join('\n'),
+      options: ['always', 'tab'],
+      errors: [{message: 'Property should be placed on a new line'}],
+      parser: parserOptions
+    },
+    {
+      code: [
         '<Foo',
         '  propOne="one"',
         '  propTwo="two"',

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -198,6 +198,11 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '<Foo prop={{',
         '}} />'
       ].join('\n'),
+      output: [
+        '<Foo',
+        'prop={{',
+        '}} />'
+      ].join('\n'),
       options: ['multiline'],
       errors: [{message: 'Property should be placed on a new line'}],
       parser: parserOptions
@@ -205,6 +210,11 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
     {
       code: [
         '<Foo bar={{',
+        '}} baz />'
+      ].join('\n'),
+      output: [
+        '<Foo',
+        'bar={{',
         '}} baz />'
       ].join('\n'),
       options: ['multiline-multiprop'],

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -152,10 +152,10 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
 
   invalid: [
     {
-      code: '<Foo prop="one" />',
+      code: '<Foo propOne="one" propTwo="two" />',
       output: [
         '<Foo',
-        'prop="one" />'
+        'propOne="one" propTwo="two" />'
       ].join('\n'),
       options: ['always'],
       errors: [{message: 'Property should be placed on a new line'}],


### PR DESCRIPTION
Hi I have made an autofix for the rule jsx-first-prop-new-line for a fork and I thought it would be useful to have it on the main repo.

I am aware and monitoring #883. Will update the autofix after that is approved! Meanwhile, PR for visibility and to start the process :)
