### PR TITLE
Link fix: ReactDOM docs were broken out

### DIFF
--- a/docs/rules/no-render-return-value.md
+++ b/docs/rules/no-render-return-value.md
@@ -2,7 +2,7 @@
 
 > `ReactDOM.render()` currently returns a reference to the root `ReactComponent` instance. However, using this return value is legacy and should be avoided because future versions of React may render components asynchronously in some cases. If you need a reference to the root `ReactComponent` instance, the preferred solution is to attach a [callback ref](http://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute) to the root element.
 
-Source: [React Top-Level API documentation](http://facebook.github.io/react/docs/top-level-api.html#reactdom.render)
+Source: [ReactDOM documentation](https://facebook.github.io/react/docs/react-dom.html#render)
 
 ## Rule Details
 


### PR DESCRIPTION
This fixes a link regarding ReactDOM.render. Previously these docs
were part of the Top Level API docs for React, but have since been
split into their own documentation.