### PR TITLE
Add forbidPatterns to forbid-component-props rule

### DIFF
--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -1,6 +1,6 @@
 # Forbid certain props on Components (forbid-component-props)
 
-By default this rule prevents passing of [props that add lots of complexity](https://medium.com/brigade-engineering/don-t-pass-css-classes-between-components-e9f7ab192785) (`className`, `style`) to Components. This rule only applies to Components (e.g. `<Foo />`) and not DOM nodes (e.g. `<div />`). The list of forbidden props can be customized with the `forbid` option.
+By default this rule prevents passing of [props that add lots of complexity](https://medium.com/brigade-engineering/don-t-pass-css-classes-between-components-e9f7ab192785) (`className`, `style`) to Components. This rule only applies to Components (e.g. `<Foo />`) and not DOM nodes (e.g. `<div />`). The list of forbidden props can be customized with the `forbid` or `forbidPatterns` options.
 
 ## Rule Details
 
@@ -35,10 +35,18 @@ The following patterns are not considered warnings:
 
 ```js
 ...
-"forbid-component-props": [<enabled>, { "forbid": [<string>] }]
+"forbid-component-props": [<enabled>, { "forbid": [<string>], "forbidPatterns": [<string>], ignoreDomNodes: <boolean> }]
 ...
 ```
 
 ### `forbid`
 
 An array of strings, with the names of props that are forbidden. The default value of this option is `['className', 'style']`.
+
+### `forbidPatterns`
+
+An array of strings, with the patterns of props that are forbidden; you can use `*` as a wildcard. e.g: `['data-*', '*-foo-*']`
+
+### `ignoreDomNodes`
+
+Whether to check forbidden props on DOM nodes (div, input, span, etc...). Defaults to true

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -35,7 +35,7 @@ The following patterns are not considered warnings:
 
 ```js
 ...
-"forbid-component-props": [<enabled>, { "forbid": [<string>], "forbidPatterns": [<string>], ignoreDomNodes: <boolean> }]
+"forbid-component-props": [<enabled>, { "forbid": [<string>], "forbidPatterns": [<string>], checkDomNodes: <boolean>, ignoreComponents: <boolean> }]
 ...
 ```
 
@@ -47,6 +47,10 @@ An array of strings, with the names of props that are forbidden. The default val
 
 An array of strings, with the patterns of props that are forbidden; you can use `*` as a wildcard. e.g: `['data-*', '*-foo-*']`
 
-### `ignoreDomNodes`
+### `checkDomNodes`
 
-Whether to check forbidden props on DOM nodes (div, input, span, etc...). Defaults to true
+Whether to check forbidden props on DOM nodes (div, input, span, etc...). Defaults to false.
+
+### `ignoreComponents`
+
+Whether to skip checking forbidden props on Components (div, input, span, etc...). Defaults to false.

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -1,8 +1,11 @@
 /**
  * @fileoverview Forbid certain props on components
  * @author Joe Lencioni
+ * @author Nicolas Fernandez <@burabure>
  */
 'use strict';
+
+var sanitizeUserPattern = require('../util/sanitizeUserPattern');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -25,7 +28,16 @@ module.exports = {
     schema: [{
       type: 'object',
       properties: {
+        ignoreDomNodes: {
+          type: 'boolean'
+        },
         forbid: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        },
+        forbidPatterns: {
           type: 'array',
           items: {
             type: 'string'
@@ -37,18 +49,38 @@ module.exports = {
   },
 
   create: function(context) {
+    var configuration = context.options[0] || {};
+    var ignoreDomNodes = configuration.ignoreDomNodes !== false;
+
+    function somePatternMatches(patterns, subject) {
+      return patterns.reduce(function (acc, pattern) {
+        if (sanitizeUserPattern(pattern).test(subject)) {
+          return true;
+        }
+        return acc;
+      }, false);
+    }
 
     function isForbidden(prop) {
-      var configuration = context.options[0] || {};
-
       var forbid = configuration.forbid || DEFAULTS;
-      return forbid.indexOf(prop) >= 0;
+      var forbidPatterns = configuration.forbidPatterns;
+      if (forbid.indexOf(prop) >= 0) {
+        return true;
+      }
+
+      if (forbidPatterns) {
+        if (somePatternMatches(forbidPatterns, prop)) {
+          return true;
+        }
+      }
+
+      return false;
     }
 
     return {
       JSXAttribute: function(node) {
         var tag = node.parent.name.name;
-        if (tag && tag[0] !== tag[0].toUpperCase()) {
+        if (ignoreDomNodes && tag && tag[0] !== tag[0].toUpperCase()) {
           // This is a DOM node, not a Component, so exit.
           return;
         }

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -28,7 +28,7 @@ module.exports = {
     schema: [{
       type: 'object',
       properties: {
-        ignoreDomNodes: {
+        checkDomNodes: {
           type: 'boolean'
         },
         forbid: {
@@ -50,7 +50,8 @@ module.exports = {
 
   create: function(context) {
     var configuration = context.options[0] || {};
-    var ignoreDomNodes = configuration.ignoreDomNodes !== false;
+    var checkDomNodes = configuration.checkDomNodes || false;
+    var ignoreComponents = configuration.ignoreComponents || false;
 
     function somePatternMatches(patterns, subject) {
       return patterns.reduce(function (acc, pattern) {
@@ -80,8 +81,15 @@ module.exports = {
     return {
       JSXAttribute: function(node) {
         var tag = node.parent.name.name;
-        if (ignoreDomNodes && tag && tag[0] !== tag[0].toUpperCase()) {
-          // This is a DOM node, not a Component, so exit.
+        var isComponent = tag && tag[0] === tag[0].toUpperCase();
+
+        if (!isComponent && !checkDomNodes) {
+          // This is a DOM node, we're not checking these.
+          return;
+        }
+
+        if (isComponent && ignoreComponents) {
+          // This is a Component, we're not checking these.
           return;
         }
 

--- a/lib/util/escapeRegExp.js
+++ b/lib/util/escapeRegExp.js
@@ -1,0 +1,43 @@
+/**
+ * Escapes RegExp special characters from a string
+ *
+ * Referring to the table here:
+ * https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/regexp
+ * these characters should be escaped
+ * \ ^ $ * + ? . ( ) | { } [ ]
+ * These characters only have special meaning inside of brackets
+ * they do not need to be escaped, but they MAY be escaped
+ * without any adverse effects (to the best of my knowledge and casual testing)
+ * : ! , =
+* my test "~!@#$%^&*(){}[]`/=?+\|-_;:'\",<.>".match(/[\#]/g)
+*/
+'use strict';
+
+var specials = [
+  // order matters for these
+  '-',
+  '[',
+  ']',
+  // order doesn't matter for any of these
+  '/',
+  '{',
+  '}',
+  '(',
+  ')',
+  '*',
+  '+',
+  '?',
+  '.',
+  '\\',
+  '^',
+  '$',
+  '|'
+];
+
+// I choose to escape every character with '\'
+// even though only some strictly require it when inside of []
+var regex = RegExp('[' + specials.join('\\') + ']', 'g');
+
+module.exports = function (str) {
+  return str.replace(regex, '\\$&');
+};

--- a/lib/util/sanitizeUserPattern.js
+++ b/lib/util/sanitizeUserPattern.js
@@ -1,0 +1,11 @@
+/**
+ * Takes an unsafe user pattern String and returns a safe RegExp
+ */
+'use strict';
+
+var escapeRegExp = require('./escapeRegExp');
+
+module.exports = function (str) {
+  var safeString = escapeRegExp(str).replace('\\*', '.*');
+  return RegExp('^' + safeString + '$');
+};

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -119,6 +119,17 @@ ruleTester.run('forbid-component-props', rule, {
     ].join('\n'),
     options: [{forbidPatterns: ['data-*', 'custom-*']}],
     parserOptions: parserOptions
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo bar="baz"/>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{forbid: ['bar'], ignoreComponents: true}],
+    parserOptions: parserOptions
   }],
 
   invalid: [{
@@ -239,7 +250,7 @@ ruleTester.run('forbid-component-props', rule, {
     options: [{
       forbid: ['className', 'style'],
       forbidPatterns: ['data-*', 'custom-*'],
-      ignoreDomNodes: false
+      checkDomNodes: true
     }],
     errors: [{
       message: STYLE_ERROR_MESSAGE,

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -108,6 +108,17 @@ ruleTester.run('forbid-component-props', rule, {
       ');'
     ].join('\n'),
     parserOptions: parserOptions
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo bar="baz"/>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{forbidPatterns: ['data-*', 'custom-*']}],
+    parserOptions: parserOptions
   }],
 
   invalid: [{
@@ -174,6 +185,71 @@ ruleTester.run('forbid-component-props', rule, {
       message: STYLE_ERROR_MESSAGE,
       line: 4,
       column: 17,
+      type: 'JSXAttribute'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo data-indicators />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: [{forbidPatterns: ['data-*', 'custom-*']}],
+    errors: [{
+      message: 'Prop `data-indicators` is forbidden on Components',
+      line: 4,
+      column: 17,
+      type: 'JSXAttribute'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <Foo style={{color: "red"}} data-indicators />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: [{forbid: ['className', 'style'], forbidPatterns: ['data-*', 'custom-*']}],
+    errors: [{
+      message: STYLE_ERROR_MESSAGE,
+      line: 4,
+      column: 17,
+      type: 'JSXAttribute'
+    }, {
+      message: 'Prop `data-indicators` is forbidden on Components',
+      line: 4,
+      column: 40,
+      type: 'JSXAttribute'
+    }]
+  }, {
+    code: [
+      'var First = React.createClass({',
+      '  propTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <div style={{color: "red"}} data-indicators />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    options: [{
+      forbid: ['className', 'style'],
+      forbidPatterns: ['data-*', 'custom-*'],
+      ignoreDomNodes: false
+    }],
+    errors: [{
+      message: STYLE_ERROR_MESSAGE,
+      line: 4,
+      column: 17,
+      type: 'JSXAttribute'
+    }, {
+      message: 'Prop `data-indicators` is forbidden on Components',
+      line: 4,
+      column: 40,
       type: 'JSXAttribute'
     }]
   }]


### PR DESCRIPTION
Adds a forbidPatterns option that takes an array of regexp strings so it's possible to forbid the use of things like `data-*` props