### PR TITLE
Fix `plugin` typo in configs

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = {
   rules: allRules,
   configs: {
     recommended: {
-      plugin: [
+      plugins: [
         'react'
       ],
       parserOptions: {
@@ -120,7 +120,7 @@ module.exports = {
       }
     },
     all: {
-      plugin: [
+      plugins: [
         'react'
       ],
       parserOptions: {


### PR DESCRIPTION
ESLint looks for the `plugins` config property. Currently, if you extend `plugin:react/recommended` you still need to add `plugins: ['react']`.

This commit fixes the typo, so you no longer need to add the plugins prop when you extend `recommended` or `all` configs.

Before:
```
 1:1  error  Definition for rule 'react/no-find-dom-node' was not found          react/no-find-dom-node
 1:1  error  Definition for rule 'react/display-name' was not found              react/display-name
 1:1  error  Definition for rule 'react/jsx-no-undef' was not found              react/jsx-no-undef
```

After:
```
 28:21  error  'items' is missing in props validation      react/prop-types
 28:27  error  'items.map' is missing in props validation  react/prop-types
```