### PR TITLE
Add rule for disallowing instantiation of classes in JSX props

### DIFF
--- a/docs/rules/jsx-no-new.md
+++ b/docs/rules/jsx-no-new.md
@@ -1,0 +1,21 @@
+# Prevent instantiation of classes in JSX attributes (jsx-no-new)
+
+Instantiating a class in the `render` method of a React component means that a brand new instance will be created every single time the component is re-rendered. This is bad for performance, as it will result in the garbage collector being invoked way more than is necessary.
+
+## Rule Details
+
+The following patterns are considered warnings:
+```jsx
+<Foo bar={new HelloWorld()} />
+<Foo bar={new HelloWorld()}></Foo>
+```
+
+The following patterns are not considered warnings:
+```jsx
+<Foo bar={helloWorld} />
+<Foo bar={helloWorld}></Foo>
+```
+
+## When Not To Use It
+
+If you do not use JSX or do not want to enforce that new classes are instantiated in props, then you can disable this rule.

--- a/index.js
+++ b/index.js
@@ -26,6 +26,7 @@ var allRules = {
   'jsx-handler-names': require('./lib/rules/jsx-handler-names'),
   'jsx-pascal-case': require('./lib/rules/jsx-pascal-case'),
   'jsx-no-bind': require('./lib/rules/jsx-no-bind'),
+  'jsx-no-new': require('./lib/rules/jsx-no-new'),
   'jsx-no-undef': require('./lib/rules/jsx-no-undef'),
   'no-unknown-property': require('./lib/rules/no-unknown-property'),
   'jsx-curly-spacing': require('./lib/rules/jsx-curly-spacing'),

--- a/lib/rules/jsx-no-new.js
+++ b/lib/rules/jsx-no-new.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Disallows instantiating classes in JSX attributes
+ * @author Daniel Lo Nigro <dan.cx>
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow instantiating classes in JSX attributes',
+      category: 'Best Practices',
+      recommended: false
+    }
+  },
+
+  create: function(context) {
+
+    return {
+      JSXAttribute: function(node) {
+        if (
+          node.value &&
+          node.value.type === 'JSXExpressionContainer' &&
+          node.value.expression &&
+          node.value.expression.type === 'NewExpression'
+        ) {
+          context.report({
+            node: node,
+            message: 'Do not instantiate classes in JSX props'
+          });
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/jsx-no-new.js
+++ b/tests/lib/rules/jsx-no-new.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Disallows instantiating classes in JSX attributes
+ * @author Daniel Lo Nigro <dan.cx>
+ */
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/jsx-no-new');
+var RuleTester = require('eslint').RuleTester;
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run('jsx-no-new', rule, {
+
+  valid: [
+    {
+      code: '<Foo />',
+      parser: 'babel-eslint'
+    },
+    {
+      code: '<Foo dummy={newDummy()} />',
+      parser: 'babel-eslint'
+    },
+    {
+      code: '<Foo dummy={newDummy()}></Foo>',
+      parser: 'babel-eslint'
+    },
+    {
+      code: '<Foo bar="hello" {...stuff} />',
+      parser: 'babel-eslint'
+    },
+    {
+      code: [
+        'class Foo extends React.Component {',
+        '  render() {',
+        '    return <Bar />;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }
+  ],
+
+  invalid: [
+    {
+      code: '<Foo dummy={new Dummy()} />',
+      parser: 'babel-eslint',
+      errors: 1
+    },
+    {
+      code: '<Foo dummy={new Dummy()}></Foo>',
+      parser: 'babel-eslint',
+      errors: 1
+    },
+    {
+      code: [
+        'class Foo extends React.Component {',
+        '  render() {',
+        '    return <Bar dummy={new Dummy()} />;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: 1
+    }
+  ]
+});


### PR DESCRIPTION
Instantiating a class in the `render` method of a React component means that a brand new instance will be created every single time the component is re-rendered. This is bad for performance, as it will result in the garbage collector being invoked way more than is necessary. This issue is in a similar category as `jsx-no-bind`.