### PR TITLE
Fix incomplete recommended configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,6 +86,9 @@ module.exports = {
   rules: exportedRules,
   configs: {
     recommended: {
+      plugin: [
+        'react'
+      ],
       parserOptions: {
         ecmaFeatures: {
           jsx: true
@@ -109,6 +112,9 @@ module.exports = {
       }
     },
     all: {
+      plugin: [
+        'react'
+      ],
       parserOptions: {
         ecmaFeatures: {
           jsx: true


### PR DESCRIPTION
This change allow you to extends "plugin:react/{something}" without having to do something more.
If you just extends one config, you get errors about missing rules definition.
