### PR TITLE
remove quotes when considering the name of a proptype

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -305,7 +305,7 @@ module.exports = {
      * @param {string} the identifier to strip
      */
     function stripQuotes(string) {
-      if (string[0] === '\'' || string[0] === '"') {
+      if (string[0] === '\'' || string[0] === '"' && string[0] === string[string.length - 1]) {
         return string.slice(1, string.length - 1);
       }
       return string;

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -301,6 +301,17 @@ module.exports = {
     }
 
     /**
+     * Removes quotes from around an identifier.
+     * @param {string} the identifier to strip
+     */
+    function stripQuotes(string) {
+      if (string[0] === '\'' || string[0] === '"') {
+        return string.slice(1, string.length - 1);
+      }
+      return string;
+    }
+
+    /**
      * Retrieve the name of a key node
      * @param {ASTNode} node The AST node with the key.
      * @return {string} the name of the key
@@ -310,7 +321,7 @@ module.exports = {
         var tokens = context.getFirstTokens(node, 2);
         return (tokens[0].value === '+' || tokens[0].value === '-'
           ? tokens[1].value
-          : tokens[0].value
+          : stripQuotes(tokens[0].value)
         );
       }
       var key = node.key || node.argument;

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1107,6 +1107,16 @@ ruleTester.run('prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: [
+        'type Props = {',
+        '  \'completed?\': boolean,',
+        '};',
+        'const Hello = (props: Props): React.Element => {',
+        '  return <div>{props[\'completed?\']}</div>;',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
         'Card.propTypes = {',
         '  title: PropTypes.string.isRequired,',
         '  children: PropTypes.element.isRequired,',


### PR DESCRIPTION
The added test illustrates the failing case. Proptypes with quotes
were referred to by the quoted name, instead of by the bare name,
for flow types.