### PR TITLE
Prepend "react/" to rule options documentation code

### DIFF
--- a/docs/rules/display-name.md
+++ b/docs/rules/display-name.md
@@ -29,7 +29,7 @@ var Hello = React.createClass({
 
 ```js
 ...
-"display-name": [<enabled>, { "ignoreTranspilerName": <boolean> }]
+"react/display-name": [<enabled>, { "ignoreTranspilerName": <boolean> }]
 ...
 ```
 

--- a/docs/rules/forbid-component-props.md
+++ b/docs/rules/forbid-component-props.md
@@ -35,7 +35,7 @@ The following patterns are not considered warnings:
 
 ```js
 ...
-"forbid-component-props": [<enabled>, { "forbid": [<string>] }]
+"react/forbid-component-props": [<enabled>, { "forbid": [<string>] }]
 ...
 ```
 

--- a/docs/rules/forbid-elements.md
+++ b/docs/rules/forbid-elements.md
@@ -10,7 +10,7 @@ This rule checks all JSX elements and `React.createElement` calls and verifies t
 
 ```js
 ...
-"forbid-elements": [<enabled>, { "forbid": [<string|object>] }]
+"react/forbid-elements": [<enabled>, { "forbid": [<string|object>] }]
 ...
 ```
 

--- a/docs/rules/jsx-closing-bracket-location.md
+++ b/docs/rules/jsx-closing-bracket-location.md
@@ -39,14 +39,14 @@ There are two ways to configure this rule.
 The first form is a string shortcut corresponding to the `location` values specified below. If omitted, it defaults to `"tag-aligned"`.
 
 ```js
-"jsx-closing-bracket-location": <enabled> // -> [<enabled>, "tag-aligned"]
-"jsx-closing-bracket-location": [<enabled>, "<location>"]
+"react/jsx-closing-bracket-location": <enabled> // -> [<enabled>, "tag-aligned"]
+"react/jsx-closing-bracket-location": [<enabled>, "<location>"]
 ```
 
 The second form allows you to distinguish between non-empty and self-closing tags. Both properties are optional, and both default to `"tag-aligned"`. You can also disable the rule for one particular type of tag by setting the value to `false`.
 
 ```js
-"jsx-closing-bracket-location": [<enabled>, {
+"react/jsx-closing-bracket-location": [<enabled>, {
   "nonEmpty": "<location>" || false,
   "selfClosing": "<location>" || false
 }]

--- a/docs/rules/jsx-curly-spacing.md
+++ b/docs/rules/jsx-curly-spacing.md
@@ -20,7 +20,7 @@ There are two main options for the rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"jsx-curly-spacing": [2, "always"]
+"react/jsx-curly-spacing": [2, "always"]
 ```
 
 #### never
@@ -68,7 +68,7 @@ The following patterns are not warnings:
 By default, braces spanning multiple lines are allowed with either setting. If you want to disallow them you can specify an additional `allowMultiline` property with the value `false`:
 
 ```json
-"jsx-curly-spacing": [2, "never", {"allowMultiline": false}]
+"react/jsx-curly-spacing": [2, "never", {"allowMultiline": false}]
 ```
 
 When `"never"` is used and `allowMultiline` is `false`, the following patterns are considered warnings:
@@ -112,7 +112,7 @@ The following patterns are not warnings:
 You can specify an additional `spacing` property that is an object with the following possible values:
 
 ```json
-"jsx-curly-spacing": [2, "always", {"spacing": {
+"react/jsx-curly-spacing": [2, "always", {"spacing": {
   "objectLiterals": "never"
 }}]
 ```

--- a/docs/rules/jsx-equals-spacing.md
+++ b/docs/rules/jsx-equals-spacing.md
@@ -18,7 +18,7 @@ There are two options for the rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"jsx-equals-spacing": [2, "always"]
+"react/jsx-equals-spacing": [2, "always"]
 ```
 
 #### never

--- a/docs/rules/jsx-handler-names.md
+++ b/docs/rules/jsx-handler-names.md
@@ -28,7 +28,7 @@ The following patterns are not considered warnings:
 
 ```js
 ...
-"jsx-handler-names": [<enabled>, {
+"react/jsx-handler-names": [<enabled>, {
   "eventHandlerPrefix": <eventHandlerPrefix>,
   "eventHandlerPropPrefix": <eventHandlerPropPrefix>
 }]

--- a/docs/rules/jsx-indent-props.md
+++ b/docs/rules/jsx-indent-props.md
@@ -33,7 +33,7 @@ It takes an option as the second parameter which can be `"tab"` for tab-based in
 
 ```js
 ...
-"jsx-indent-props": [<enabled>, 'tab'|<number>]
+"react/jsx-indent-props": [<enabled>, 'tab'|<number>]
 ...
 ```
 

--- a/docs/rules/jsx-max-props-per-line.md
+++ b/docs/rules/jsx-max-props-per-line.md
@@ -35,7 +35,7 @@ The following patterns are not considered warnings:
 
 ```js
 ...
-"jsx-max-props-per-line": [<enabled>, { "maximum": <number>, "when": <string> }]
+"react/jsx-max-props-per-line": [<enabled>, { "maximum": <number>, "when": <string> }]
 ...
 ```
 

--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -21,7 +21,7 @@ The following patterns are not considered warnings:
 ## Rule Options
 
 ```js
-"jsx-no-bind": [<enabled>, {
+"react/jsx-no-bind": [<enabled>, {
   "ignoreRefs": <boolean> || false,
   "allowArrowFunctions": <boolean> || false,
   "allowBind": <boolean> || false

--- a/docs/rules/jsx-no-duplicate-props.md
+++ b/docs/rules/jsx-no-duplicate-props.md
@@ -20,7 +20,7 @@ The following patterns are not considered warnings:
 
 ```js
 ...
-"jsx-no-duplicate-props": [<enabled>, { "ignoreCase": <boolean> }]
+"react/jsx-no-duplicate-props": [<enabled>, { "ignoreCase": <boolean> }]
 ...
 ```
 

--- a/docs/rules/jsx-pascal-case.md
+++ b/docs/rules/jsx-pascal-case.md
@@ -40,7 +40,7 @@ The following patterns are not considered warnings:
 
 ```js
 ...
-"jsx-pascal-case": [<enabled>, { allowAllCaps: <allowAllCaps>, ignore: <ignore> }]
+"react/jsx-pascal-case": [<enabled>, { allowAllCaps: <allowAllCaps>, ignore: <ignore> }]
 ...
 ```
 

--- a/docs/rules/jsx-sort-props.md
+++ b/docs/rules/jsx-sort-props.md
@@ -23,7 +23,7 @@ The following patterns are considered okay and do not cause warnings:
 
 ```js
 ...
-"jsx-sort-props": [<enabled>, {
+"react/jsx-sort-props": [<enabled>, {
   "callbacksLast": <boolean>,
   "shorthandFirst": <boolean>,
   "shorthandLast": <boolean>,

--- a/docs/rules/no-did-mount-set-state.md
+++ b/docs/rules/no-did-mount-set-state.md
@@ -53,7 +53,7 @@ var Hello = React.createClass({
 
 ```js
 ...
-"no-did-mount-set-state": [<enabled>, <mode>]
+"react/no-did-mount-set-state": [<enabled>, <mode>]
 ...
 ```
 

--- a/docs/rules/no-did-update-set-state.md
+++ b/docs/rules/no-did-update-set-state.md
@@ -51,7 +51,7 @@ var Hello = React.createClass({
 
 ```js
 ...
-"no-did-update-set-state": [<enabled>, <mode>]
+"react/no-did-update-set-state": [<enabled>, <mode>]
 ...
 ```
 

--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -36,7 +36,7 @@ var HelloJohn = React.createClass({
 
 ```js
 ...
-"no-multi-comp": [<enabled>, { "ignoreStateless": <boolean> }]
+"react/no-multi-comp": [<enabled>, { "ignoreStateless": <boolean> }]
 ...
 ```
 

--- a/docs/rules/no-unknown-property.md
+++ b/docs/rules/no-unknown-property.md
@@ -26,7 +26,7 @@ var Hello = <div className="hello">Hello World</div>;
 
 ```js
 ...
-"no-unknown-property": [<enabled>, { ignore: <ignore> }]
+"react/no-unknown-property": [<enabled>, { ignore: <ignore> }]
 ...
 ```
 

--- a/docs/rules/no-will-update-set-state.md
+++ b/docs/rules/no-will-update-set-state.md
@@ -51,7 +51,7 @@ var Hello = React.createClass({
 
 ```js
 ...
-"no-will-update-set-state": [<enabled>, <mode>]
+"react/no-will-update-set-state": [<enabled>, <mode>]
 ...
 ```
 

--- a/docs/rules/prefer-es6-class.md
+++ b/docs/rules/prefer-es6-class.md
@@ -6,7 +6,7 @@ React offers you two way to create traditional components: using the ES5 `React.
 
 ```js
 ...
-"prefer-es6-class": [<enabled>, <mode>]
+"react/prefer-es6-class": [<enabled>, <mode>]
 ...
 ```
 

--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -54,7 +54,7 @@ class Foo extends React.Component {
 
 ```js
 ...
-"prefer-stateless-function": [<enabled>, { "ignorePureComponents": <ignorePureComponents> }]
+"react/prefer-stateless-function": [<enabled>, { "ignorePureComponents": <ignorePureComponents> }]
 ...
 ```
 

--- a/docs/rules/require-optimization.md
+++ b/docs/rules/require-optimization.md
@@ -52,7 +52,7 @@ React.createClass({
 
 ```js
 ...
-"require-optimization": [<enabled>, { allowDecorators: [<allowDecorator>] }]
+"react/require-optimization": [<enabled>, { allowDecorators: [<allowDecorator>] }]
 ...
 ```
 
@@ -76,6 +76,6 @@ class Hello extends React.Component {}
 
 ```js
 ...
-"require-optimization": [2, {allowDecorators: ['customDecorators']}]
+"react/require-optimization": [2, {allowDecorators: ['customDecorators']}]
 ...
 ```

--- a/docs/rules/self-closing-comp.md
+++ b/docs/rules/self-closing-comp.md
@@ -32,7 +32,7 @@ The rule can take one argument to select types of tags, which should be self-clo
 
 ```js
 ...
-"self-closing-comp": ["error", {
+"react/self-closing-comp": ["error", {
   "component": true,
   "html": true
 }]

--- a/docs/rules/sort-prop-types.md
+++ b/docs/rules/sort-prop-types.md
@@ -76,7 +76,7 @@ class Component extends React.Component {
 
 ```js
 ...
-"sort-prop-types": [<enabled>, {
+"react/sort-prop-types": [<enabled>, {
   "callbacksLast": <boolean>,
   "ignoreCase": <boolean>,
   "requiredFirst": <boolean>,


### PR DESCRIPTION
Using `"jsx-pascal-case": ...` leads to
```shell
1:1  error  Definition for rule 'jsx-pascal-case' was not found  jsx-pascal-case
```

We need `"react/jsx-pascal-case": ...` as shown in the [Readme](https://github.com/yannickcr/eslint-plugin-react/blob/master/README.md)