### PR TITLE
Fix nextProps false positive in no-unused-prop-types

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -18,6 +18,7 @@ var annotations = require('../util/annotations');
 // ------------------------------------------------------------------------------
 
 var DIRECT_PROPS_REGEX = /^props\s*(\.|\[)/;
+var DIRECT_NEXT_PROPS_REGEX = /^nextProps\s*(\.|\[)/;
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -78,6 +79,24 @@ module.exports = {
     }
 
     /**
+     * Check if we are in a class constructor
+     * @return {boolean} true if we are in a class constructor, false if not
+     **/
+    function inComponentWillReceiveProps() {
+      var scope = context.getScope();
+      while (scope) {
+        if (
+          scope.block && scope.block.parent &&
+          scope.block.parent.key && scope.block.parent.key.name === 'componentWillReceiveProps'
+        ) {
+          return true;
+        }
+        scope = scope.upper;
+      }
+      return false;
+    }
+
+    /**
      * Checks if we are using a prop
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if we are using a prop, false if not.
@@ -88,7 +107,8 @@ module.exports = {
         node.object.type === 'ThisExpression' && node.property.name === 'props'
       );
       var isStatelessFunctionUsage = node.object.name === 'props';
-      return isClassUsage || isStatelessFunctionUsage;
+      var isNextPropsUsage = node.object.name === 'nextProps' && inComponentWillReceiveProps();
+      return isClassUsage || isStatelessFunctionUsage || isNextPropsUsage;
     }
 
     /**
@@ -491,12 +511,17 @@ module.exports = {
      */
     function getPropertyName(node) {
       var isDirectProp = DIRECT_PROPS_REGEX.test(sourceCode.getText(node));
+      var isDirectNextProp = DIRECT_NEXT_PROPS_REGEX.test(sourceCode.getText(node));
       var isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
       var isNotInConstructor = !inConstructor(node);
-      if (isDirectProp && isInClassComponent && isNotInConstructor) {
+      var isNotInComponentWillReceiveProps = !inComponentWillReceiveProps();
+      if ((isDirectProp || isDirectNextProp)
+        && isInClassComponent
+        && isNotInConstructor
+        && isNotInComponentWillReceiveProps) {
         return void 0;
       }
-      if (!isDirectProp) {
+      if (!isDirectProp && !isDirectNextProp) {
         node = node.parent;
       }
       var property = node.property;

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1461,6 +1461,22 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       parserOptions: parserOptions
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  componentWillReceiveProps (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      doSomething(this.props.bar);',
+        '    }',
+        '  }',
+        '}',
+
+        'Hello.propTypes = {',
+        '  foo: PropTypes.bool,',
+        '  bar: PropTypes.bool',
+        '};'
+      ].join('\n'),
+      parserOptions: parserOptions
     }
   ],
 


### PR DESCRIPTION
Fixes #1079

I did the same comparisons as the `prop-types` rules (https://github.com/yannickcr/eslint-plugin-react/blob/b64648521f9a7949eef4cd1a210768e906b4f3d1/lib/rules/prop-types.js#L130) for the `no-unused-prop-types` rule.
This way they both handle nextProps identically.

I also borrowed the test case from #1105.