### PR TITLE
Update jsx-closing-bracket-location.md

### DIFF
--- a/docs/rules/jsx-closing-bracket-location.md
+++ b/docs/rules/jsx-closing-bracket-location.md
@@ -116,6 +116,17 @@ var x = function() {
 // 'jsx-closing-bracket-location': [1, 'after-props']
 <Hello 
   firstName="John"
+  lastName="Smith" />;
+
+<Say
+  firstName="John"
+  lastName="Smith">
+  Hello
+</Say>;
+
+// 'jsx-closing-bracket-location': [1, 'props-aligned']
+<Hello 
+  firstName="John"
   lastName="Smith"
   />;
 
@@ -123,17 +134,6 @@ var x = function() {
   firstName="John"
   lastName="Smith"
 >
-  Hello
-</Say>;
-
-// 'jsx-closing-bracket-location': [1, 'props-aligned']
-<Hello 
-  firstName="John"
-  lastName="Smith" />;
-
-<Say
-  firstName="John"
-  lastName="Smith">
   Hello
 </Say>;
 ```

--- a/docs/rules/jsx-closing-bracket-location.md
+++ b/docs/rules/jsx-closing-bracket-location.md
@@ -133,7 +133,7 @@ var x = function() {
 <Say
   firstName="John"
   lastName="Smith"
->
+  >
   Hello
 </Say>;
 ```


### PR DESCRIPTION
the examples of 'after-props' and 'props-aligned' is wrong,  so it should change position them