### PR TITLE
Fix defaultProps detection when ObjectExpression

### DIFF
--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -556,6 +556,10 @@ module.exports = {
             return;
           }
 
+          if (isDefaultProp && property.value.type === 'ObjectExpression') {
+            addDefaultPropsToComponent(component, getDefaultPropsFromObjectExpression(property.value));
+          }
+
           if (isDefaultProp && property.value.type === 'FunctionExpression') {
             var returnStatement = utils.findReturnStatement(property);
             if (!returnStatement || returnStatement.argument.type !== 'ObjectExpression') {

--- a/tests/lib/rules/require-default-props.js
+++ b/tests/lib/rules/require-default-props.js
@@ -178,6 +178,22 @@ ruleTester.run('require-default-props', rule, {
         '    foo: React.PropTypes.string,',
         '    bar: React.PropTypes.string.isRequired',
         '  },',
+        '  defaultProps: {',
+        '    foo: "foo"',
+        '  }',
+        '});'
+      ].join('\n')
+    },
+    {
+      code: [
+        'var Greeting = React.createClass({',
+        '  render: function() {',
+        '    return <div>Hello {this.props.foo} {this.props.bar}</div>;',
+        '  },',
+        '  propTypes: {',
+        '    foo: React.PropTypes.string,',
+        '    bar: React.PropTypes.string.isRequired',
+        '  },',
         '  getDefaultProps: function() {',
         '    return {',
         '      foo: "foo"',
@@ -313,6 +329,25 @@ ruleTester.run('require-default-props', rule, {
         'Greeting.defaultProps = {};',
         'Greeting.defaultProps.foo = "foo";'
       ].join('\n')
+    },
+    {
+      code: [
+        'class Greeting extends React.Component {',
+        '  render() {',
+        '    return (',
+        '      <h1>Hello, {this.props.foo} {this.props.bar}</h1>',
+        '    );',
+        '  }',
+        '  static propTypes = {',
+        '    foo: React.PropTypes.string,',
+        '    bar: React.PropTypes.string.isRequired',
+        '  };',
+        '  static defaultProps = {',
+        '    foo: "foo"',
+        '  };',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
     },
 
     //


### PR DESCRIPTION
`defaultProps` defined as objects in `React.CreateClass` were
not being recorded causing false positives. Added test
case. Added corresponding ES6 version test as none was present.