### PR TITLE
Fix "allowMultiline" being undefined in some cases

### DIFF
--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -10,6 +10,8 @@
  */
 'use strict';
 
+var has = require('has');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -52,10 +54,13 @@ module.exports = {
 
   create: function(context) {
 
+    var DEFAULT_ALLOW_MULTILINE = true;
+
     var sourceCode = context.getSourceCode();
     var spaced = context.options[0] === SPACING.always;
-    var multiline = context.options[1] ? context.options[1].allowMultiline : true;
-    var spacing = context.options[1] ? context.options[1].spacing || {} : {};
+    var config = context.options[1] || {};
+    var multiline = has(config, 'allowMultiline') ? config.allowMultiline : DEFAULT_ALLOW_MULTILINE;
+    var spacing = config.spacing || {};
     var defaultSpacing = spaced ? SPACING.always : SPACING.never;
     var objectLiteralSpacing = spacing.objectLiterals || (spaced ? SPACING.always : SPACING.never);
 

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -87,6 +87,14 @@ ruleTester.run('jsx-curly-spacing', rule, {
     options: ['always', {spacing: {}}],
     parserOptions: parserOptions
   }, {
+    code: [
+      '<App foo={',
+      'bar',
+      '} />;'
+    ].join('\n'),
+    options: ['always', {spacing: {}}],
+    parserOptions: parserOptions
+  }, {
     code: '<App foo={{ bar: true, baz: true }} />;',
     options: ['always', {spacing: {objectLiterals: 'never'}}],
     parserOptions: parserOptions


### PR DESCRIPTION
From comment https://github.com/yannickcr/eslint-plugin-react/issues/857#issuecomment-299664309:

> Btw. I think there was a small bug: when only "spacing" was set in the extended options, the following line was setting "allowMultiline" to undefined:
>
> ```
> var multiline = context.options[1] ? context.options[1].allowMultiline : true;
> ```
> Then in all the following conditions !multiline was being checked, which yielded a different result than the > default true value would.
>
> Now I'll be checking if the property exists on the config object (using the has package, I found it being used in other rules).