### PR TITLE
Add new deprecations from 15.5.0

### DIFF
--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -16,6 +16,12 @@ React.findDOMNode(this.refs.foo);
 React.renderToString(<MyComponent />);
 
 React.renderToStaticMarkup(<MyComponent />);
+
+React.createClass({ /* Class object */ });
+
+const propTypes = {
+  foo: React.PropTypes.bar,
+};
 ```
 
 The following patterns are not considered warnings:

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -66,6 +66,7 @@ module.exports = {
       deprecated.MemberExpression['Perf.getMeasurementsSummaryMap'] = ['15.0.0', 'Perf.getWasted'];
       // 15.5.0
       deprecated.MemberExpression['React.createClass'] = ['15.5.0', 'the npm module create-react-class'];
+      deprecated.MemberExpression['React.PropTypes'] = ['15.5.0', 'the npm module prop-types'];
 
       return deprecated;
     }

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -64,6 +64,8 @@ module.exports = {
       deprecated.MemberExpression['Perf.printDOM'] = ['15.0.0', 'Perf.printOperations'];
       deprecated.MemberExpression['ReactPerf.getMeasurementsSummaryMap'] = ['15.0.0', 'ReactPerf.getWasted'];
       deprecated.MemberExpression['Perf.getMeasurementsSummaryMap'] = ['15.0.0', 'Perf.getWasted'];
+      // 15.5.0
+      deprecated.MemberExpression['React.createClass'] = ['15.5.0', 'the npm module create-react-class'];
 
       return deprecated;
     }

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -65,8 +65,8 @@ module.exports = {
       deprecated.MemberExpression['ReactPerf.getMeasurementsSummaryMap'] = ['15.0.0', 'ReactPerf.getWasted'];
       deprecated.MemberExpression['Perf.getMeasurementsSummaryMap'] = ['15.0.0', 'Perf.getWasted'];
       // 15.5.0
-      deprecated.MemberExpression['React.createClass'] = ['15.5.0', 'the npm module create-react-class'];
-      deprecated.MemberExpression['React.PropTypes'] = ['15.5.0', 'the npm module prop-types'];
+      deprecated.MemberExpression[pragma + '.createClass'] = ['15.5.0', 'the npm module create-react-class'];
+      deprecated.MemberExpression[pragma + '.PropTypes'] = ['15.5.0', 'the npm module prop-types'];
 
       return deprecated;
     }

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -23,7 +23,6 @@ ruleTester.run('no-deprecated', rule, {
 
   valid: [
     // Not deprecated
-    'var MyClass = React.createClass({});',
     'var element = React.createElement(\'p\', {}, null);',
     'var clone = React.cloneElement(element);',
     'ReactDOM.render(element, container);',
@@ -93,6 +92,11 @@ ruleTester.run('no-deprecated', rule, {
         'React.renderToStaticMarkup is deprecated since React 0.14.0, ' +
         'use ReactDOMServer.renderToStaticMarkup instead'
       )
+    }]
+  }, {
+    code: 'React.createClass({});',
+    errors: [{
+      message: 'React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead'
     }]
   }]
 

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -31,7 +31,9 @@ ruleTester.run('no-deprecated', rule, {
     'ReactDOMServer.renderToString(element);',
     'ReactDOMServer.renderToStaticMarkup(element);',
     // Deprecated in a later version
-    {code: 'React.renderComponent()', settings: {react: {version: '0.11.0'}}}
+    {code: 'React.renderComponent()', settings: {react: {version: '0.11.0'}}},
+    {code: 'React.createClass()', settings: {react: {version: '15.4.0'}}},
+    {code: 'React.PropTypes', settings: {react: {version: '15.4.0'}}}
   ],
 
   invalid: [{
@@ -97,6 +99,12 @@ ruleTester.run('no-deprecated', rule, {
     code: 'React.createClass({});',
     errors: [{
       message: 'React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead'
+    }]
+  }, {
+    code: 'Foo.createClass({});',
+    settings: {react: {pragma: 'Foo'}},
+    errors: [{
+      message: 'Foo.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead'
     }]
   }, {
     code: 'React.PropTypes',

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -98,6 +98,11 @@ ruleTester.run('no-deprecated', rule, {
     errors: [{
       message: 'React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead'
     }]
+  }, {
+    code: 'React.PropTypes',
+    errors: [{
+      message: 'React.PropTypes is deprecated since React 15.5.0, use the npm module prop-types instead'
+    }]
   }]
 
 });


### PR DESCRIPTION
Added more deprecations rules regarding last react update.

But it does not seem to match patterns like this:
```javascript
import { PropTypes, createClass } from 'react';
```

Any idea on how we can match those too?