### PR TITLE
fix #884

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -11,12 +11,6 @@ var Components = require('../util/Components');
 var variable = require('../util/variable');
 
 // ------------------------------------------------------------------------------
-// Constants
-// ------------------------------------------------------------------------------
-
-var DIRECT_PROPS_REGEX = /^props\s*(\.|\[)/;
-
-// ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
@@ -74,17 +68,15 @@ module.exports = {
     }
 
     /**
-     * Checks if we are using a prop
+     * Checks if this node is `this.props`.
      * @param {ASTNode} node The AST node being checked.
-     * @returns {Boolean} True if we are using a prop, false if not.
+     * @returns {Boolean} True if this node is `this.props`, false if not.
      */
-    function isPropTypesUsage(node) {
-      var isClassUsage = (
+    function isPropsMemberExpression(node) {
+      return (
         (utils.getParentES6Component() || utils.getParentES5Component()) &&
         node.object.type === 'ThisExpression' && node.property.name === 'props'
       );
-      var isStatelessFunctionUsage = node.object.name === 'props';
-      return isClassUsage || isStatelessFunctionUsage;
     }
 
     /**
@@ -209,15 +201,26 @@ module.exports = {
     }
 
     /**
-     * Checks if a prop init name matches common naming patterns
+     * Checks if a node is an identifier referring to props
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if the prop name matches
      */
-    function isPropAttributeName (node) {
+    function isPropsIdentifier (node) {
       return (
-        node.init.name === 'props' ||
-        node.init.name === 'nextProps' ||
-        node.init.name === 'prevProps'
+        node.type === 'Identifier' && (
+          node.parent.type === 'MemberExpression' ||
+          node.parent.type === 'VariableDeclarator'
+        ) && (
+          (
+            (isInLifeCycleMethod(node) || utils.getParentStatelessComponent()) &&
+            node.name === 'props'
+          ) || (
+            isInLifeCycleMethod(node) && (
+              node.name === 'nextProps' ||
+              node.name === 'prevProps'
+            )
+          )
+        )
       );
     }
 
@@ -484,40 +487,16 @@ module.exports = {
     }
 
     /**
-     * Check if we are in a class constructor
-     * @return {boolean} true if we are in a class constructor, false if not
-     */
-    function inConstructor() {
-      var scope = context.getScope();
-      while (scope) {
-        if (scope.block && scope.block.parent && scope.block.parent.kind === 'constructor') {
-          return true;
-        }
-        scope = scope.upper;
-      }
-      return false;
-    }
-
-    /**
      * Retrieve the name of a property node
      * @param {ASTNode} node The AST node with the property.
      * @return {string} the name of the property or undefined if not found
      */
     function getPropertyName(node) {
-      var isDirectProp = DIRECT_PROPS_REGEX.test(sourceCode.getText(node));
-      var isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
-      var isNotInConstructor = !inConstructor(node);
-      if (isDirectProp && isInClassComponent && isNotInConstructor) {
-        return void 0;
-      }
-      if (!isDirectProp) {
-        node = node.parent;
-      }
-      var property = node.property;
+      var property = node.parent.property;
       if (property) {
         switch (property.type) {
           case 'Identifier':
-            if (node.computed) {
+            if (node.parent.computed) {
               return '__COMPUTED_PROP__';
             }
             return property.name;
@@ -530,7 +509,7 @@ module.exports = {
             }
             // falls through
           default:
-            if (node.computed) {
+            if (node.parent.computed) {
               return '__COMPUTED_PROP__';
             }
             break;
@@ -550,6 +529,7 @@ module.exports = {
       var allNames;
       var properties;
       switch (node.type) {
+        case 'Identifier':
         case 'MemberExpression':
           name = getPropertyName(node);
           if (name) {
@@ -582,16 +562,9 @@ module.exports = {
               (node.id.properties[i].key.name === 'props' || node.id.properties[i].key.value === 'props') &&
               node.id.properties[i].value.type === 'ObjectPattern'
             );
-            // let {firstname} = props
-            var genericDestructuring = isPropAttributeName(node) && (
-                utils.getParentStatelessComponent() ||
-                isInLifeCycleMethod(node)
-            );
 
             if (thisDestructuring) {
               properties = node.id.properties[i].value.properties;
-            } else if (genericDestructuring) {
-              properties = node.id.properties;
             } else {
               continue;
             }
@@ -828,13 +801,8 @@ module.exports = {
         var destructuring = node.init && node.id && node.id.type === 'ObjectPattern';
         // let {props: {firstname}} = this
         var thisDestructuring = destructuring && node.init.type === 'ThisExpression';
-        // let {firstname} = props
-        var statelessDestructuring = destructuring && isPropAttributeName(node) && (
-            utils.getParentStatelessComponent() ||
-            isInLifeCycleMethod(node)
-        );
 
-        if (!thisDestructuring && !statelessDestructuring) {
+        if (!thisDestructuring) {
           return;
         }
         markPropTypesAsUsed(node);
@@ -848,7 +816,7 @@ module.exports = {
 
       MemberExpression: function(node) {
         var type;
-        if (isPropTypesUsage(node)) {
+        if (isPropsMemberExpression(node)) {
           type = 'usage';
         } else if (isPropTypesDeclaration(node.property)) {
           type = 'declaration';
@@ -867,6 +835,12 @@ module.exports = {
             break;
           default:
             break;
+        }
+      },
+
+      Identifier: function(node) {
+        if (isPropsIdentifier(node)) {
+          markPropTypesAsUsed(node);
         }
       },
 

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -487,16 +487,17 @@ module.exports = {
     }
 
     /**
-     * Retrieve the name of a property node
-     * @param {ASTNode} node The AST node with the property.
+     * Retrieve the name of the property of a MemberExpression given the object of the MemberExpression
+     * @param {ASTNode} node The AST node that is the object of the MemberExpression
      * @return {string} the name of the property or undefined if not found
      */
     function getPropertyName(node) {
-      var property = node.parent.property;
+      var memberExpression = node.parent;
+      var property = memberExpression.property;
       if (property) {
         switch (property.type) {
           case 'Identifier':
-            if (node.parent.computed) {
+            if (memberExpression.computed) {
               return '__COMPUTED_PROP__';
             }
             return property.name;
@@ -509,7 +510,7 @@ module.exports = {
             }
             // falls through
           default:
-            if (node.parent.computed) {
+            if (memberExpression.computed) {
               return '__COMPUTED_PROP__';
             }
             break;

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -201,7 +201,7 @@ module.exports = {
     }
 
     /**
-     * Checks if a node is an identifier referring to props
+     * Checks if a node is an identifier referring to props, by looking for common names in common locations
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if the prop name matches
      */
@@ -212,9 +212,11 @@ module.exports = {
           node.parent.type === 'VariableDeclarator'
         ) && (
           (
+            // In lifecycle methods and in stateless components, people refer to props as `props`.
             (isInLifeCycleMethod(node) || utils.getParentStatelessComponent()) &&
             node.name === 'props'
           ) || (
+            // In lifecycle methods, people can also refer to props as `nextProps` or `prevProps`.
             isInLifeCycleMethod(node) && (
               node.name === 'nextProps' ||
               node.name === 'prevProps'

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -347,12 +347,12 @@ function componentRule(rule, context) {
         var isFunction = /Function/.test(node.type); // Functions
         var isMethod = node.parent && node.parent.type === 'MethodDefinition'; // Classes methods
         var isArgument = node.parent && node.parent.type === 'CallExpression'; // Arguments (callback, etc.)
-        // Stop moving up if we reach a class or an argument (like a callback)
-        if (isClass || isArgument) {
+        // Stop moving up if we reach a class
+        if (isClass) {
           return null;
         }
-        // Return the node if it is a function that is not a class method
-        if (isFunction && !isMethod) {
+        // Return the node if it is a function that is not a class method and not a callback argument
+        if (isFunction && !isMethod && !isArgument) {
           return node;
         }
         scope = scope.upper;

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1213,33 +1213,6 @@ ruleTester.run('no-unused-prop-types', rule, {
       options: [{skipShapeProps: true}],
       parser: 'babel-eslint'
     }, {
-      // Destructured props in componentWillReceiveProps shouldn't throw errors
-      code: [
-        'class Hello extends Component {',
-        '  static propTypes = {',
-        '    something: PropTypes.bool',
-        '  }',
-        '  componentWillReceiveProps (nextProps) {',
-        '    const {something} = nextProps;',
-        '    doSomething(something);',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint'
-    }, {
-      // Destructured function props in componentWillReceiveProps shouldn't throw errors
-      code: [
-        'class Hello extends Component {',
-        '  static propTypes = {',
-        '    something: PropTypes.bool',
-        '  }',
-        '  componentWillReceiveProps ({something}) {',
-        '    doSomething(something);',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint'
-    }, {
       // Destructured props in the constructor shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1265,6 +1238,21 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  constructor ({something}) {',
         '    super({something});',
         '    doSomething(something);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // MemberExpression-accessed props in the constructor shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  constructor (props) {',
+        '    super(props);',
+        '    doSomething(props.something);',
         '  }',
         '}'
       ].join('\n'),
@@ -1300,6 +1288,20 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint',
       parserOptions: parserOptions
     }, {
+      // MemberExpression-accessed props in the `componentWillReceiveProps` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentWillReceiveProps (nextProps, nextState) {',
+        '    return nextProps.something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
       // Destructured props in the `shouldComponentUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1328,6 +1330,21 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint',
       parserOptions: parserOptions
+    }, {
+      // MemberExpression-accessed props in the `shouldComponentUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  shouldComponentUpdate (nextProps, nextState) {',
+        '    return nextProps.something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+
     }, {
       // Destructured props in the `componentWillUpdate` method shouldn't throw errors
       code: [
@@ -1358,13 +1375,27 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint',
       parserOptions: parserOptions
     }, {
+      // MemberExpression-accessed function props in the `componentWillUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentWillUpdate (nextProps, nextState) {',
+        '    return nextProps.something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
       // Destructured props in the `componentDidUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
         '  static propTypes = {',
         '    something: PropTypes.bool',
         '  }',
-        '  componentDidUpdate (prevProps, nextState) {',
+        '  componentDidUpdate (prevProps, prevState) {',
         '    const {something} = prevProps;',
         '    return something;',
         '  }',
@@ -1379,8 +1410,22 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  static propTypes = {',
         '    something: PropTypes.bool',
         '  }',
-        '  componentDidUpdate ({something}, nextState) {',
+        '  componentDidUpdate ({something}, prevState) {',
         '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    }, {
+      // MemberExpression-accessed props in the `componentDidUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    something: PropTypes.bool',
+        '  }',
+        '  componentDidUpdate (prevProps, prevState) {',
+        '    return prevProps.something;',
         '  }',
         '}'
       ].join('\n'),
@@ -2244,6 +2289,24 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  static propTypes = {',
         '    unused: PropTypes.bool',
         '  }',
+        '  componentWillReceiveProps (nextProps, nextState) {',
+        '    return nextProps.something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
         '  shouldComponentUpdate (nextProps, nextState) {',
         '    const {something} = nextProps;',
         '    return something;',
@@ -2265,6 +2328,24 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  }',
         '  shouldComponentUpdate ({something}, nextState) {',
         '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  shouldComponentUpdate (nextProps, nextState) {',
+        '    return nextProps.something;',
         '  }',
         '}'
       ].join('\n'),
@@ -2318,6 +2399,24 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  static propTypes = {',
         '    unused: PropTypes.bool',
         '  }',
+        '  componentWillUpdate (nextProps, nextState) {',
+        '    return nextProps.something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
         '  componentDidUpdate (prevProps, prevState) {',
         '    const {something} = prevProps;',
         '    return something;',
@@ -2339,6 +2438,24 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  }',
         '  componentDidUpdate ({something}, prevState) {',
         '    return something;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      parserOptions: parserOptions,
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
+        '  componentDidUpdate (prevProps, prevState) {',
+        '    return prevProps.something;',
         '  }',
         '}'
       ].join('\n'),

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1277,6 +1277,9 @@ ruleTester.run('prop-types', rule, {
         '  return names.map((name) => {',
         '    return <div>{name}</div>;',
         '  });',
+        '}',
+        'Hello.propTypes = {',
+        '  names: React.PropTypes.string',
         '}'
       ].join('\n'),
       parser: 'babel-eslint'


### PR DESCRIPTION
The most straightforward way of fixing #884 would be to add a third condition to `isPropTypesUsage` that checks if it's a `nextProps` or `prevProps` in a lifecycle method. If I did this, then I'd also have to add `nextProps` and `prevProps` to `DIRECT_PROPS_REGEX`. I didn't want to do that because it duplicates logic between `DIRECT_PROPS_REGEX` and `isPropAttributeName`.

So this PR removes the need for `DIRECT_PROPS_REGEX`.

The main idea is that before this PR, the `MemberExpression` callback caught direct access (`props.foo`) and ThisExpression access (`this.props.foo`) at different "levels" in the AST. This meant that `getPropertyName` had to have some logic to fix them up to be on the same level. I added a `Identifer` callback that catches direct access at the same level as `MemberExpression` catches ThisExpression access so that `getPropertyName` no longer needs that logic.

This change uncovered something that I think is a bug in Components.js that made one of the existing no-unused-prop-types tests start failing, so I fixed that too.
