### PR TITLE
Fix require-default-props rule filter of undefined exception

### DIFF
--- a/tests/lib/rules/require-default-props.js
+++ b/tests/lib/rules/require-default-props.js
@@ -680,6 +680,16 @@ ruleTester.run('require-default-props', rule, {
     },
     {
       code: [
+        'type Props = any;',
+
+        'const Hello = function({ foo }: Props) {',
+        '  return <div>Hello {foo}</div>;',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    },
+    {
+      code: [
         'import type ImportedProps from "fake";',
         'type Props = ImportedProps;',
         'function Hello(props: Props) {',


### PR DESCRIPTION
Fix error while trying to map over `annotation.properties` that are undefined for `AnyTypeAnnotation`

Fix #1043.
