### PR TITLE
Fix the newline with object literals bug

### DIFF
--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -54,15 +54,15 @@ module.exports = {
 
   create: function(context) {
 
+    var DEFAULT_SPACING = SPACING.never;
     var DEFAULT_ALLOW_MULTILINE = true;
 
     var sourceCode = context.getSourceCode();
-    var spaced = context.options[0] === SPACING.always;
+    var baseSpacing = context.options[0] || DEFAULT_SPACING;
     var config = context.options[1] || {};
     var multiline = has(config, 'allowMultiline') ? config.allowMultiline : DEFAULT_ALLOW_MULTILINE;
-    var spacing = config.spacing || {};
-    var defaultSpacing = spaced ? SPACING.always : SPACING.never;
-    var objectLiteralSpacing = spacing.objectLiterals || (spaced ? SPACING.always : SPACING.never);
+    var spacingConfig = config.spacing || {};
+    var objectLiteralSpacing = spacingConfig.objectLiterals || baseSpacing;
 
     // --------------------------------------------------------------------------
     // Helpers
@@ -84,14 +84,14 @@ module.exports = {
     * @param {Token} token - The token to use for the report.
     * @returns {void}
     */
-    function reportNoBeginningNewline(node, token) {
+    function reportNoBeginningNewline(node, token, spacing) {
       context.report({
         node: node,
         loc: token.loc.start,
         message: `There should be no newline after '${token.value}'`,
         fix: function(fixer) {
           var nextToken = sourceCode.getTokenAfter(token);
-          return fixer.replaceTextRange([token.range[1], nextToken.range[0]], spaced ? ' ' : '');
+          return fixer.replaceTextRange([token.range[1], nextToken.range[0]], spacing === SPACING.always ? ' ' : '');
         }
       });
     }
@@ -102,14 +102,14 @@ module.exports = {
     * @param {Token} token - The token to use for the report.
     * @returns {void}
     */
-    function reportNoEndingNewline(node, token) {
+    function reportNoEndingNewline(node, token, spacing) {
       context.report({
         node: node,
         loc: token.loc.start,
         message: `There should be no newline before '${token.value}'`,
         fix: function(fixer) {
           var previousToken = sourceCode.getTokenBefore(token);
-          return fixer.replaceTextRange([previousToken.range[1], token.range[0]], spaced ? ' ' : '');
+          return fixer.replaceTextRange([previousToken.range[1], token.range[0]], spacing === SPACING.always ? ' ' : '');
         }
       });
     }
@@ -217,53 +217,29 @@ module.exports = {
       }
 
       var isObjectLiteral = first.value === second.value;
-      if (isObjectLiteral) {
-        if (objectLiteralSpacing === SPACING.never) {
-          if (sourceCode.isSpaceBetweenTokens(first, second)) {
-            reportNoBeginningSpace(node, first);
-          } else if (!multiline && isMultiline(first, second)) {
-            reportNoBeginningNewline(node, first);
-          }
-          if (sourceCode.isSpaceBetweenTokens(penultimate, last)) {
-            reportNoEndingSpace(node, last);
-          } else if (!multiline && isMultiline(penultimate, last)) {
-            reportNoEndingNewline(node, last);
-          }
-        } else if (objectLiteralSpacing === SPACING.always) {
-          if (!sourceCode.isSpaceBetweenTokens(first, second)) {
-            reportRequiredBeginningSpace(node, first);
-          } else if (!multiline && isMultiline(first, second)) {
-            reportNoBeginningNewline(node, first);
-          }
-          if (!sourceCode.isSpaceBetweenTokens(penultimate, last)) {
-            reportRequiredEndingSpace(node, last);
-          } else if (!multiline && isMultiline(penultimate, last)) {
-            reportNoEndingNewline(node, last);
-          }
-        }
-      } else if (defaultSpacing === SPACING.always) {
+      var spacing = isObjectLiteral ? objectLiteralSpacing : baseSpacing;
+      if (spacing === SPACING.always) {
         if (!sourceCode.isSpaceBetweenTokens(first, second)) {
           reportRequiredBeginningSpace(node, first);
         } else if (!multiline && isMultiline(first, second)) {
-          reportNoBeginningNewline(node, first);
+          reportNoBeginningNewline(node, first, spacing);
         }
-
         if (!sourceCode.isSpaceBetweenTokens(penultimate, last)) {
           reportRequiredEndingSpace(node, last);
         } else if (!multiline && isMultiline(penultimate, last)) {
-          reportNoEndingNewline(node, last);
+          reportNoEndingNewline(node, last, spacing);
         }
-      } else if (defaultSpacing === SPACING.never) {
+      } else if (spacing === SPACING.never) {
         if (isMultiline(first, second)) {
           if (!multiline) {
-            reportNoBeginningNewline(node, first);
+            reportNoBeginningNewline(node, first, spacing);
           }
         } else if (sourceCode.isSpaceBetweenTokens(first, second)) {
           reportNoBeginningSpace(node, first);
         }
         if (isMultiline(penultimate, last)) {
           if (!multiline) {
-            reportNoEndingNewline(node, last);
+            reportNoEndingNewline(node, last, spacing);
           }
         } else if (sourceCode.isSpaceBetweenTokens(penultimate, last)) {
           reportNoEndingSpace(node, last);

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -29,8 +29,21 @@ ruleTester.run('jsx-curly-spacing', rule, {
   valid: [{
     code: '<App foo={bar} />;'
   }, {
+    code: [
+      '<App foo={',
+      '{ bar: true, baz: true }',
+      '} />;'
+    ].join('\n')
+  }, {
     code: '<App foo={bar} />;',
     options: ['never']
+  }, {
+    code: [
+      '<App foo={',
+      '{ bar: true, baz: true }',
+      '} />;'
+    ].join('\n'),
+    options: ['never', {spacing: {objectLiterals: 'never'}}]
   }, {
     code: '<App foo={ bar } />;',
     options: ['always']
@@ -41,12 +54,19 @@ ruleTester.run('jsx-curly-spacing', rule, {
     code: '<App foo={{ bar:baz }} />;',
     options: ['never']
   }, {
+    code: [
+      '<App foo={',
+      '{ bar: true, baz: true }',
+      '} />;'
+    ].join('\n'),
+    options: ['never']
+  }, {
     code: '<App foo={ {bar:baz} } />;',
     options: ['always']
   }, {
     code: [
       '<App foo={',
-      'bar',
+      '{ bar: true, baz: true }',
       '} />;'
     ].join('\n'),
     options: ['always']
@@ -92,6 +112,13 @@ ruleTester.run('jsx-curly-spacing', rule, {
       '} />;'
     ].join('\n'),
     options: ['always', {allowMultiline: true}]
+  }, {
+    code: [
+      '<App foo={',
+      '{ bar: true, baz: true }',
+      '} />;'
+    ].join('\n'),
+    options: ['always', {spacing: {objectLiterals: 'never'}}]
   }, {
     code: '<App {...bar} />;'
   }, {
@@ -181,6 +208,58 @@ ruleTester.run('jsx-curly-spacing', rule, {
       message: 'There should be no space after \'{\''
     }, {
       message: 'There should be no space before \'}\''
+    }]
+  }, {
+    code: [
+      '<App foo={',
+      '{ bar: true, baz: true }',
+      '} />;'
+    ].join('\n'),
+    output: '<App foo={{ bar: true, baz: true }} />;',
+    options: ['never', {allowMultiline: false, spacing: {objectLiterals: 'never'}}],
+    errors: [{
+      message: 'There should be no newline after \'{\''
+    }, {
+      message: 'There should be no newline before \'}\''
+    }]
+  }, {
+    code: [
+      '<App foo={',
+      '{ bar: true, baz: true }',
+      '} />;'
+    ].join('\n'),
+    output: '<App foo={ { bar: true, baz: true } } />;',
+    options: ['never', {allowMultiline: false, spacing: {objectLiterals: 'always'}}],
+    errors: [{
+      message: 'There should be no newline after \'{\''
+    }, {
+      message: 'There should be no newline before \'}\''
+    }]
+  }, {
+    code: [
+      '<App foo={',
+      '{ bar: true, baz: true }',
+      '} />;'
+    ].join('\n'),
+    output: '<App foo={{ bar: true, baz: true }} />;',
+    options: ['always', {allowMultiline: false, spacing: {objectLiterals: 'never'}}],
+    errors: [{
+      message: 'There should be no newline after \'{\''
+    }, {
+      message: 'There should be no newline before \'}\''
+    }]
+  }, {
+    code: [
+      '<App foo={',
+      '{ bar: true, baz: true }',
+      '} />;'
+    ].join('\n'),
+    output: '<App foo={ { bar: true, baz: true } } />;',
+    options: ['always', {allowMultiline: false, spacing: {objectLiterals: 'always'}}],
+    errors: [{
+      message: 'There should be no newline after \'{\''
+    }, {
+      message: 'There should be no newline before \'}\''
     }]
   }, {
     code: '<App foo={bar} />;',


### PR DESCRIPTION
From comment https://github.com/yannickcr/eslint-plugin-react/issues/857#issuecomment-299698993:

> Found another bug:
>
> ```
> <App foo={
> { bar: true, baz: true }
> } />;
> ```
> This would get 2 errors using the default settings: `There should be no space after '{'` and `There should be no space before '}'`.
>
> This is because conditions for the object literal spacing were written so that the second one was never reached:
>
> ```
>           if (sourceCode.isSpaceBetweenTokens(first, second)) {
>             reportNoBeginningSpace(node, first);
>           } else if (!config.allowMultiline && isMultiline(first, second)) {
>             reportNoBeginningNewline(node, first, config);
>           }
> ```
> If the first condition fails, `isMultiline` will return `false` - there is no newline.
>
> Will fix this and add appropriate tests.