### PR TITLE
Bug Repro: Unused PropTypes detects flow destructuring

### DIFF
--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1096,6 +1096,30 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: parsers.BABEL_ESLINT
     }, {
       code: [
+        'type Props = {notTarget: string};',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  onEvent({ target }: { target: Object }) {};',
+        '  render () {',
+        '    return <div>Hello {this.props.notTarget}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: parsers.BABEL_ESLINT
+    }, {
+      code: [
+        'type Props = {notTarget: string};',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  onEvent(infos: { target: Object }) {};',
+        '  render () {',
+        '    return <div>Hello {this.props.notTarget}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: parsers.BABEL_ESLINT
+    }, {
+      code: [
         'class Hello extends React.Component {',
         '  props = {a: 123};',
         '  render () {',
@@ -5081,6 +5105,21 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'person.lastname\' PropType is defined but prop is never used'
       }]
+    }, {
+      code: [
+        'type Props = {notTarget: string, unused: string};',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  onEvent = ({ target }: { target: Object }) => {};',
+        '  render () {',
+        '    return <div>Hello {this.props.notTarget}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: parsers.BABEL_ESLINT,
+      errors: [
+        {message: '\'unused\' PropType is defined but prop is never used'}
+      ]
     }, {
       code: `
         import PropTypes from 'prop-types';


### PR DESCRIPTION
Hello! I figured I would open a PR instead of an issue to be able to show the two failing test cases.

The first, should pass because notTarget is used. But it fails with `'target' PropType is defined but prop is never used`. It seems like it takes the destructuring as the props instead of the `props: Props`. Note that this is fine if instead of destructuring `{ target }` I do a simple argument like `infos` (added a test case to show).

```
type Props = {notTarget: string};
class Hello extends React.Component {
  props: Props;
  onEvent({ target }: { target: Object }) {};
  //   onEvent(infos: { target: Object }) {}; passes
  render () {
    return <div>Hello {this.props.notTarget}</div>;
  }
}
```


And on the invalid side, I added a similar test case with two props, one unused, but it fails on the wrong prop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yannickcr/eslint-plugin-react/977)
<!-- Reviewable:end -->
