### PR TITLE
jsx-sort-props noSortAlphabetically option

### DIFF
--- a/docs/rules/jsx-sort-props.md
+++ b/docs/rules/jsx-sort-props.md
@@ -27,7 +27,8 @@ The following patterns are considered okay and do not cause warnings:
   "callbacksLast": <boolean>,
   "shorthandFirst": <boolean>,
   "shorthandLast": <boolean>,
-  "ignoreCase": <boolean>
+  "ignoreCase": <boolean>,
+  "noSortAlphabetically": <boolean>
 }]
 ...
 ```
@@ -64,6 +65,14 @@ When `true`, short hand props must be listed after all other props (unless `call
 
 ```js
 <Hello name="John" tel={5555555} active validate />
+```
+
+### `noSortAlphabetically`
+
+When `true`, alphabetical order is not enforced:
+
+```js
+<Hello tel={5555555} name="John" />
 ```
 
 ## When not to use

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -40,6 +40,10 @@ module.exports = {
         },
         ignoreCase: {
           type: 'boolean'
+        },
+        // Whether alphabetical sorting should be enforced
+        noSortAlphabetically: {
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -53,6 +57,7 @@ module.exports = {
     var callbacksLast = configuration.callbacksLast || false;
     var shorthandFirst = configuration.shorthandFirst || false;
     var shorthandLast = configuration.shorthandLast || false;
+    var noSortAlphabetically = configuration.noSortAlphabetically || false;
 
     return {
       JSXOpeningElement: function(node) {
@@ -114,7 +119,7 @@ module.exports = {
             }
           }
 
-          if (currentPropName < previousPropName) {
+          if (!noSortAlphabetically && currentPropName < previousPropName) {
             context.report({
               node: decl,
               message: 'Props should be sorted alphabetically'

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -57,6 +57,12 @@ var shorthandAndCallbackLastArgs = [{
 var ignoreCaseArgs = [{
   ignoreCase: true
 }];
+var noSortAlphabeticallyArgs = [{
+  noSortAlphabetically: true
+}];
+var sortAlphabeticallyArgs = [{
+  noSortAlphabetically: false
+}];
 
 ruleTester.run('jsx-sort-props', rule, {
   valid: [
@@ -84,7 +90,10 @@ ruleTester.run('jsx-sort-props', rule, {
       code: '<App a="a" b="b" x y z onBar onFoo />;',
       options: shorthandAndCallbackLastArgs,
       parserOptions: parserOptions
-    }
+    },
+    // noSortAlphabetically
+    {code: '<App a b />;', options: noSortAlphabeticallyArgs, parserOptions: parserOptions},
+    {code: '<App b a />;', options: noSortAlphabeticallyArgs, parserOptions: parserOptions}
   ],
   invalid: [
     {code: '<App b a />;', errors: [expectedError], parserOptions: parserOptions},
@@ -122,6 +131,7 @@ ruleTester.run('jsx-sort-props', rule, {
       errors: [shorthandAndCallbackLastArgs],
       options: shorthandLastArgs,
       parserOptions: parserOptions
-    }
+    },
+    {code: '<App b a />;', errors: [expectedError], options: sortAlphabeticallyArgs, parserOptions: parserOptions}
   ]
 });


### PR DESCRIPTION
Adds a `noSortAlphabetically ` option to `jsx-sort-props` which will allow sorting of callbacks last without forcing alphabetical ordering.

Closes #541
Closes #786