### PR TITLE
Valid self reference jsx element.

### DIFF
--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -48,7 +48,7 @@ module.exports = {
     return {
       JSXAttribute: function(node) {
         var tag = node.parent.name.name;
-        if (tag[0] !== tag[0].toUpperCase()) {
+        if (tag && tag[0] !== tag[0].toUpperCase()) {
           // This is a DOM node, not a Component, so exit.
           return;
         }

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -81,6 +81,17 @@ ruleTester.run('forbid-component-props', rule, {
     ].join('\n'),
     options: [{forbid: ['style', 'foo']}],
     parserOptions: parserOptions
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <this.Foo className="bar" />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{forbid: ['style', 'foo']}],
+    parserOptions: parserOptions
   }],
 
   invalid: [{

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -101,6 +101,13 @@ ruleTester.run('forbid-component-props', rule, {
     ].join('\n'),
     options: [{forbid: ['style']}],
     parserOptions: parserOptions
+  }, {
+    code: [
+      'const First = (props) => (',
+      '  <this.Foo {...props} />',
+      ');'
+    ].join('\n'),
+    parserOptions: parserOptions
   }],
 
   invalid: [{

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -86,11 +86,20 @@ ruleTester.run('forbid-component-props', rule, {
       'var First = React.createClass({',
       '  propTypes: externalPropTypes,',
       '  render: function() {',
-      '    return <this.Foo className="bar" />;',
+      '    return <this.Foo bar="baz" />;',
       '  }',
       '});'
     ].join('\n'),
-    options: [{forbid: ['style', 'foo']}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class First extends React.createClass {',
+      '  render() {',
+      '    return <this.foo className="bar" />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{forbid: ['style']}],
     parserOptions: parserOptions
   }],
 


### PR DESCRIPTION
Please check the information here https://github.com/yannickcr/eslint-plugin-react/pull/839 

I'm trying to include [xo](https://github.com/sindresorhus/xo) in one of our projects, i hit the issue exactly the same as @pfhayes . And after dig into the codebase, i found we have a self reference linked jsx element and that cause the issue, Like this 
```
class Foo extends React.createClass {
   render() {
       return <this.Bar  className='demo' />
   }
}
```

That's cause the issue. I don't think it's a best practice, but at least it shouldn't crash the workflow.