### PR TITLE
#961 support flow variance syntax

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -271,8 +271,11 @@ module.exports = {
      */
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
-        var tokens = context.getFirstTokens(node, 1);
-        return tokens[0].value;
+        var tokens = context.getFirstTokens(node, 2);
+        return (tokens[0].value === '+' || tokens[0].value === '-'
+          ? tokens[1].value
+          : tokens[0].value
+        );
       }
       var key = node.key || node.argument;
       return key.type === 'Identifier' ? key.name : key.value;

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1385,6 +1385,19 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Flow annotations with variance
+      code: [
+        'type Props = {',
+        '  +firstname: string;',
+        '  -lastname: string;',
+        '};',
+        'function Hello(props: Props): React.Element {',
+        '  const {firstname, lastname} = props;',
+        '  return <div>Hello {firstname} {lastname}</div>',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
     }
   ],
 
@@ -2471,6 +2484,52 @@ ruleTester.run('prop-types', rule, {
         line: 3,
         column: 29
       }]
+    }, {
+      code: [
+        'type MyComponentProps = {',
+        '  +a: number,',
+        '};',
+        'function MyComponent({ a, b }: MyComponentProps) {',
+        '  return <div />;',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'b\' is missing in props validation',
+        line: 4,
+        column: 27,
+        type: 'Property'
+      }]
+    }, {
+      code: [
+        'type MyComponentProps = {',
+        '  -a: number,',
+        '};',
+        'function MyComponent({ a, b }: MyComponentProps) {',
+        '  return <div />;',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'b\' is missing in props validation',
+        line: 4,
+        column: 27,
+        type: 'Property'
+      }]
+    }, {
+      code: [
+        'type Props = {+name: Object;};',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [
+        {message: '\'firstname\' is missing in props validation'}
+      ]
     }
   ]
 });


### PR DESCRIPTION
Fixes #961 

It looks like getKeyValue was naively grabbing the first token for `'ObjectTypeProperty'`, which was sometimes a '+'.  There's probably a more robust solution, but I've just opted to account for `'+'` and `'-'` as possible tokens that might be encountered.