### PR TITLE
Fix `jsx-tag-spacing` crash when options object isn't passed

### DIFF
--- a/lib/rules/jsx-tag-spacing.js
+++ b/lib/rules/jsx-tag-spacing.js
@@ -204,9 +204,11 @@ module.exports = {
       beforeSelfClosing: 'always',
       afterOpening: 'never'
     };
-    for (var key in options) {
-      if (options.hasOwnProperty(key) && context.options[0].hasOwnProperty(key)) {
-        options[key] = context.options[0][key];
+    if (context.options[0]) {
+      for (var key in options) {
+        if (options.hasOwnProperty(key) && context.options[0].hasOwnProperty(key)) {
+          options[key] = context.options[0][key];
+        }
       }
     }
 


### PR DESCRIPTION
Fixes #955 