### PR TITLE
Improve syntax highlighting of code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add `plugins` section and specify ESLint-plugin-React as a plugin.
 
 You can also specify some settings that will be shared across all the plugin rules.
 
-```js
+```json
 {
   "settings": {
     "react": {
@@ -152,7 +152,7 @@ This plugin exports a `recommended` configuration that enforce React good practi
 
 To enable this configuration use the `extends` property in your `.eslintrc` config file:
 
-```js
+```json
 {
   "extends": ["eslint:recommended", "plugin:react/recommended"]
 }
@@ -182,7 +182,7 @@ The rules enabled in this configuration are:
 This plugin also exports an `all` configuration that includes every available rule.
 This pairs well with the `eslint:all` rule.
 
-```js
+```json
 {
   "plugins": [
     "react"

--- a/docs/rules/display-name.md
+++ b/docs/rules/display-name.md
@@ -6,7 +6,7 @@ DisplayName allows you to name your component. This name is used by React in deb
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>Hello {this.props.name}</div>;
@@ -16,7 +16,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   displayName: 'Hello',
   render: function() {
@@ -39,7 +39,7 @@ When `true` the rule will ignore the name set by the transpiler and require a `d
 
 The following patterns are considered okay and do not cause warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   displayName: 'Hello',
 
@@ -50,7 +50,7 @@ var Hello = React.createClass({
 module.exports = Hello;
 ```
 
-```js
+```jsx
 export default class Hello extends React.Component {
   render() {
     return <div>Hello {this.props.name}</div>;
@@ -59,7 +59,7 @@ export default class Hello extends React.Component {
 Hello.displayName = 'Hello';
 ```
 
-```js
+```jsx
 export default function Hello({ name }) {
   return <div>Hello {name}</div>;
 }
@@ -68,7 +68,7 @@ Hello.displayName = 'Hello';
 
 The following patterns will cause warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>Hello {this.props.name}</div>;
@@ -77,7 +77,7 @@ var Hello = React.createClass({
 module.exports = Hello;
 ```
 
-```js
+```jsx
 export default class Hello extends React.Component {
   render() {
     return <div>Hello {this.props.name}</div>;
@@ -85,7 +85,7 @@ export default class Hello extends React.Component {
 }
 ```
 
-```js
+```jsx
 module.exports = React.createClass({
   render: function() {
     return <div>Hello {this.props.name}</div>;
@@ -93,7 +93,7 @@ module.exports = React.createClass({
 });
 ```
 
-```js
+```jsx
 export default class extends React.Component {
   render() {
     return <div>Hello {this.props.name}</div>;
@@ -101,7 +101,7 @@ export default class extends React.Component {
 }
 ```
 
-```js
+```jsx
 function HelloComponent() {
   return React.createClass({
     render: function() {

--- a/docs/rules/forbid-prop-types.md
+++ b/docs/rules/forbid-prop-types.md
@@ -9,7 +9,7 @@ This rule is off by default.
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Component = React.createClass({
   propTypes: {
     a: React.PropTypes.any,

--- a/docs/rules/jsx-boolean-value.md
+++ b/docs/rules/jsx-boolean-value.md
@@ -10,25 +10,25 @@ This rule takes one argument. If it is `"always"` then it warns whenever an attr
 
 The following patterns are considered warnings when configured `"never"`:
 
-```js
+```jsx
 var Hello = <Hello personal={true} />;
 ```
 
 The following patterns are not considered warnings when configured `"never"`:
 
-```js
+```jsx
 var Hello = <Hello personal />;
 ```
 
 The following patterns are considered warnings when configured `"always"`:
 
-```js
+```jsx
 var Hello = <Hello personal />;
 ```
 
 The following patterns are not considered warnings when configured `"always"`:
 
-```js
+```jsx
 var Hello = <Hello personal={true} />;
 ```
 

--- a/docs/rules/jsx-curly-spacing.md
+++ b/docs/rules/jsx-curly-spacing.md
@@ -27,7 +27,7 @@ Depending on your coding conventions, you can choose either option by specifying
 
 When `"never"` is set, the following patterns are considered warnings:
 
-```js
+```jsx
 <Hello name={ firstname } />;
 <Hello name={ firstname} />;
 <Hello name={firstname } />;
@@ -35,7 +35,7 @@ When `"never"` is set, the following patterns are considered warnings:
 
 The following patterns are not warnings:
 
-```js
+```jsx
 <Hello name={firstname} />;
 <Hello name={{ firstname: 'John', lastname: 'Doe' }} />;
 <Hello name={
@@ -47,7 +47,7 @@ The following patterns are not warnings:
 
 When `"always"` is used, the following patterns are considered warnings:
 
-```js
+```jsx
 <Hello name={firstname} />;
 <Hello name={ firstname} />;
 <Hello name={firstname } />;
@@ -55,7 +55,7 @@ When `"always"` is used, the following patterns are considered warnings:
 
 The following patterns are not warnings:
 
-```js
+```jsx
 <Hello name={ firstname } />;
 <Hello name={ {firstname: 'John', lastname: 'Doe'} } />;
 <Hello name={
@@ -73,7 +73,7 @@ By default, braces spanning multiple lines are allowed with either setting. If y
 
 When `"never"` is used and `allowMultiline` is `false`, the following patterns are considered warnings:
 
-```js
+```jsx
 <Hello name={ firstname } />;
 <Hello name={ firstname} />;
 <Hello name={firstname } />;
@@ -84,14 +84,14 @@ When `"never"` is used and `allowMultiline` is `false`, the following patterns a
 
 The following patterns are not warnings:
 
-```js
+```jsx
 <Hello name={firstname} />;
 <Hello name={{ firstname: 'John', lastname: 'Doe' }} />;
 ```
 
 When `"always"` is used and `allowMultiline` is `false`, the following patterns are considered warnings:
 
-```js
+```jsx
 <Hello name={firstname} />;
 <Hello name={ firstname} />;
 <Hello name={firstname } />;
@@ -102,7 +102,7 @@ When `"always"` is used and `allowMultiline` is `false`, the following patterns 
 
 The following patterns are not warnings:
 
-```js
+```jsx
 <Hello name={ firstname } />;
 <Hello name={ {firstname: 'John', lastname: 'Doe'} } />;
 ```
@@ -123,13 +123,13 @@ All spacing options accept either the string `"always"` or the string `"never"`.
 
 When `"always"` is used but `objectLiterals` is `"never"`, the following pattern is not considered a warning:
 
-```js
+```jsx
 <App blah={ 3 } foo={{ bar: true, baz: true }} />;
 ```
 
 When `"never"` is used and `objectLiterals` is `"always"`, the following pattern is not considered a warning:
 
-```js
+```jsx
 <App blah={3} foo={ {bar: true, baz: true} } />;
 ```
 

--- a/docs/rules/jsx-equals-spacing.md
+++ b/docs/rules/jsx-equals-spacing.md
@@ -25,7 +25,7 @@ Depending on your coding conventions, you can choose either option by specifying
 
 When `"never"` is set, the following patterns are considered warnings:
 
-```js
+```jsx
 <Hello name = {firstname} />;
 <Hello name ={firstname} />;
 <Hello name= {firstname} />;
@@ -33,7 +33,7 @@ When `"never"` is set, the following patterns are considered warnings:
 
 The following patterns are not warnings:
 
-```js
+```jsx
 <Hello name={firstname} />;
 <Hello name />;
 <Hello {...props} />;
@@ -43,7 +43,7 @@ The following patterns are not warnings:
 
 When `"always"` is used, the following patterns are considered warnings:
 
-```js
+```jsx
 <Hello name={firstname} />;
 <Hello name ={firstname} />;
 <Hello name= {firstname} />;
@@ -51,7 +51,7 @@ When `"always"` is used, the following patterns are considered warnings:
 
 The following patterns are not warnings:
 
-```js
+```jsx
 <Hello name = {firstname} />;
 <Hello name />;
 <Hello {...props} />;

--- a/docs/rules/jsx-handler-names.md
+++ b/docs/rules/jsx-handler-names.md
@@ -6,21 +6,21 @@ Ensures that any component or prop methods used to handle events are correctly p
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 <MyComponent handleChange={this.handleChange} />
 ```
 
-```js
+```jsx
 <MyComponent onChange={this.componentChanged} />
 ```
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 <MyComponent onChange={this.handleChange} />
 ```
 
-```js
+```jsx
 <MyComponent onChange={this.props.onFoo} />
 ```
 

--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -6,15 +6,15 @@ A `bind` call or [arrow function](https://developer.mozilla.org/en-US/docs/Web/J
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 <div onClick={this._handleClick.bind(this)}></div>
 ```
-```js
+```jsx
 <div onClick={() => console.log('Hello!'))}></div>
 ```
 
 The following patterns are not considered warnings:
-```js
+```jsx
 <div onClick={this._handleClick}></div>
 ```
 
@@ -59,7 +59,7 @@ When `true` the following is not considered a warning:
 
 A common use case of `bind` in render is when rendering a list, to have a separate callback per list item:
 
-```js
+```jsx
 var List = React.createClass({
   render() {
     return (
@@ -77,7 +77,7 @@ var List = React.createClass({
 
 Rather than doing it this way, pull the repeated section into its own component:
 
-```js
+```jsx
 var List = React.createClass({
   render() {
     return (
@@ -110,7 +110,7 @@ This will speed up rendering, as it avoids the need to create new functions (thr
 
 Unfortunately [React ES6 classes](https://facebook.github.io/react/blog/2015/01/27/react-v0.13.0-beta-1.html#es6-classes) do not autobind their methods like components created with the older `React.createClass` syntax. There are several approaches to binding methods for ES6 classes. A basic approach is to just manually bind the methods in the constructor:
 
-```js
+```jsx
 class Foo extends React.Component {
   constructor() {
     super();

--- a/docs/rules/jsx-no-comment-textnodes.md
+++ b/docs/rules/jsx-no-comment-textnodes.md
@@ -7,7 +7,7 @@ injected as a text node in JSX statements.
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return (
@@ -29,7 +29,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   displayName: 'Hello',
   render: function() {
@@ -57,7 +57,7 @@ var Hello = React.createClass({
 It's possible you may want to legitimately output comment start characters (`//` or `/*`)
 in a JSX text node. In which case, you can do the following:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return (

--- a/docs/rules/jsx-no-duplicate-props.md
+++ b/docs/rules/jsx-no-duplicate-props.md
@@ -6,13 +6,13 @@ Creating JSX elements with duplicate props can cause unexpected behavior in your
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 <Hello name="John" name="John" />;
 ```
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 <Hello firstname="John" lastname="Doe" />;
 ```
 

--- a/docs/rules/jsx-no-literals.md
+++ b/docs/rules/jsx-no-literals.md
@@ -8,13 +8,13 @@ Prevents any odd artifacts of highlighters if your unwrapped string contains an 
 
 The following patterns are considered warnings:
 
-```javascript
+```jsx
 var Hello = <div>test</div>;
 ```
 
 The following patterns are not considered warnings:
 
-```javascript
+```jsx
 var Hello = <div>{'test'}</div>;
 ```
 

--- a/docs/rules/jsx-no-undef.md
+++ b/docs/rules/jsx-no-undef.md
@@ -6,13 +6,13 @@ This rule helps locate potential ReferenceErrors resulting from misspellings or 
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 <Hello name="John" />;
 ```
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = require('./Hello');
 
 <Hello name="John" />;

--- a/docs/rules/jsx-pascal-case.md
+++ b/docs/rules/jsx-pascal-case.md
@@ -8,31 +8,31 @@ Note that since React's JSX uses the upper vs. lower case convention to distingu
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 <Test_component />
 ```
 
-```js
+```jsx
 <TEST_COMPONENT />
 ```
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 <div />
 ```
 
-```js
+```jsx
 <TestComponent />
 ```
 
-```js
+```jsx
 <TestComponent>
   <div />
 </TestComponent>
 ```
 
-```js
+```jsx
 <CSSTransitionGroup />
 ```
 

--- a/docs/rules/jsx-sort-props.md
+++ b/docs/rules/jsx-sort-props.md
@@ -8,13 +8,13 @@ This rule checks all JSX components and verifies that all props are sorted alpha
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 <Hello lastName="Smith" firstName="John" />;
 ```
 
 The following patterns are considered okay and do not cause warnings:
 
-```js
+```jsx
 <Hello firstName="John" lastName="Smith" />;
 <Hello tel={5555555} {...this.props} firstName="John" lastName="Smith" />;
 ```
@@ -39,7 +39,7 @@ When `true` the rule ignores the case-sensitivity of the props order.
 
 The following patterns are considered okay and do not cause warnings:
 
-```js
+```jsx
 <Hello name="John" Number="2" />;
 ```
 
@@ -47,7 +47,7 @@ The following patterns are considered okay and do not cause warnings:
 
 When `true`, callbacks must be listed after all other props, even if `shorthandLast` is set :
 
-```js
+```jsx
 <Hello tel={5555555} onClick={this._handleClick} />
 ```
 
@@ -55,7 +55,7 @@ When `true`, callbacks must be listed after all other props, even if `shorthandL
 
 When `true`, short hand props must be listed before all other props, but still respecting the alphabetical order:
 
-```js
+```jsx
 <Hello active validate name="John" tel={5555555} />
 ```
 
@@ -63,7 +63,7 @@ When `true`, short hand props must be listed before all other props, but still r
 
 When `true`, short hand props must be listed after all other props (unless `callbacksLast` is set), but still respecting the alphabetical order:
 
-```js
+```jsx
 <Hello name="John" tel={5555555} active validate />
 ```
 
@@ -71,7 +71,7 @@ When `true`, short hand props must be listed after all other props (unless `call
 
 When `true`, alphabetical order is not enforced:
 
-```js
+```jsx
 <Hello tel={5555555} name="John" />
 ```
 

--- a/docs/rules/jsx-space-before-closing.md
+++ b/docs/rules/jsx-space-before-closing.md
@@ -12,14 +12,14 @@ This rule takes one argument. If it is `"always"` then it warns whenever a space
 
 The following patterns are considered warnings when configured `"always"`:
 
-```js
+```jsx
 <Hello/>
 <Hello firstname="John"/>
 ```
 
 The following patterns are not considered warnings when configured `"always"`:
 
-```js
+```jsx
 <Hello />
 <Hello firstName="John" />
 <Hello
@@ -30,14 +30,14 @@ The following patterns are not considered warnings when configured `"always"`:
 
 The following patterns are considered warnings when configured `"never"`:
 
-```js
+```jsx
 <Hello />
 <Hello firstName="John" />
 ```
 
 The following patterns are not considered warnings when configured `"never"`:
 
-```js
+```jsx
 <Hello/>
 <Hello firstname="John"/>
 <Hello

--- a/docs/rules/jsx-uses-react.md
+++ b/docs/rules/jsx-uses-react.md
@@ -19,7 +19,7 @@ var React = require('react');
 // nothing to do with React
 ```
 
-```js
+```jsx
 /** @jsx Foo */
 var React = require('react');
 
@@ -28,13 +28,13 @@ var Hello = <div>Hello {this.props.name}</div>;
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var React = require('react');
 
 var Hello = <div>Hello {this.props.name}</div>;
 ```
 
-```js
+```jsx
 /** @jsx Foo */
 var Foo = require('foo');
 

--- a/docs/rules/jsx-uses-vars.md
+++ b/docs/rules/jsx-uses-vars.md
@@ -14,7 +14,7 @@ var Hello = require('./Hello');
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = require('./Hello');
 
 <Hello name="John" />;

--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -8,7 +8,7 @@ Wrapping multiline JSX in parentheses can improve readability and/or convenience
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>
@@ -20,7 +20,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var singleLineJSX = <p>Hello</p>
 
 var Hello = React.createClass({

--- a/docs/rules/no-danger.md
+++ b/docs/rules/no-danger.md
@@ -8,7 +8,7 @@ See https://facebook.github.io/react/tips/dangerously-set-inner-html.html
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var React = require('react');
 
 var Hello = <div dangerouslySetInnerHTML={{ __html: "Hello World" }}></div>;
@@ -16,7 +16,7 @@ var Hello = <div dangerouslySetInnerHTML={{ __html: "Hello World" }}></div>;
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var React = require('react');
 
 var Hello = <div>Hello World</div>;

--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -6,7 +6,7 @@ Several methods are deprecated between React versions. This rule will warn you i
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 React.render(<MyComponent />, root);
 
 React.unmountComponentAtNode(root);
@@ -20,7 +20,7 @@ React.renderToStaticMarkup(<MyComponent />);
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 ReactDOM.render(<MyComponent />, root);
 
 // When [1, {"react": "0.13.0"}]

--- a/docs/rules/no-did-mount-set-state.md
+++ b/docs/rules/no-did-mount-set-state.md
@@ -8,7 +8,7 @@ This rule is aimed to forbid the use of `this.setState` in `componentDidMount` o
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     this.setState({
@@ -23,7 +23,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     this.onMount(function callback(newName) {
@@ -38,7 +38,7 @@ var Hello = React.createClass({
 });
 ```
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     this.props.onMount();
@@ -63,7 +63,7 @@ By default this rule forbids any call to `this.setState` in `componentDidMount` 
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     this.setState({
@@ -76,7 +76,7 @@ var Hello = React.createClass({
 });
 ```
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     this.onMount(function callback(newName) {

--- a/docs/rules/no-did-update-set-state.md
+++ b/docs/rules/no-did-update-set-state.md
@@ -6,7 +6,7 @@ Updating the state after a component update will trigger a second `render()` cal
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidUpdate: function() {
      this.setState({
@@ -21,7 +21,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidUpdate: function() {
     this.props.onUpdate();
@@ -32,7 +32,7 @@ var Hello = React.createClass({
 });
 ```
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidUpdate: function() {
     this.onUpdate(function callback(newName) {
@@ -61,7 +61,7 @@ By default this rule forbids any call to `this.setState` in `componentDidUpdate`
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidUpdate: function() {
      this.setState({
@@ -74,7 +74,7 @@ var Hello = React.createClass({
 });
 ```
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidUpdate: function() {
     this.onUpdate(function callback(newName) {

--- a/docs/rules/no-direct-mutation-state.md
+++ b/docs/rules/no-direct-mutation-state.md
@@ -9,7 +9,7 @@ This rule is aimed to forbid the use of mutating `this.state` directly.
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     this.state.name = this.props.name.toUpperCase();
@@ -23,7 +23,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     this.setState({

--- a/docs/rules/no-find-dom-node.md
+++ b/docs/rules/no-find-dom-node.md
@@ -8,7 +8,7 @@ It is recommended to use callback refs instead. See [Dan Abramov comments and ex
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 class MyComponent extends Component {
   componentDidMount() {
     findDOMNode(this).scrollIntoView();
@@ -21,7 +21,7 @@ class MyComponent extends Component {
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 class MyComponent extends Component {
   componentDidMount() {
     this.node.scrollIntoView();

--- a/docs/rules/no-is-mounted.md
+++ b/docs/rules/no-is-mounted.md
@@ -8,7 +8,7 @@
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   handleClick: function() {
     setTimeout(function() {
@@ -25,7 +25,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div onClick={this.props.handleClick}>Hello</div>;

--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -6,7 +6,7 @@ Declaring only one component per file improves readability and reusability of co
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>Hello {this.props.name}</div>;
@@ -22,7 +22,7 @@ var HelloJohn = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = require('./components/Hello');
 
 var HelloJohn = React.createClass({
@@ -46,7 +46,7 @@ When `true` the rule will ignore stateless components and will allow you to have
 
 The following patterns are considered okay and do not cause warnings:
 
-```js
+```jsx
 function Hello(props) {
   return <div>Hello {props.name}</div>;
 }
@@ -55,7 +55,7 @@ function HelloAgain(props) {
 }
 ```
 
-```js
+```jsx
 function Hello(props) {
   return <div>Hello {props.name}</div>;
 }

--- a/docs/rules/no-render-return-value.md
+++ b/docs/rules/no-render-return-value.md
@@ -10,14 +10,14 @@ This rule will warn you if you try to use the `ReactDOM.render()` return value.
 
 The following pattern is considered a warning:
 
-```js
+```jsx
 const inst = ReactDOM.render(<App />, document.body);
 doSomethingWithInst(inst);
 ```
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 ReactDOM.render(<App ref={doSomethingWithInst} />, document.body);
 
 ReactDOM.render(<App />, document.body, doSomethingWithInst);

--- a/docs/rules/no-set-state.md
+++ b/docs/rules/no-set-state.md
@@ -6,7 +6,7 @@ When using an architecture that separates your application state from your UI co
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   getInitialState: function() {
     return {
@@ -26,7 +26,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div onClick={this.props.handleClick}>Hello {this.props.name}</div>;

--- a/docs/rules/no-string-refs.md
+++ b/docs/rules/no-string-refs.md
@@ -6,7 +6,7 @@ Currently, two ways are supported by React to refer to components. The first one
 
 Invalid:
 
-```js
+```jsx
 var Hello = React.createClass({
  render: function() {
   return <div ref="hello">Hello, world.</div>;
@@ -14,7 +14,7 @@ var Hello = React.createClass({
 });
 ```
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     var component = this.refs.hello;
@@ -28,7 +28,7 @@ var Hello = React.createClass({
 
 Valid:
 
-```js
+```jsx
 var Hello = React.createClass({
   componentDidMount: function() {
     var component = this.hello;

--- a/docs/rules/no-unknown-property.md
+++ b/docs/rules/no-unknown-property.md
@@ -8,7 +8,7 @@ In JSX all DOM properties and attributes should be camelCased to be consistent w
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var React = require('react');
 
 var Hello = <div class="hello">Hello World</div>;
@@ -16,7 +16,7 @@ var Hello = <div class="hello">Hello World</div>;
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var React = require('react');
 
 var Hello = <div className="hello">Hello World</div>;

--- a/docs/rules/prefer-es6-class.md
+++ b/docs/rules/prefer-es6-class.md
@@ -16,7 +16,7 @@ Will enforce ES6 classes for React Components. This is the default mode.
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>Hello {this.props.name}</div>;
@@ -26,7 +26,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 class Hello extends React.Component {
   render() {
     return <div>Hello {this.props.name}</div>;
@@ -40,7 +40,7 @@ Will enforce ES5 classes for React Components
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 class Hello extends React.Component {
   render() {
     return <div>Hello {this.props.name}</div>;
@@ -50,7 +50,7 @@ class Hello extends React.Component {
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>Hello {this.props.name}</div>;

--- a/docs/rules/react-in-jsx-scope.md
+++ b/docs/rules/react-in-jsx-scope.md
@@ -9,11 +9,11 @@ If you are using the @jsx pragma this rule will check the designated variable an
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = <div>Hello {this.props.name}</div>;
 ```
 
-```js
+```jsx
 /** @jsx Foo.bar */
 var React = require('react');
 
@@ -22,19 +22,19 @@ var Hello = <div>Hello {this.props.name}</div>;
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 import React from 'react';
 
 var Hello = <div>Hello {this.props.name}</div>;
 ```
 
-```js
+```jsx
 var React = require('react');
 
 var Hello = <div>Hello {this.props.name}</div>;
 ```
 
-```js
+```jsx
 /** @jsx Foo.bar */
 var Foo = require('foo');
 

--- a/docs/rules/require-default-props.md
+++ b/docs/rules/require-default-props.md
@@ -8,7 +8,8 @@ The same also holds true for stateless functional components: default function p
 To illustrate, consider the following example:
 
 With `defaultProps`:
-```js
+
+```jsx
 const HelloWorld = ({ name }) => (
   <h1>Hello, {name.first} {name.last}!</h1>
 );
@@ -30,7 +31,8 @@ ReactDOM.render(<HelloWorld />,  document.getElementById('app'));
 ```
 
 Without `defaultProps`:
-```js
+
+```jsx
 const HelloWorld = ({ name = 'John Doe' }) => (
   <h1>Hello, {name.first} {name.last}!</h1>
 );
@@ -51,7 +53,7 @@ ReactDOM.render(<HelloWorld />,  document.getElementById('app'));
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 function MyStatelessComponent({ foo, bar }) {
   return <div>{foo}{bar}</div>;
 }
@@ -62,7 +64,7 @@ MyStatelessComponent.propTypes = {
 };
 ```
 
-```js
+```jsx
 var Greeting = React.createClass({
   render: function() {
     return <div>Hello {this.props.foo} {this.props.bar}</div>;
@@ -81,7 +83,7 @@ var Greeting = React.createClass({
 });
 ```
 
-```js
+```jsx
 class Greeting extends React.Component {
   render() {
     return (
@@ -100,7 +102,7 @@ Greeting.defaultProps = {
 };
 ```
 
-```js
+```jsx
 class Greeting extends React.Component {
   render() {
     return (
@@ -119,7 +121,7 @@ class Greeting extends React.Component {
 }
 ```
 
-```js
+```jsx
 type Props = {
   foo: string,
   bar?: string
@@ -132,7 +134,7 @@ function MyStatelessComponent(props: Props) {
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 function MyStatelessComponent({ foo, bar }) {
   return <div>{foo}{bar}</div>;
 }
@@ -143,7 +145,7 @@ MyStatelessComponent.propTypes = {
 };
 ```
 
-```js
+```jsx
 function MyStatelessComponent({ foo, bar }) {
   return <div>{foo}{bar}</div>;
 }
@@ -158,7 +160,7 @@ MyStatelessComponent.defaultProps = {
 };
 ```
 
-```js
+```jsx
 type Props = {
   foo: string,
   bar?: string

--- a/docs/rules/require-render-return.md
+++ b/docs/rules/require-render-return.md
@@ -6,7 +6,7 @@ When writing the `render` method in a component it is easy to forget to return t
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render() {
     <div>Hello</div>;
@@ -22,7 +22,7 @@ class Hello extends React.Component {
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render() {
     return <div>Hello</div>;

--- a/docs/rules/sort-comp.md
+++ b/docs/rules/sort-comp.md
@@ -15,7 +15,7 @@ The default configuration ensures that the following order must be followed:
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>Hello</div>;
@@ -26,7 +26,7 @@ var Hello = React.createClass({
 
 The following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   displayName : 'Hello',
   render: function() {
@@ -109,7 +109,7 @@ For example, if you want to place your event handlers (`onClick`, `onSubmit`, et
 
 With the above configuration, the following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   render: function() {
     return <div>Hello</div>;
@@ -120,7 +120,7 @@ var Hello = React.createClass({
 
 With the above configuration, the following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   onClick: function() {},
   render: function() {
@@ -150,7 +150,7 @@ If you want to split your `render` method into smaller ones and keep them just b
 
 With the above configuration, the following patterns are considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   renderButton: function() {},
   onClick: function() {},
@@ -162,7 +162,7 @@ var Hello = React.createClass({
 
 With the above configuration, the following patterns are not considered warnings:
 
-```js
+```jsx
 var Hello = React.createClass({
   onClick: function() {},
   renderButton: function() {},
@@ -188,7 +188,7 @@ If you want to flow annotations to be at the top:
 
 With the above configuration, the following patterns are considered warnings:
 
-```js
+```jsx
 class Hello extends React.Component<any, Props, void> {
   onClick() { this._someElem = true; }
   props: Props;
@@ -201,7 +201,7 @@ class Hello extends React.Component<any, Props, void> {
 
 With the above configuration, the following patterns are not considered warnings:
 
-```js
+```jsx
 type Props = {};
 class Hello extends React.Component<any, Props, void> {
   props: Props;

--- a/docs/rules/sort-prop-types.md
+++ b/docs/rules/sort-prop-types.md
@@ -8,7 +8,7 @@ This rule checks all components and verifies that all propTypes declarations are
 
 The following patterns are considered warnings:
 
-```js
+```jsx
 var Component = React.createClass({
   propTypes: {
     z: React.PropTypes.number,
@@ -41,7 +41,7 @@ class Component extends React.Component {
 
 The following patterns are considered okay and do not cause warnings:
 
-```js
+```jsx
 var Component = React.createClass({
   propTypes: {
     a: React.PropTypes.number,


### PR DESCRIPTION
Using the jsx tag on the fenced code blocks will instruct GitHub to use
JSX syntax highlighting, which will usually be better.