### PR TITLE
Add no-common-typos rule

### DIFF
--- a/lib/rules/no-common-typos.js
+++ b/lib/rules/no-common-typos.js
@@ -18,9 +18,6 @@ var PATTERN_REGEXP = new RegExp('^/(.+)/(.+)?$');
  * @return {RegExp}
  */
 function parsePattern(pattern) {
-  if (pattern instanceof RegExp) {
-    return pattern;
-  }
   if (PATTERN_REGEXP.exec(pattern)) {
     return new RegExp(RegExp.$1, RegExp.$2);
   }

--- a/lib/rules/no-common-typos.js
+++ b/lib/rules/no-common-typos.js
@@ -40,10 +40,7 @@ module.exports = {
         type: 'object',
         properties: {
           pattern: {
-            oneOf: [
-              { type: 'string' },
-              { type: 'object' }
-            ]
+            type: 'string'
           },
           correct: {
             type: 'string'

--- a/lib/rules/no-common-typos.js
+++ b/lib/rules/no-common-typos.js
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Warn for common attribute typos.
+ * @author Koen Punt
+ */
+'use strict';
+
+var Components = require('../util/Components');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+var PATTERN_REGEXP = new RegExp('^/(.+)/(.+)?$');
+
+/**
+ * Convert pattern string to a regular expression.
+ * @param {String|RegExp} string regex
+ * @return {RegExp}
+ */
+function parsePattern(pattern) {
+  if (pattern instanceof RegExp) {
+    return pattern;
+  }
+  if (PATTERN_REGEXP.exec(pattern)) {
+    return new RegExp(RegExp.$1, RegExp.$2);
+  }
+  return new RegExp('^' + pattern + '$');
+}
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Warn for common attribute typos.',
+      category: 'Possible Errors',
+      recommended: false
+    },
+    schema: [{
+      type: 'object',
+      rules: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            pattern: {
+              type: 'string'
+            },
+            correct: {
+              type: 'string'
+            }
+          },
+          additionalProperties: false
+        }
+      }
+    }],
+    fixable: 'code'
+  },
+
+  create: Components.detect(function(context) {
+
+    var rules = context.options || [];
+
+    /**
+     * Checks if we are using an incorrect cased dangerouslySetInnerHTML attribute.
+     * @param {ASTNode} node The AST node being checked.
+     * @returns {Boolean} True if we are using a ref attribute, false if not.
+     */
+    function isIncorrectAttributeName(regex, correct, node) {
+      return Boolean(
+        node.type === 'JSXAttribute' &&
+        node.name &&
+        node.name.name !== correct &&
+        regex.test(node.name.name)
+      );
+    }
+
+    return {
+      JSXAttribute: function(node) {
+        rules.forEach(function(rule) {
+          var regex = parsePattern(rule.pattern);
+          if (isIncorrectAttributeName(regex, rule.correct, node)) {
+            var attribute = node.name.name;
+            context.report({
+              node: node,
+              message: 'Using possible incorrect attribute `' + attribute + '`, did you mean `' + rule.correct + '`?',
+              fix: function(fixer) {
+                return fixer.replaceText(attribute, rule.correct);
+              }
+            });
+          }
+        });
+      }
+    };
+  })
+};

--- a/lib/rules/no-common-typos.js
+++ b/lib/rules/no-common-typos.js
@@ -35,21 +35,18 @@ module.exports = {
       recommended: false
     },
     schema: [{
-      type: 'object',
-      rules: {
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: {
-            pattern: {
-              type: 'string'
-            },
-            correct: {
-              type: 'string'
-            }
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          pattern: {
+            type: 'string'
           },
-          additionalProperties: false
-        }
+          correct: {
+            type: 'string'
+          }
+        },
+        additionalProperties: false
       }
     }],
     fixable: 'code'
