### PR TITLE
Update jsx-filename-extension.md

### DIFF
--- a/docs/rules/jsx-filename-extension.md
+++ b/docs/rules/jsx-filename-extension.md
@@ -26,7 +26,7 @@ The set of allowed extensions is configurable. By default '.jsx' is allowed. If 
 
 ```js
 "rules": {
-  "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+  "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }]
 }
 ```
 


### PR DESCRIPTION
* Trailing comma is causing .json file stops working
* Trailing comma is supported in .eslintrc.js only