### PR TITLE
show context in pure component for clarity

### DIFF
--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -27,7 +27,11 @@ var Hello = React.createClass({
 The following pattern is not considered a warning:
 
 ```jsx
-const Foo = function(props) {
+const Foo = function(props, context) {
+  const {
+    location
+  } = context.router;
+
   return <div>{props.foo}</div>;
 };
 ```


### PR DESCRIPTION
ESLint will throw a very unclear complaint to somebody who converts a regular React component into a Pure Component (stateless) as instructed in this doc, if contextTypes are defined. Because there is no "this.context" accessible, it's unclear to someone that they need to use `props, context` arguments.

This will just help clarify and probably save a couple of people a few minutes of research if they come from an ESLint error. Cheers!