### PR TITLE
Support tab indentation

### DIFF
--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -155,11 +155,11 @@ module.exports = {
     function getIndentation(tokens, expectedLocation) {
       switch (expectedLocation) {
         case 'props-aligned':
-          return /^\s*/.exec(sourceCode[tokens.lastProp.lastLine])[0];
+          return /^\s*/.exec(sourceCode.lines[tokens.lastProp.lastLine])[0];
         case 'tag-aligned':
-          return /^\s*/.exec(sourceCode[tokens.opening.line])[0];
+          return /^\s*/.exec(sourceCode.lines[tokens.opening.line])[0];
         case 'line-aligned':
-          return /^\s*/.exec(sourceCode[tokens.openingStartOfLine.line])[0];
+          return /^\s*/.exec(sourceCode.lines[tokens.openingStartOfLine.line])[0];
         default:
           return '';
       }

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -147,6 +147,25 @@ module.exports = {
     }
 
     /**
+     * Get the characters used for indentation on the line to be matched
+     * @param {Object} tokens Locations of the opening bracket, closing bracket and last prop
+     * @param {String} expectedLocation Expected location for the closing bracket
+     * @return {String} The characters used for indentation
+     */
+    function getIndentation(tokens, expectedLocation) {
+      switch (expectedLocation) {
+        case 'props-aligned':
+          return /^\s*/.exec(sourceCode[tokens.lastProp.lastLine])[0];
+        case 'tag-aligned':
+          return /^\s*/.exec(sourceCode[tokens.opening.line])[0];
+        case 'line-aligned':
+          return /^\s*/.exec(sourceCode[tokens.openingStartOfLine.line])[0];
+        default:
+          return '';
+      }
+    }
+
+    /**
      * Get the locations of the opening bracket, closing bracket, last prop, and
      * start of opening line.
      * @param {ASTNode} node The node to check
@@ -244,9 +263,8 @@ module.exports = {
               case 'props-aligned':
               case 'tag-aligned':
               case 'line-aligned':
-                var spaces = new Array(+correctColumn + 1);
                 return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
-                  '\n' + spaces.join(' ') + closingTag);
+                  '\n' + getIndentation(tokens, expectedLocation) + closingTag);
               default:
                 return true;
             }

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -162,6 +162,7 @@ module.exports = {
         case 'tag-aligned':
         case 'line-aligned':
           indentation = /^\s*/.exec(sourceCode.lines[tokens.opening.line - 1])[0];
+          break;
         default:
           indentation = '';
       }

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -150,19 +150,26 @@ module.exports = {
      * Get the characters used for indentation on the line to be matched
      * @param {Object} tokens Locations of the opening bracket, closing bracket and last prop
      * @param {String} expectedLocation Expected location for the closing bracket
+     * @param {Number} correctColumn Expected column for the closing bracket
      * @return {String} The characters used for indentation
      */
-    function getIndentation(tokens, expectedLocation) {
+    function getIndentation(tokens, expectedLocation, correctColumn) {
+      var indentation, spaces = [];
       switch (expectedLocation) {
         case 'props-aligned':
-          return /^\s*/.exec(sourceCode.lines[tokens.lastProp.lastLine])[0];
+          indentation = /^\s*/.exec(sourceCode.lines[tokens.lastProp.firstLine - 1])[0];
+          break;
         case 'tag-aligned':
-          return /^\s*/.exec(sourceCode.lines[tokens.opening.line])[0];
         case 'line-aligned':
-          return /^\s*/.exec(sourceCode.lines[tokens.openingStartOfLine.line])[0];
+          indentation = /^\s*/.exec(sourceCode.lines[tokens.opening.line - 1])[0];
         default:
-          return '';
+          indentation = '';
       }
+      if (indentation.length + 1 < correctColumn) {
+        // Non-whitespace characters were included in the column offset
+        spaces = new Array(+correctColumn + 1 - indentation.length);
+      }
+      return indentation + spaces.join(' ');
     }
 
     /**
@@ -264,7 +271,7 @@ module.exports = {
               case 'tag-aligned':
               case 'line-aligned':
                 return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
-                  '\n' + getIndentation(tokens, expectedLocation) + closingTag);
+                  '\n' + getIndentation(tokens, expectedLocation, correctColumn) + closingTag);
               default:
                 return true;
             }

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -398,6 +398,334 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     parserOptions: parserOptions
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App ',
+      '\tfoo />'
+    ].join('\n'),
+    options: ['after-props'],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '\t/>'
+    ].join('\n'),
+    options: ['props-aligned'],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App ',
+      '\tfoo />'
+    ].join('\n'),
+    options: [{location: 'after-props'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '\t/>'
+    ].join('\n'),
+    options: [{location: 'props-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App',
+      '\tfoo',
+      '></App>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App',
+      '\tfoo',
+      '></App>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App',
+      '\tfoo',
+      '\t></App>'
+    ].join('\n'),
+    options: [{location: 'props-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App',
+      '\tfoo={function() {',
+      '\t\tconsole.log(\'bar\');',
+      '\t}} />'
+    ].join('\n'),
+    options: [{location: 'after-props'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App',
+      '\tfoo={function() {',
+      '\t\tconsole.log(\'bar\');',
+      '\t}}',
+      '\t/>'
+    ].join('\n'),
+    options: [{location: 'props-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App',
+      '\tfoo={function() {',
+      '\t\tconsole.log(\'bar\');',
+      '\t}}',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App',
+      '\tfoo={function() {',
+      '\t\tconsole.log(\'bar\');',
+      '\t}}',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App foo={function() {',
+      '\tconsole.log(\'bar\');',
+      '}}/>'
+    ].join('\n'),
+    options: [{location: 'after-props'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App foo={function() {',
+      '\t\t\tconsole.log(\'bar\');',
+      '\t\t}}',
+      '\t\t/>'
+    ].join('\n'),
+    options: [{location: 'props-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App foo={function() {',
+      '\tconsole.log(\'bar\');',
+      '}}',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App foo={function() {',
+      '\tconsole.log(\'bar\');',
+      '}}',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<Provider store>',
+      '\t<App',
+      '\t\tfoo />',
+      '</Provider>'
+    ].join('\n'),
+    options: [{selfClosing: 'after-props'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<Provider ',
+      '\tstore',
+      '>',
+      '\t<App',
+      '\t\tfoo />',
+      '</Provider>'
+    ].join('\n'),
+    options: [{selfClosing: 'after-props'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<Provider ',
+      '\tstore>',
+      '\t<App ',
+      '\t\tfoo',
+      '\t/>',
+      '</Provider>'
+    ].join('\n'),
+    options: [{nonEmpty: 'after-props'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<Provider store>',
+      '\t<App ',
+      '\t\tfoo',
+      '\t\t/>',
+      '</Provider>'
+    ].join('\n'),
+    options: [{selfClosing: 'props-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<Provider',
+      '\tstore',
+      '\t>',
+      '\t<App ',
+      '\t\tfoo',
+      '\t/>',
+      '</Provider>'
+    ].join('\n'),
+    options: [{nonEmpty: 'props-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var x = function() {',
+      '\treturn <App',
+      '\t\tfoo',
+      '\t\t\t\t>',
+      '\t\t\tbar',
+      '\t       </App>',
+      '}'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var x = function() {',
+      '\treturn <App',
+      '\t\tfoo',
+      '\t       />',
+      '}'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var x = <App',
+      '\tfoo',
+      '        />'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var x = function() {',
+      '\treturn <App',
+      '\t\tfoo={function() {',
+      '\t\t\tconsole.log(\'bar\');',
+      '\t\t}}',
+      '\t/>',
+      '}'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'var x = <App',
+      '\tfoo={function() {',
+      '\t\tconsole.log(\'bar\');',
+      '\t}}',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<Provider',
+      '\tstore',
+      '>',
+      '\t<App',
+      '\t\tfoo={function() {',
+      '\t\t\tconsole.log(\'bar\');',
+      '\t\t}}',
+      '\t/>',
+      '</Provider>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<Provider',
+      '\tstore',
+      '>',
+      '\t{baz && <App',
+      '\t\tfoo={function() {',
+      '\t\t\tconsole.log(\'bar\');',
+      '\t\t}}',
+      '\t/>}',
+      '</Provider>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App>',
+      '\t<Foo',
+      '\t\tbar',
+      '\t>',
+      '\t</Foo>',
+      '\t<Foo',
+      '\t\tbar />',
+      '</App>'
+    ].join('\n'),
+    options: [{
+      nonEmpty: false,
+      selfClosing: 'after-props'
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<App>',
+      '\t<Foo',
+      '\t\tbar>',
+      '\t</Foo>',
+      '\t<Foo',
+      '\t\tbar',
+      '\t/>',
+      '</App>'
+    ].join('\n'),
+    options: [{
+      nonEmpty: 'after-props',
+      selfClosing: false
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<div className={[',
+      '\t"some",',
+      '\t"stuff",',
+      '\t2 ]}',
+      '>',
+      '\tSome text',
+      '</div>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions
   }],
 
   invalid: [{
@@ -958,6 +1286,535 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
       line: 4,
       column: 7
+    }]
+  }, {
+    code: [
+      '<App ',
+      '\tfoo />'
+    ].join('\n'),
+    output: [
+      '<App ',
+      '\tfoo',
+      '\t/>'
+    ].join('\n'),
+    options: [{location: 'props-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, true),
+      line: 2,
+      column: 6
+    }]
+  }, {
+    code: [
+      '<App ',
+      '\tfoo />'
+    ].join('\n'),
+    output: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      line: 2,
+      column: 6
+    }]
+  }, {
+    code: [
+      '<App ',
+      '\tfoo />'
+    ].join('\n'),
+    output: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, true),
+      line: 2,
+      column: 6
+    }]
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    output: [
+      '<App ',
+      '\tfoo/>'
+    ].join('\n'),
+    options: [{location: 'after-props'}],
+    parserOptions: parserOptions,
+    errors: MESSAGE_AFTER_PROPS
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    output: [
+      '<App ',
+      '\tfoo',
+      '\t/>'
+    ].join('\n'),
+    options: [{location: 'props-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, false),
+      line: 3,
+      column: 1
+    }]
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '\t/>'
+    ].join('\n'),
+    output: [
+      '<App ',
+      '\tfoo/>'
+    ].join('\n'),
+    options: [{location: 'after-props'}],
+    parserOptions: parserOptions,
+    errors: MESSAGE_AFTER_PROPS
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '\t/>'
+    ].join('\n'),
+    output: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, false),
+      line: 3,
+      column: 2
+    }]
+  }, {
+    code: [
+      '<App ',
+      '\tfoo',
+      '\t/>'
+    ].join('\n'),
+    output: [
+      '<App ',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      line: 3,
+      column: 2
+    }]
+  }, {
+    code: [
+      '<App',
+      '\tfoo',
+      '></App>'
+    ].join('\n'),
+    output: [
+      '<App',
+      '\tfoo></App>'
+    ].join('\n'),
+    options: [{location: 'after-props'}],
+    parserOptions: parserOptions,
+    errors: MESSAGE_AFTER_PROPS
+  }, {
+    code: [
+      '<App',
+      '\tfoo',
+      '></App>'
+    ].join('\n'),
+    output: [
+      '<App',
+      '  foo',
+      '  ></App>'
+    ].join('\n'),
+    options: [{location: 'props-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, false),
+      line: 3,
+      column: 1
+    }]
+  }, {
+    code: [
+      '<App',
+      '\tfoo',
+      '\t></App>'
+    ].join('\n'),
+    output: [
+      '<App',
+      '\tfoo></App>'
+    ].join('\n'),
+    options: [{location: 'after-props'}],
+    parserOptions: parserOptions,
+    errors: MESSAGE_AFTER_PROPS
+  }, {
+    code: [
+      '<App',
+      '\tfoo',
+      '\t></App>'
+    ].join('\n'),
+    output: [
+      '<App',
+      '  foo',
+      '></App>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, false),
+      line: 3,
+      column: 2
+    }]
+  }, {
+    code: [
+      '<App',
+      '\tfoo',
+      '\t></App>'
+    ].join('\n'),
+    output: [
+      '<App',
+      '\tfoo',
+      '></App>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      line: 3,
+      column: 2
+    }]
+  }, {
+    code: [
+      '<Provider ',
+      '\tstore>', // <--
+      '\t<App ',
+      '\t\tfoo',
+      '\t\t/>',
+      '</Provider>'
+    ].join('\n'),
+    output: [
+      '<Provider ',
+      '\tstore',
+      '>',
+      '\t<App ',
+      '\t\tfoo',
+      '\t\t/>',
+      '</Provider>'
+    ].join('\n'),
+    options: [{selfClosing: 'props-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      line: 2,
+      column: 7
+    }]
+  }, {
+    code: [
+      'const Button = function(props) {',
+      '\treturn (',
+      '\t\t<Button',
+      '\t\t\tsize={size}',
+      '\t\t\tonClick={onClick}',
+      '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>',
+      '\t\t\tButton Text',
+      '\t\t</Button>',
+      '\t);',
+      '};'
+    ].join('\n'),
+    output: [
+      'const Button = function(props) {',
+      '\treturn (',
+      '\t\t<Button',
+      '\t\t\tsize={size}',
+      '\t\t\tonClick={onClick}',
+      '\t\t\t>',
+      '\t\t\tButton Text',
+      '\t\t</Button>',
+      '\t);',
+      '};'
+    ].join('\n'),
+    options: ['props-aligned'],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 7, false),
+      line: 6,
+      column: 19
+    }]
+  }, {
+    code: [
+      'const Button = function(props) {',
+      '\treturn (',
+      '\t\t<Button',
+      '\t\t\tsize={size}',
+      '\t\t\tonClick={onClick}',
+      '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>',
+      '\t\t\tButton Text',
+      '\t\t</Button>',
+      '\t);',
+      '};'
+    ].join('\n'),
+    output: [
+      'const Button = function(props) {',
+      '\treturn (',
+      '\t\t<Button',
+      '\t\t\tsize={size}',
+      '\t\t\tonClick={onClick}',
+      '\t\t>',
+      '\t\t\tButton Text',
+      '\t\t</Button>',
+      '\t);',
+      '};'
+    ].join('\n'),
+    options: ['tag-aligned'],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 5, false),
+      line: 6,
+      column: 19
+    }]
+  }, {
+    code: [
+      'const Button = function(props) {',
+      '\treturn (',
+      '\t\t<Button',
+      '\t\t\tsize={size}',
+      '\t\t\tonClick={onClick}',
+      '\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t>',
+      '\t\t\tButton Text',
+      '\t\t</Button>',
+      '\t);',
+      '};'
+    ].join('\n'),
+    output: [
+      'const Button = function(props) {',
+      '\treturn (',
+      '\t\t<Button',
+      '\t\t\tsize={size}',
+      '\t\t\tonClick={onClick}',
+      '\t\t>',
+      '\t\t\tButton Text',
+      '\t\t</Button>',
+      '\t);',
+      '};'
+    ].join('\n'),
+    options: ['line-aligned'],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 5, false),
+      line: 6,
+      column: 19
+    }]
+  }, {
+    code: [
+      '<Provider',
+      '\tstore',
+      '\t>',
+      '\t<App ',
+      '\t\tfoo',
+      '\t\t/>', // <--
+      '</Provider>'
+    ].join('\n'),
+    output: [
+      '<Provider',
+      '\tstore',
+      '\t>',
+      '\t<App ',
+      '\t\tfoo',
+      '\t/>',
+      '</Provider>'
+    ].join('\n'),
+    options: [{nonEmpty: 'props-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      line: 6,
+      column: 3
+    }]
+  }, {
+    code: [
+      '<Provider ',
+      '\tstore>', // <--
+      '\t<App',
+      '\t\tfoo />',
+      '</Provider>'
+    ].join('\n'),
+    output: [
+      '<Provider ',
+      '\tstore',
+      '>',
+      '\t<App',
+      '\t\tfoo />',
+      '</Provider>'
+    ].join('\n'),
+    options: [{selfClosing: 'after-props'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      line: 2,
+      column: 7
+    }]
+  }, {
+    code: [
+      '<Provider ',
+      '\tstore>',
+      '\t<App ',
+      '\t\tfoo',
+      '\t\t/>', // <--
+      '</Provider>'
+    ].join('\n'),
+    output: [
+      '<Provider ',
+      '\tstore>',
+      '\t<App ',
+      '\t\tfoo',
+      '\t/>', // <--
+      '</Provider>'
+    ].join('\n'),
+    options: [{nonEmpty: 'after-props'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      line: 5,
+      column: 3
+    }]
+  }, {
+    code: [
+      'var x = function() {',
+      '\treturn <App',
+      '\t\tfoo',
+      '\t\t\t\t />',
+      '}'
+    ].join('\n'),
+    output: [
+      'var x = function() {',
+      '\treturn <App',
+      '\t\tfoo',
+      '\t/>',
+      '}'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, false),
+      line: 4,
+      column: 6
+    }]
+  }, {
+    code: [
+      'var x = <App',
+      '\tfoo',
+      '        />'
+    ].join('\n'),
+    output: [
+      'var x = <App',
+      '\tfoo',
+      '/>'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      line: 3,
+      column: 9
+    }]
+  }, {
+    code: [
+      'var x = (',
+      '\t<div',
+      '\t\tclassName="MyComponent"',
+      '\t\t{...props} />',
+      ')'
+    ].join('\n'),
+    output: [
+      'var x = (',
+      '\t<div',
+      '\t\tclassName="MyComponent"',
+      '\t\t{...props}',
+      '\t/>',
+      ')'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, true),
+      line: 4,
+      column: 14
+    }]
+  }, {
+    code: [
+      'var x = (',
+      '\t<Something',
+      '\t\tcontent={<Foo />} />',
+      ')'
+    ].join('\n'),
+    output: [
+      'var x = (',
+      '\t<Something',
+      '\t\tcontent={<Foo />}',
+      '\t/>',
+      ')'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, true),
+      line: 3,
+      column: 21
+    }]
+  }, {
+    code: [
+      'var x = (',
+      '\t<Something ',
+      '\t\t/>',
+      ')'
+    ].join('\n'),
+    output: [
+      'var x = (',
+      '\t<Something />',
+      ')'
+    ].join('\n'),
+    options: [{location: 'line-aligned'}],
+    parserOptions: parserOptions,
+    errors: [MESSAGE_AFTER_TAG]
+  }, {
+    code: [
+      '<div className={[',
+      '\t"some",',
+      '\t"stuff",',
+      '\t2 ]}>',
+      '\tSome text',
+      '</div>'
+    ].join('\n'),
+    output: [
+      '<div className={[',
+      '\t"some",',
+      '\t"stuff",',
+      '\t2 ]}',
+      '>',
+      '\tSome text',
+      '</div>'
+    ].join('\n'),
+    options: [{location: 'tag-aligned'}],
+    parserOptions: parserOptions,
+    errors: [{
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      line: 4,
+      column: 6
     }]
   }]
 });

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -527,7 +527,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '<App foo={function() {',
       '\t\t\tconsole.log(\'bar\');',
       '\t\t}}',
-      '\t\t/>'
+      '     />'
     ].join('\n'),
     options: [{location: 'props-aligned'}],
     parserOptions: parserOptions
@@ -607,7 +607,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       'var x = function() {',
       '\treturn <App',
       '\t\tfoo',
-      '\t\t\t\t>',
+      '\t       >',
       '\t\t\tbar',
       '\t       </App>',
       '}'
@@ -1300,7 +1300,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{location: 'props-aligned'}],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, true),
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 2, true),
       line: 2,
       column: 6
     }]
@@ -1365,7 +1365,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{location: 'props-aligned'}],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, false),
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 2, false),
       line: 3,
       column: 1
     }]
@@ -1439,13 +1439,13 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     output: [
       '<App',
-      '  foo',
-      '  ></App>'
+      '\tfoo',
+      '\t></App>'
     ].join('\n'),
     options: [{location: 'props-aligned'}],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, false),
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 2, false),
       line: 3,
       column: 1
     }]
@@ -1470,7 +1470,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     output: [
       '<App',
-      '  foo',
+      '\tfoo',
       '></App>'
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
@@ -1551,7 +1551,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: ['props-aligned'],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 7, false),
+      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 4, false),
       line: 6,
       column: 19
     }]
@@ -1583,7 +1583,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: ['tag-aligned'],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 5, false),
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
       line: 6,
       column: 19
     }]
@@ -1615,7 +1615,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: ['line-aligned'],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 5, false),
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, false),
       line: 6,
       column: 19
     }]
@@ -1641,7 +1641,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{nonEmpty: 'props-aligned'}],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 2, false),
       line: 6,
       column: 3
     }]
@@ -1688,7 +1688,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{nonEmpty: 'after-props'}],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 2, false),
       line: 5,
       column: 3
     }]
@@ -1710,7 +1710,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{location: 'line-aligned'}],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, false),
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 2, false),
       line: 4,
       column: 6
     }]
@@ -1751,7 +1751,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{location: 'line-aligned'}],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, true),
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 2, true),
       line: 4,
       column: 14
     }]
@@ -1772,7 +1772,7 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     options: [{location: 'line-aligned'}],
     parserOptions: parserOptions,
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, true),
+      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 2, true),
       line: 3,
       column: 21
     }]


### PR DESCRIPTION
The autofix for this rule substitutes spaces even when the code is normally indented with tabs. This change accommodates tabs, spaces, and even mixed whitespace (we won't judge).