### PR TITLE
Fix required prop types for classes with annotated methods.

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -868,7 +868,12 @@ module.exports = {
 
       ArrowFunctionExpression: handleStatelessComponent,
 
-      FunctionExpression: handleStatelessComponent,
+      FunctionExpression: function(node) {
+        if (node.parent.type === 'MethodDefinition') {
+          return;
+        }
+        handleStatelessComponent(node);
+      },
 
       MemberExpression: function(node) {
         var type;

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1117,6 +1117,20 @@ ruleTester.run('prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: [
+        'type Props = {',
+        '  name: string,',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  render() {',
+        '    const {name} = this.props;',
+        '    return name;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
         'Card.propTypes = {',
         '  title: PropTypes.string.isRequired,',
         '  children: PropTypes.element.isRequired,',
@@ -1405,6 +1419,25 @@ ruleTester.run('prop-types', rule, {
 
   invalid: [
     {
+      code: [
+        'type Props = {',
+        '  name: string,',
+        '};',
+        'class Hello extends React.Component {',
+        '  foo(props: Props) {}',
+        '  render() {',
+        '    return this.props.name;',
+        '  }',
+        '}'
+      ].join('\n'),
+      errors: [{
+        message: '\'name\' is missing in props validation',
+        line: 7,
+        column: 23,
+        type: 'Identifier'
+      }],
+      parser: 'babel-eslint'
+    }, {
       code: [
         'var Hello = createReactClass({',
         '  render: function() {',


### PR DESCRIPTION
The `react/prop-types` rule incorrectly considers  flow type
annotations on class methods with arguments named `props` as
prop type declarations for the class, even though flow itself
gives them no such weight.

When a react component is defined as a class extending `React.Component`,
and it defines a method that takes an annotated argument named `props`,
then, even though flow still thinks the props have `any` type, the
`prop-types` rule will not produce 'missing in props validation' errors.

A pattern that gets used a lot in React components is as follows:
```javascript
type Props = {...};
class Comp extends React.Component {
  constructor(props: Props) {
    super(props);
    // do something...
  }

  // ...
}
```
which makes this especially nefarious.