### PR TITLE
New jsx-no-ref rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Finally, enable all of the rules that you would like to use.  Use [our preset](#
 * [react/jsx-no-bind](docs/rules/jsx-no-bind.md): Prevent usage of `.bind()` and arrow functions in JSX props
 * [react/jsx-no-comment-textnodes](docs/rules/jsx-no-comment-textnodes.md): Prevent comments from being inserted as text nodes
 * [react/jsx-no-duplicate-props](docs/rules/jsx-no-duplicate-props.md): Prevent duplicate props in JSX
+* [react/jsx-no-ref](docs/rules/jsx-no-ref.md): Prevent use of `ref` prop in user-defined JSX components
 * [react/jsx-no-literals](docs/rules/jsx-no-literals.md): Prevent usage of unwrapped JSX strings
 * [react/jsx-no-target-blank](docs/rules/jsx-no-target-blank.md): Prevent usage of unsafe `target='_blank'`
 * [react/jsx-no-undef](docs/rules/jsx-no-undef.md): Disallow undeclared variables in JSX

--- a/docs/rules/jsx-no-ref.md
+++ b/docs/rules/jsx-no-ref.md
@@ -1,0 +1,27 @@
+# Warn for use of `ref` prop (jsx-no-ref)
+
+Warn if an custom element uses a `ref` prop, as this is considered a smell of
+non-declarative React component design.  Note that this does rule does _not_
+warn a ref attribute is added to a standard HTML tag, like `<input>`.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```jsx
+<App ref={someRef} />
+
+<App foo={bar} ref={someRef} />
+```
+
+The following patterns are not considered warnings:
+
+```jsx
+<input ref="message" type="text" />
+
+<div ref="contrived"></div>
+```
+
+## When not to use
+
+If you are not using JSX then you can disable this rule.

--- a/docs/rules/jsx-no-ref.md
+++ b/docs/rules/jsx-no-ref.md
@@ -1,12 +1,13 @@
 # Warn for use of `ref` prop (jsx-no-ref)
 
-Warn if an custom element uses a `ref` prop, as this is considered a smell of
-non-declarative React component design.  Note that this does rule does _not_
-warn a ref attribute is added to a standard HTML tag, like `<input>`.
+Warn if an custom element uses a `ref` prop in user-defined JSX components, as
+this is a smell of non-declarative React component design.  Note that this does
+rule does _not_ warn when a `ref` attribute appears in a standard HTML tag,
+like `<input>`.
 
 ## Rule Details
 
-The following patterns are considered warnings:
+Identifies the following patterns as warnings:
 
 ```jsx
 <App ref={someRef} />

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var allRules = {
   'jsx-no-duplicate-props': require('./lib/rules/jsx-no-duplicate-props'),
   'jsx-max-props-per-line': require('./lib/rules/jsx-max-props-per-line'),
   'jsx-no-literals': require('./lib/rules/jsx-no-literals'),
+  'jsx-no-ref': require('./lib/rules/jsx-no-ref'),
   'jsx-indent-props': require('./lib/rules/jsx-indent-props'),
   'jsx-indent': require('./lib/rules/jsx-indent'),
   'jsx-closing-bracket-location': require('./lib/rules/jsx-closing-bracket-location'),

--- a/lib/rules/jsx-no-ref.js
+++ b/lib/rules/jsx-no-ref.js
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Report attempt to use `ref` prop in custom component JSX tags.
+ * @author John Lianoglou
+ */
+'use strict';
+
+var hasProp = require('jsx-ast-utils/hasProp');
+
+// ------------------------------------------------------------------------------
+// Rule Definition (inspired by jsx-key)
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Report attempt to use `ref` prop in custom component JSX tags',
+      category: 'Best Practices',
+      recommended: false
+    },
+    schema: []
+  },
+
+  create: function(context) {
+    return {
+      JSXElement: function(node) {
+        var element = node.openingElement;
+
+        if (!hasProp(element.attributes, 'ref')) {
+          return;
+        }
+
+        if (/^[A-Z]/.test(element.name.name)) {
+          context.report({
+            node: node,
+            message: 'Use of "ref" prop considered smell of non-declarative design'
+          });
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/jsx-no-ref.js
+++ b/lib/rules/jsx-no-ref.js
@@ -13,7 +13,7 @@ var hasProp = require('jsx-ast-utils/hasProp');
 module.exports = {
   meta: {
     docs: {
-      description: 'Report attempt to use `ref` prop in custom component JSX tags',
+      description: 'Report attempt to use `ref` prop in user-defined JSX components',
       category: 'Best Practices',
       recommended: false
     },
@@ -32,7 +32,7 @@ module.exports = {
         if (/^[A-Z]/.test(element.name.name)) {
           context.report({
             node: node,
-            message: 'Use of "ref" prop considered smell of non-declarative design'
+            message: 'Use of "ref" in user-defined JSX components is considered smell of non-declarative design'
           });
         }
       }

--- a/tests/lib/rules/jsx-no-ref.js
+++ b/tests/lib/rules/jsx-no-ref.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Report attempt to use `ref` prop in custom component JSX tags.
+ * @author John Lianoglou
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/jsx-no-ref');
+var RuleTester = require('eslint').RuleTester;
+
+var expectedErrorMessage = 'Use of "ref" prop considered smell of non-declarative design';
+
+var parserOptions = {
+  ecmaVersion: 6,
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+
+ruleTester.run('jsx-no-ref', rule, {
+  valid: [
+    {code: '<App />', parserOptions: parserOptions},
+    {code: '<App reference={value}/>', parserOptions: parserOptions},
+    {code: '<App someProp={ref}/>', parserOptions: parserOptions},
+    {code: '<App foo="ref"/>;', parserOptions: parserOptions},
+    {code: '<input ref={value}/>', parserOptions: parserOptions}
+  ],
+  invalid: [
+    {
+      code: '<App ref={something}/>',
+      errors: [{message: expectedErrorMessage}],
+      parserOptions: parserOptions
+    },
+    {
+      code: '<App otherProp={value} ref={something}/>',
+      errors: [{message: expectedErrorMessage}],
+      parserOptions: parserOptions
+    }
+  ]
+});

--- a/tests/lib/rules/jsx-no-ref.js
+++ b/tests/lib/rules/jsx-no-ref.js
@@ -11,7 +11,7 @@
 var rule = require('../../../lib/rules/jsx-no-ref');
 var RuleTester = require('eslint').RuleTester;
 
-var expectedErrorMessage = 'Use of "ref" prop considered smell of non-declarative design';
+var expectedErrorMessage = 'Use of "ref" in user-defined JSX components is considered smell of non-declarative design';
 
 var parserOptions = {
   ecmaVersion: 6,


### PR DESCRIPTION
Implemented rule that flags use of `ref` attribute in user-defined JSX tags, as this is considered a smell of non-declarative component design.

cc: @mjackson