### PR TITLE
Mark deprecated rules as deprecated in their metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,6 @@
 'use strict';
 
-var deprecatedRules = {
-  'no-comment-textnodes': require('./lib/rules/no-comment-textnodes'),
-  'require-extension': require('./lib/rules/require-extension'),
-  'wrap-multilines': require('./lib/rules/wrap-multilines')
-};
-
-var rules = {
+var allRules = {
   'jsx-uses-react': require('./lib/rules/jsx-uses-react'),
   'no-multi-comp': require('./lib/rules/no-multi-comp'),
   'prop-types': require('./lib/rules/prop-types'),
@@ -58,32 +52,45 @@ var rules = {
   'no-danger-with-children': require('./lib/rules/no-danger-with-children'),
   'style-prop-object': require('./lib/rules/style-prop-object'),
   'no-unused-prop-types': require('./lib/rules/no-unused-prop-types'),
-  'no-children-prop': require('./lib/rules/no-children-prop')
+  'no-children-prop': require('./lib/rules/no-children-prop'),
+  'no-comment-textnodes': require('./lib/rules/no-comment-textnodes'),
+  'require-extension': require('./lib/rules/require-extension'),
+  'wrap-multilines': require('./lib/rules/wrap-multilines')
 };
 
-var ruleNames = Object.keys(rules);
-var allRules = {};
-for (var i = 0; i < ruleNames.length; i++) {
-  allRules['react/' + ruleNames[i]] = 2;
+function filterRules(rules, predicate) {
+  var result = {};
+  for (var key in rules) {
+    if (rules.hasOwnProperty(key) && predicate(rules[key])) {
+      result[key] = rules[key];
+    }
+  }
+  return result;
 }
 
-var exportedRules = {};
-for (var key in rules) {
-  if (!rules.hasOwnProperty(key)) {
-    continue;
+function configureAsError(rules) {
+  var result = {};
+  for (var key in rules) {
+    if (!rules.hasOwnProperty(key)) {
+      continue;
+    }
+    result['react/' + key] = 2;
   }
-  exportedRules[key] = rules[key];
+  return result;
 }
-for (var deprecatedKey in deprecatedRules) {
-  if (!deprecatedRules.hasOwnProperty(deprecatedKey)) {
-    continue;
-  }
-  exportedRules[deprecatedKey] = deprecatedRules[deprecatedKey];
-}
+
+var activeRules = filterRules(allRules, function(rule) {
+  return !rule.meta.deprecated;
+});
+var activeRulesConfig = configureAsError(activeRules);
+
+var deprecatedRules = filterRules(allRules, function(rule) {
+  return rule.meta.deprecated;
+});
 
 module.exports = {
   deprecatedRules: deprecatedRules,
-  rules: exportedRules,
+  rules: allRules,
   configs: {
     recommended: {
       parserOptions: {
@@ -114,7 +121,7 @@ module.exports = {
           jsx: true
         }
       },
-      rules: allRules
+      rules: activeRulesConfig
     }
   }
 };

--- a/lib/rules/no-comment-textnodes.js
+++ b/lib/rules/no-comment-textnodes.js
@@ -15,6 +15,7 @@ var isWarnedForDeprecation = false;
 
 module.exports = {
   meta: {
+    deprecated: true,
     docs: {
       description: 'Comments inside children section of tag should be placed inside braces',
       category: 'Possible Errors',

--- a/lib/rules/require-extension.js
+++ b/lib/rules/require-extension.js
@@ -24,6 +24,7 @@ var PKG_REGEX = /^[^\.]((?!\/).)*$/;
 
 module.exports = {
   meta: {
+    deprecated: true,
     docs: {
       description: 'Restrict file extensions that may be required',
       category: 'Stylistic Issues',

--- a/lib/rules/wrap-multilines.js
+++ b/lib/rules/wrap-multilines.js
@@ -15,6 +15,7 @@ var isWarnedForDeprecation = false;
 
 module.exports = {
   meta: {
+    deprecated: true,
     docs: {
       description: 'Prevent missing parentheses around multilines JSX',
       category: 'Stylistic Issues',

--- a/tests/index.js
+++ b/tests/index.js
@@ -23,6 +23,20 @@ describe('all rule files should be exported by the plugin', function() {
   });
 });
 
+describe('deprecated rules', function() {
+  it('marks all deprecated rules as deprecated', function() {
+    ruleFiles.forEach(function(ruleName) {
+      var inDeprecatedRules = Boolean(plugin.deprecatedRules[ruleName]);
+      var isDeprecated = plugin.rules[ruleName].meta.deprecated;
+      if (inDeprecatedRules) {
+        assert(isDeprecated, ruleName + ' metadata should mark it as deprecated');
+      } else {
+        assert(!isDeprecated, ruleName + ' metadata should not mark it as deprecated');
+      }
+    });
+  });
+});
+
 describe('configurations', function() {
   it('should export a \'recommended\' configuration', function() {
     assert(plugin.configs.recommended);


### PR DESCRIPTION
Over on [eslint-find-rules](https://github.com/sarbbottam/eslint-find-rules), there has been some discussion about being able to detect deprecated rules in order to [not report them as unused](https://github.com/sarbbottam/eslint-find-rules/issues/172) and to [report when they are still being used](https://github.com/sarbbottam/eslint-find-rules/issues/188).

In order to implement those features, there needs to be a way to detect that a rule has been deprecated.  Core ESLint rules that are deprecated are marked as such in their metadata.

This PR adds the same `deprecated` flag to the metadata of the deprecated rules in this plugin.

It might be possible to make use of this metadata in `index.js` to automatically determine which rules are deprecated, rather than duplicating the information in two places.  However, my attempts at this were not that clean and didn’t seem worth it.  I could take another look if you think it worth it.
