### PR TITLE
Deprecate jsx-space-before-closing rule

### DIFF
--- a/docs/rules/jsx-space-before-closing.md
+++ b/docs/rules/jsx-space-before-closing.md
@@ -1,5 +1,7 @@
 # Validate spacing before closing bracket in JSX (jsx-space-before-closing)
 
+**Deprecation notice**: This rule is deprecated. Please use the `"beforeSelfClosing"` option of the [jsx-tag-spacing](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-tag-spacing.md) rule instead.
+
 Enforce or forbid spaces before the closing bracket of self-closing JSX elements.
 
 **Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.

--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -1,10 +1,12 @@
 /**
  * @fileoverview Validate spacing before closing bracket in JSX.
  * @author ryym
+ * @deprecated
  */
 'use strict';
 
 var getTokenBeforeClosingBracket = require('../util/getTokenBeforeClosingBracket');
+var isWarnedForDeprecation = false;
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -12,6 +14,7 @@ var getTokenBeforeClosingBracket = require('../util/getTokenBeforeClosingBracket
 
 module.exports = {
   meta: {
+    deprecated: true,
     docs: {
       description: 'Validate spacing before closing bracket in JSX',
       category: 'Stylistic Issues',
@@ -67,6 +70,19 @@ module.exports = {
             }
           });
         }
+      },
+
+      Program: function() {
+        if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
+          return;
+        }
+
+        /* eslint-disable no-console */
+        console.log('The react/jsx-space-before-closing rule is deprecated. ' +
+                    'Please use the react/jsx-tag-spacing rule with the ' +
+                    '"beforeSelfClosing" option instead.');
+        /* eslint-enable no-console */
+        isWarnedForDeprecation = true;
       }
     };
 


### PR DESCRIPTION
Closes #967

As discussed in https://github.com/yannickcr/eslint-plugin-react/issues/693#issuecomment-234842809, the `react/jsx-space-before-closing` can now be deprecated in favour of `react/jsx-tag-spacing` which offers a superset of its functionality.

This PR marks the old rule as deprecated and triggers a warning where it is still being used, reusing some code from the also deprecated `react/require-extension` rule.

Let me know if I've missed any steps in the deprecation process!