### PR TITLE
Fix `require-default-props` rule when using Flow type from assignment

### DIFF
--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -141,7 +141,12 @@ module.exports = {
       switch (node.typeAnnotation.type) {
         case 'GenericTypeAnnotation':
           var annotation = resolveGenericTypeAnnotation(node.typeAnnotation);
-          properties = annotation ? annotation.properties : [];
+
+          if (annotation && annotation.id) {
+            annotation = findVariableByName(annotation.id.name);
+          }
+
+          properties = annotation ? (annotation.properties || []) : [];
           break;
 
         case 'UnionTypeAnnotation':

--- a/tests/lib/rules/require-default-props.js
+++ b/tests/lib/rules/require-default-props.js
@@ -676,6 +676,39 @@ ruleTester.run('require-default-props', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    },
+    {
+      code: [
+        'import type ImportedProps from "fake";',
+        'type Props = ImportedProps;',
+        'function Hello(props: Props) {',
+        '  return <div>Hello {props.name.firstname}</div>;',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    },
+    // don't error when variable is not in scope
+    {
+      code: [
+        'import type { ImportedType } from "fake";',
+        'type Props = ImportedType;',
+        'function Hello(props: Props) {',
+        '  return <div>Hello {props.name.firstname}</div>;',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    },
+    // make sure error is not thrown with multiple assignments
+    {
+      code: [
+        'import type ImportedProps from "fake";',
+        'type NestedProps = ImportedProps;',
+        'type Props = NestedProps;',
+        'function Hello(props: Props) {',
+        '  return <div>Hello {props.name.firstname}</div>;',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
     }
   ],
 


### PR DESCRIPTION
This fixes the issue I reported in #1017.

The condition I added is hit when code like the following is used:

```js
type Props = Message
```

This just takes the right side of the annotation (`Message`) and tries to find that variable in scope and then continues on.