### PR TITLE
skipShapeProps should be enabled by default until it works properly

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -47,9 +47,10 @@ module.exports = {
 
   create: Components.detect(function(context, components, utils) {
 
+    var defaults = {skipShapeProps: true};
     var sourceCode = context.getSourceCode();
-    var configuration = context.options[0] || {};
-    var skipShapeProps = configuration.skipShapeProps || false;
+    var configuration = Object.assign({}, defaults, context.options[0] || {});
+    var skipShapeProps = configuration.skipShapeProps;
     var customValidators = configuration.customValidators || [];
     // Used to track the type annotations in scope.
     // Necessary because babel's scopes do not track type annotations.

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -257,6 +257,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  b: React.PropTypes.string',
         '});'
       ].join('\n'),
+      options: [{skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -274,6 +275,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};',
         'Hello.propTypes.a.b.c = React.PropTypes.number;'
       ].join('\n'),
+      options: [{skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -295,6 +297,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  )',
         '};'
       ].join('\n'),
+      options: [{skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -318,6 +321,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  )',
         '};'
       ].join('\n'),
+      options: [{skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -358,6 +362,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  ])',
         '};'
       ].join('\n'),
+      options: [{skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -458,6 +463,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  )',
         '};'
       ].join('\n'),
+      options: [{skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -490,6 +496,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  })',
         '};'
       ].join('\n'),
+      options: [{skipShapeProps: false}],
       parser: 'babel-eslint'
     }, {
       code: [
@@ -540,7 +547,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  }',
         '});'
       ].join('\n'),
-      options: [{customValidators: ['CustomValidator']}],
+      options: [{customValidators: ['CustomValidator'], skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -555,7 +562,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  }',
         '});'
       ].join('\n'),
-      options: [{customValidators: ['CustomValidator']}],
+      options: [{customValidators: ['CustomValidator'], skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -570,7 +577,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  }',
         '});'
       ].join('\n'),
-      options: [{customValidators: ['CustomValidator']}],
+      options: [{customValidators: ['CustomValidator'], skipShapeProps: false}],
       parserOptions: parserOptions
     }, {
       code: [
@@ -1195,7 +1202,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
-      // Destructured shape props can't be tested, unless we use `skipShapeProps`
+      // Destructured shape props are skipped by default
       code: [
         'class Hello extends Component {',
         '  static propTypes = {',
@@ -1210,7 +1217,6 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  }',
         '}'
       ].join('\n'),
-      options: [{skipShapeProps: true}],
       parser: 'babel-eslint'
     }, {
       // Destructured props in componentWillReceiveProps shouldn't throw errors
@@ -1570,6 +1576,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       parserOptions: parserOptions,
+      options: [{skipShapeProps: false}],
       errors: [{
         message: '\'a.b\' PropType is defined but prop is never used'
       }]
@@ -1590,6 +1597,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       parserOptions: parserOptions,
+      options: [{skipShapeProps: false}],
       errors: [{
         message: '\'a.b.c\' PropType is defined but prop is never used'
       }]
@@ -1612,6 +1620,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       parserOptions: parserOptions,
+      options: [{skipShapeProps: false}],
       errors: [
         {message: '\'a.*.unused\' PropType is defined but prop is never used'}
       ]
@@ -1636,6 +1645,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       parserOptions: parserOptions,
+      options: [{skipShapeProps: false}],
       errors: [
         {message: '\'a.*.unused\' PropType is defined but prop is never used'}
       ]
@@ -1662,6 +1672,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       parserOptions: parserOptions,
+      options: [{skipShapeProps: false}],
       errors: [
         {message: '\'a.unused\' PropType is defined but prop is never used'},
         {message: '\'a.anotherunused\' PropType is defined but prop is never used'}
@@ -1699,6 +1710,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       parserOptions: parserOptions,
+      options: [{skipShapeProps: false}],
       errors: [
         {message: '\'arr.*.some.unused\' PropType is defined but prop is never used'}
       ]


### PR DESCRIPTION
The option `no-unused-prop-types` doesn't work properly for shape proptypes in lots of popular cases: #851, #819 and other cases, like when used outside of the component class.

This causes very annoying inconviences.

So currently the option only works without problems if the `skipShapeProps` is set to `true`. Therefore it's best to skip linting shape props by default until the mentioned problems are fixed and setting this option to false actually becomes useful.