### PR TITLE
added option to automatically search for imports and add them

### DIFF
--- a/lib/rules/jsx-no-undef.js
+++ b/lib/rules/jsx-no-undef.js
@@ -26,6 +26,7 @@ module.exports = {
       category: 'Possible Errors',
       recommended: true
     },
+    fixable: 'code',
     schema: []
   },
 
@@ -67,7 +68,28 @@ module.exports = {
 
       context.report({
         node: node,
-        message: '\'' + node.name + '\' is not defined.'
+        message: '\'' + node.name + '\' is not defined.',
+        fix: function(fixer) {
+          var path = require('path');
+          var spawn = require('child_process').spawnSync;
+
+          var filename = context.getFilename();
+          var importRoot = context.options[0];
+          var searchRoot = filename.substring(0, filename.lastIndexOf('/' + importRoot + '/')) + '/' + importRoot + '/';
+
+          var findOut = spawn('find', [
+            searchRoot,
+            '-type', 'f',
+            '-name', node.name + '.js'
+          ]).stdout.toString();
+
+          var importPath = '';
+          if (findOut.length > 0) {
+            importPath = '\'' + path.relative(searchRoot, findOut.replace(/...\n$/, '')) + '\'';
+          }
+
+          return fixer.insertTextAfterRange([0, 0], 'import ' + node.name + ' from ' + importPath + ';\n');
+        }
       });
     }
 


### PR DESCRIPTION
This uses the `find` command to automatically find and insert missing JSX imports.

Config: `"react/jsx-no-undef": [2, "src"]`
Result when missing `MyComponent`: `import MyComponent from "some/folder/MyComponent";`

When it doesn't find a file named like the Component it just writes `import MyComponent from ;`