### PR TITLE
Test false positive component detection for destructured createElement

### DIFF
--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -363,6 +363,48 @@ ruleTester.run('display-name', rule, {
     `,
     parser: 'babel-eslint'
   }, {
+    code: [
+      'import React, {createElement} from "react";',
+      'const SomeComponent = (props) => {',
+      '  const {foo, bar} = props;',
+      '  return someComponentFactory({',
+      '    onClick: () => foo(bar("x"))',
+      '  });',
+      '};'
+    ].join('\n')
+  }, {
+    code: [
+      'import React, {createElement} from "react";',
+      'const SomeComponent = (props) => {',
+      '  const {foo, bar} = props;',
+      '  return someComponentFactory({',
+      '    onClick: () => foo(bar("x"))',
+      '  });',
+      '};'
+    ].join('\n'),
+    parser: 'babel-eslint'
+  }, {
+    code: [
+      'import React, {Component} from "react";',
+      'function someDecorator(ComposedComponent) {',
+      '  return class MyDecorator extends Component {',
+      '    render() {return <ComposedComponent {...this.props} />;}',
+      '  };',
+      '}',
+      'module.exports = someDecorator;'
+    ].join('\n')
+  }, {
+    code: [
+      'import React, {Component} from "react";',
+      'function someDecorator(ComposedComponent) {',
+      '  return class MyDecorator extends Component {',
+      '    render() {return <ComposedComponent {...this.props} />;}',
+      '  };',
+      '}',
+      'module.exports = someDecorator;'
+    ].join('\n'),
+    parser: 'babel-eslint'
+  }, {
     code: `
       const element = (
         <Media query={query} render={() => {


### PR DESCRIPTION
See https://github.com/yannickcr/eslint-plugin-react/pull/1089#issuecomment-283423305

Before that pull request an arrow function such as: `() => foo(bar("x"))` would be detected as a component if `createElement` was destructured (`import {createElement} from 'react'`).

This adds a test for display-name that it's ok that a function like that does not need a display name, as it's not a component.