### PR TITLE
FIX: wrong syntax in docs for prop-types rule

### DIFF
--- a/docs/rules/no-unused-prop-types.md
+++ b/docs/rules/no-unused-prop-types.md
@@ -47,7 +47,7 @@ This rule can take one argument to ignore some specific props during validation.
 
 ```
 ...
-"no-unused-prop-types": [<enabled>, { customValidators: <customValidator>, skipShapeProps: <skipShapeProps> }]
+"react/no-unused-prop-types": [<enabled>, { customValidators: <customValidator>, skipShapeProps: <skipShapeProps> }]
 ...
 ```
 

--- a/docs/rules/prop-types.md
+++ b/docs/rules/prop-types.md
@@ -102,7 +102,7 @@ This rule can take one argument to ignore some specific props during validation.
 
 ```
 ...
-"prop-types": [<enabled>, { ignore: <ignore>, customValidators: <customValidator> }]
+"react/prop-types": [<enabled>, { ignore: <ignore>, customValidators: <customValidator> }]
 ...
 ```
 


### PR DESCRIPTION
This fixes the syntax in the docs for the prop-types rule: "prop-types" (wrong) instead of "react/prop-types" (correct)