### PR TITLE
failing test for jsx-indent without parens

### DIFF
--- a/tests/lib/rules/jsx-indent.js
+++ b/tests/lib/rules/jsx-indent.js
@@ -167,6 +167,26 @@ ruleTester.run('jsx-indent', rule, {
     ].join('\n'),
     parserOptions: parserOptions,
     options: [2]
+  }, {
+    code: [
+      '{head.title && (',
+      '  <h1>',
+      '    {head.title}',
+      '  </h1>',
+      ')}'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: [2]
+  }, {
+    code: [
+      '{head.title &&',
+      '  <h1>',
+      '    {head.title}',
+      '  </h1>',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: [2]
   }],
 
   invalid: [{


### PR DESCRIPTION
Starting in 6.4.0 I got some new errors from `jsx-indent` in some of my projects.

Here's a simple example that I added as a failing test:

```js
{head.title &&
  <h1>
    {head.title}
  </h1>
}
```

I could wrap the `<h1>` with parens and then it works (I added a test for that also), but I'm wondering if it could be made to pass without parens. Or there's probably a good reason why it shouldn't pass that I'm missing 😄 . If this should be ok, I'd be more than willing to work on a fix for this.