@@ -60,9 +57,9 @@ module.exports = {
     var rules = context.options || [];
 
     /**
-     * Checks if we are using an incorrect cased dangerouslySetInnerHTML attribute.
+     * Checks if we are using an an incorrect attribute name.
      * @param {ASTNode} node The AST node being checked.
-     * @returns {Boolean} True if we are using a ref attribute, false if not.
+     * @returns {Boolean} True if an incorrect attribute name is used, false if not.
      */
     function isIncorrectAttributeName(regex, correct, node) {
       return Boolean(

--- a/lib/rules/no-common-typos.js
+++ b/lib/rules/no-common-typos.js
@@ -57,7 +57,7 @@ module.exports = {
 
   create: Components.detect(function(context) {
 
-    var rules = context.options || [];
+    var rules = context.options[0] || [];
 
     /**
      * Checks if we are using an an incorrect attribute name.

--- a/lib/rules/no-common-typos.js
+++ b/lib/rules/no-common-typos.js
@@ -40,7 +40,10 @@ module.exports = {
         type: 'object',
         properties: {
           pattern: {
-            type: 'string'
+            oneOf: [
+              { type: 'string' },
+              { type: 'object' }
+            ]
           },
           correct: {
             type: 'string'

--- a/tests/lib/rules/no-common-typos.js
+++ b/tests/lib/rules/no-common-typos.js
@@ -18,10 +18,12 @@ require('babel-eslint');
 // ------------------------------------------------------------------------------
 
 var options = [
-  {
-    pattern: /dangerouslySetInnerHTML/i,
-    correct: 'dangerouslySetInnerHTML'
-  }
+  [
+    {
+      pattern: /dangerouslySetInnerHTML/i,
+      correct: 'dangerouslySetInnerHTML'
+    }
+  ]
 ];
 
 var ruleTester = new RuleTester();

--- a/tests/lib/rules/no-common-typos.js
+++ b/tests/lib/rules/no-common-typos.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Warn for common attribute typos.
+ * @author Koen Punt
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/no-common-typos');
+var RuleTester = require('eslint').RuleTester;
+
+require('babel-eslint');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var options = [
+  {
+    pattern: /dangerouslySetInnerHTML/i,
+    correct: 'dangerouslySetInnerHTML'
+  }
+];
+
+var ruleTester = new RuleTester();
+ruleTester.run('no-common-typos', rule, {
+
+  valid: [{
+    code: [
+      'var Hello = React.createClass({',
+      '  render: function() {',
+      '    return <div dangerouslySetInnerHTML={{__html: "Hello World"}}/>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: options,
+    parser: 'babel-eslint',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+  ],
+
+  invalid: [{
+    code: [
+      'var Hello = React.createClass({',
+      '  render: function() {',
+      '    return <div dangerouslySetInnerHtml={{__html: "Hello World"}}/>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: options,
+    parser: 'babel-eslint',
+    ecmaFeatures: {
+      classes: true,
+      jsx: true
+    },
+    errors: [{
+      message: 'Using possible incorrect attribute `dangerouslySetInnerHtml`, did you mean `dangerouslySetInnerHTML`?'
+    }]
+  }]
+});

--- a/tests/lib/rules/no-common-typos.js
+++ b/tests/lib/rules/no-common-typos.js
@@ -26,6 +26,13 @@ var options = [
   ]
 ];
 
+var parserOptions = {
+  ecmaVersion: 6,
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
 var ruleTester = new RuleTester();
 ruleTester.run('no-common-typos', rule, {
 
@@ -38,12 +45,8 @@ ruleTester.run('no-common-typos', rule, {
       '});'
     ].join('\n'),
     options: options,
-    parser: 'babel-eslint',
-    ecmaFeatures: {
-      jsx: true
-    }
-  }
-  ],
+    parserOptions: parserOptions
+  }],
 
   invalid: [{
     code: [
@@ -54,10 +57,7 @@ ruleTester.run('no-common-typos', rule, {
       '});'
     ].join('\n'),
     options: options,
-    parser: 'babel-eslint',
-    ecmaFeatures: {
-      jsx: true
-    },
+    parserOptions: parserOptions,
     errors: [{
       message: 'Using possible incorrect attribute `dangerouslySetInnerHtml`, did you mean `dangerouslySetInnerHTML`?'
     }]

--- a/tests/lib/rules/no-common-typos.js
+++ b/tests/lib/rules/no-common-typos.js
@@ -20,7 +20,7 @@ require('babel-eslint');
 var options = [
   [
     {
-      pattern: /dangerouslySetInnerHTML/i,
+      pattern: '/dangerouslySetInnerHTML/i',
       correct: 'dangerouslySetInnerHTML'
     }
   ]

--- a/tests/lib/rules/no-common-typos.js
+++ b/tests/lib/rules/no-common-typos.js
@@ -56,7 +56,6 @@ ruleTester.run('no-common-typos', rule, {
     options: options,
     parser: 'babel-eslint',
     ecmaFeatures: {
-      classes: true,
       jsx: true
     },
     errors: [{


### PR DESCRIPTION
I had it quite some time that I incorrectly used `dangerouslySetInnerHtml` instead of `dangerouslySetInnerHTML`. 
To prevent certain typos I introduce a rule for which you can set a pattern and the corrected string.

I can imagine this might not only apply to attributes, in which case this rule could be extended to also validate props and other variables.

**Todo:**
- [ ] Documentation