### PR TITLE
Fix jsx-indent bug on multiline ternary

### DIFF
--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -193,7 +193,8 @@ module.exports = {
         node.parent &&
         node.parent.parent &&
         node.parent.parent.type === 'ConditionalExpression' &&
-        node.parent.parent.alternate === node.parent
+        node.parent.parent.alternate === node.parent &&
+        sourceCode.getTokenBefore(node).value !== '('
       );
     }
 

--- a/tests/lib/rules/jsx-indent.js
+++ b/tests/lib/rules/jsx-indent.js
@@ -215,6 +215,30 @@ ruleTester.run('jsx-indent', rule, {
       '</div>'
     ].join('\n'),
     parserOptions: parserOptions
+  }, {
+    code: [
+      '<div>',
+      '    { this.props.asd.length > 0 ? <Button className="bacon-yay">{this.props.asd.length}</Button> : (',
+      '        <span className="bacon-no-trigger">0</span>',
+      '    ) }',
+      '</div>'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      '<div>',
+      '    {',
+      '      this.props.asd.length > 0',
+      '        ? (',
+      '            <Button className="bacon-yay">{this.props.asd.length}</Button>',
+      '        )',
+      '        : (',
+      '            <span className="bacon-no-trigger">0</span>',
+      '        )',
+      '    }',
+      '</div>'
+    ].join('\n'),
+    parserOptions: parserOptions
   }],
 
   invalid: [{
@@ -503,6 +527,64 @@ ruleTester.run('jsx-indent', rule, {
       message: 'Expected indentation of 8 space characters but found 4.',
       line: 4,
       column: 5
+    }]
+  }, {
+    code: [
+      '<div>',
+      '    {this.props.asd.length > 0 ? <Button className="bacon-yay">{this.props.asd.length}</Button> : (',
+      '    <span className="bacon-no-trigger">0</span>',
+      '    )}',
+      '</div>'
+    ].join('\n'),
+    output: [
+      '<div>',
+      '    {this.props.asd.length > 0 ? <Button className="bacon-yay">{this.props.asd.length}</Button> : (',
+      '        <span className="bacon-no-trigger">0</span>',
+      '    )}',
+      '</div>'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Expected indentation of 8 space characters but found 4.',
+      line: 3,
+      column: 5
+    }]
+  }, {
+    code: [
+      '<div>',
+      '    {',
+      '      this.props.asd.length > 0',
+      '        ? (',
+      '        <Button className="bacon-yay">{this.props.asd.length}</Button>',
+      '        )',
+      '        : (',
+      '              <span className="bacon-no-trigger">0</span>',
+      '        )',
+      '    }',
+      '</div>'
+    ].join('\n'),
+    output: [
+      '<div>',
+      '    {',
+      '      this.props.asd.length > 0',
+      '        ? (',
+      '            <Button className="bacon-yay">{this.props.asd.length}</Button>',
+      '        )',
+      '        : (',
+      '            <span className="bacon-no-trigger">0</span>',
+      '        )',
+      '    }',
+      '</div>'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Expected indentation of 12 space characters but found 8.',
+      line: 5,
+      column: 9
+    }, {
+      message: 'Expected indentation of 12 space characters but found 14.',
+      line: 8,
+      column: 15
     }]
   }]
 });


### PR DESCRIPTION
This PR is an attempt at fixing #945.

I'm no master at ESLint or it's parser, but adding some new tests and looking at the AST and figuring out what it would take to make the new test pass while not breaking the tests from  https://github.com/yannickcr/eslint-plugin-react/commit/d88ee379079cee18e3bc718dddc7dfc1c91bee1c gave the following solution.

I also ran this version of the module against my large react project and all errors that occurred with `6.6.0` was then gone.