### PR TITLE
add props to lifecycle sort group

### DIFF
--- a/docs/rules/sort-comp.md
+++ b/docs/rules/sort-comp.md
@@ -9,7 +9,7 @@ When creating React components it is more convenient to always follow the same o
 With default configuration the following organisation must be followed:
 
   1. static methods and properties
-  2. lifecycle methods: `displayName`, `propTypes`, `contextTypes`, `childContextTypes`, `mixins`, `statics`,`defaultProps`, `constructor`, `getDefaultProps`, `getInitialState`, `state`, `getChildContext`, `componentWillMount`, `componentDidMount`, `componentWillReceiveProps`, `shouldComponentUpdate`, `componentWillUpdate`, `componentDidUpdate`, `componentWillUnmount` (in this order).
+  2. lifecycle methods: `displayName`, `props`, `propTypes`, `contextTypes`, `childContextTypes`, `mixins`, `statics`,`defaultProps`, `constructor`, `getDefaultProps`, `getInitialState`, `state`, `getChildContext`, `componentWillMount`, `componentDidMount`, `componentWillReceiveProps`, `shouldComponentUpdate`, `componentWillUpdate`, `componentDidUpdate`, `componentWillUnmount` (in this order).
   3. custom methods
   4. `render` method
 
@@ -62,6 +62,7 @@ The default configuration is:
   groups: {
     lifecycle: [
       'displayName',
+      'props',
       'propTypes',
       'contextTypes',
       'childContextTypes',

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -87,6 +87,7 @@ module.exports = {
       groups: {
         lifecycle: [
           'displayName',
+          'props',
           'propTypes',
           'contextTypes',
           'childContextTypes',


### PR DESCRIPTION
When using Flow, you’ll often include types for your props like so:

``` js
class MyComponent extends Component {
  props: {
    a: number,
    b: number,
  }

  state: {
    c: number,
    d: number,
  } = {
    c: 1,
    d: 2,
  }

  ...
}
```

In such a case you will also want the `props` type definition on top of the component. This PR adds the `props` to the `sort-comp` `lifecycle` rule so that by default the `props` property will be sorted to the top. Adding a `props` property is generally not desirable in any other case but this one.
