### PR TITLE
Detect base class expressions wrapping `React.Component`

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -172,7 +172,7 @@ function componentRule(rule, context) {
       if (!node.superClass) {
         return false;
       }
-      return new RegExp('^(' + pragma + '\\.)?(Pure)?Component$').test(sourceCode.getText(node.superClass));
+      return new RegExp('^(.*\\()?(' + pragma + '\\.)?(Pure)?Component\\)?$').test(sourceCode.getText(node.superClass));
     },
 
     /**
@@ -208,7 +208,7 @@ function componentRule(rule, context) {
      */
     isPureComponent: function (node) {
       if (node.superClass) {
-        return new RegExp('^(' + pragma + '\\.)?PureComponent$').test(sourceCode.getText(node.superClass));
+        return new RegExp('^(.*\\()?(' + pragma + '\\.)?PureComponent\\)?$').test(sourceCode.getText(node.superClass));
       }
       return false;
     },


### PR DESCRIPTION
e.g., treat `class Foo extends specialWrapper(React.Component) {}` as an ES6 React component.

I'm looking to use expressions as base classes in a project (a la [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes#Mix-ins)), but eslint-plugin-react doesn't properly detect components in that case.

This PR simply ignores any parentheses/function call wrappers around `(React.)?(Pure)?Component`. I'm absolutely open to other approaches. I also came up with a version that allows a custom component class regex shared ESLint setting (although I think it suffers from ignoring pure components) here: https://github.com/yannickcr/eslint-plugin-react/compare/master...appropos:custom-component-regex

I'd be happy to add tests for my change here. I just wasn't sure where to put them, since this change affects multiple rules.