### PR TITLE
react/jsx-no-undef allowGlobals option

### DIFF
--- a/docs/rules/jsx-no-undef.md
+++ b/docs/rules/jsx-no-undef.md
@@ -10,12 +10,47 @@ The following patterns are considered warnings:
 <Hello name="John" />;
 ```
 
+```jsx
+// will ignore Text in the global scope and warn
+var Hello = React.createClass({
+  render: function() {
+    return <Text>Hello</Text>;
+  }
+});
+module.exports = Hello;
+```
+
+
 The following patterns are not considered warnings:
 
 ```jsx
 var Hello = require('./Hello');
 
 <Hello name="John" />;
+```
+
+## Rule Options
+
+```js
+...
+"react/jsx-no-undef": [<enabled>, { "allowGlobals": <boolean> }]
+...
+```
+
+### `allowGlobals`
+
+When `true` the rule will consider the global scope when checking for defined Components.
+
+The following patterns are considered okay and do not cause warnings:
+
+```jsx
+var Text = require('./Text');
+var Hello = React.createClass({
+  render: function() {
+    return <Text>Hello</Text>;
+  }
+});
+module.exports = Hello;
 ```
 
 ## When Not To Use It

--- a/lib/rules/jsx-no-undef.js
+++ b/lib/rules/jsx-no-undef.js
@@ -26,10 +26,21 @@ module.exports = {
       category: 'Possible Errors',
       recommended: true
     },
-    schema: []
+    schema: [{
+      type: 'object',
+      properties: {
+        allowGlobals: {
+          type: 'boolean'
+        }
+      },
+      additionalProperties: false
+    }]
   },
 
   create: function(context) {
+
+    var config = context.options[0] || {};
+    var allowGlobals = config.allowGlobals || false;
 
     /**
      * Compare an identifier with the variables declared in the scope
@@ -38,7 +49,10 @@ module.exports = {
      */
     function checkIdentifierInJSX(node) {
       var scope = context.getScope();
+      var sourceCode = context.getSourceCode();
+      var sourceType = sourceCode.ast.sourceType;
       var variables = scope.variables;
+      var scopeType = 'global';
       var i;
       var len;
 
@@ -47,7 +61,11 @@ module.exports = {
         return;
       }
 
-      while (scope.type !== 'global') {
+      if (!allowGlobals && sourceType === 'module') {
+        scopeType = 'module';
+      }
+
+      while (scope.type !== scopeType) {
         scope = scope.upper;
         variables = scope.variables.concat(variables);
       }

--- a/tests/lib/rules/jsx-no-undef.js
+++ b/tests/lib/rules/jsx-no-undef.js
@@ -56,6 +56,26 @@ ruleTester.run('jsx-no-undef', rule, {
       '}'
     ].join('\n'),
     parserOptions: parserOptions
+  }, {
+    code: 'var React; React.render(<Text />);',
+    parserOptions: parserOptions,
+    globals: {
+      Text: true
+    }
+  }, {
+    code: [
+      'import Text from "cool-module";',
+      'const TextWrapper = function (props) {',
+      '  return (',
+      '    <Text />',
+      '  );',
+      '};'
+    ].join('\n'),
+    options: [{
+      allowGlobals: false
+    }],
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
   }],
   invalid: [{
     code: '/*eslint no-undef:1*/ var React; React.render(<App />);',
@@ -85,6 +105,32 @@ ruleTester.run('jsx-no-undef', rule, {
     code: '/*eslint no-undef:1*/ var React; React.render(<appp.foo.Bar />);',
     errors: [{
       message: '\'appp\' is not defined.'
+    }],
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'const TextWrapper = function (props) {',
+      '  return (',
+      '    <Text />',
+      '  );',
+      '};',
+      'export default TextWrapper;'
+    ].join('\n'),
+    errors: [{
+      message: '\'Text\' is not defined.'
+    }],
+    options: [{
+      allowGlobals: false
+    }],
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    globals: {
+      Text: true
+    }
+  }, {
+    code: '/*eslint no-undef:1*/ var React; React.render(<Foo />);',
+    errors: [{
+      message: '\'Foo\' is not defined.'
     }],
     parserOptions: parserOptions
   }]


### PR DESCRIPTION
This should allow for the use case outlined in #922.

With the `disallowGlobals` option enabled, the global scope will be ignored
when checking for defined components. Without this option enabled,
Pascal case global variables will be allowed when checking for defined
components.