### PR TITLE
fix: void-dom-elements-no-children

### DIFF
--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -110,7 +110,7 @@ module.exports = {
           return;
         }
 
-        if (args.length < 2) {
+        if (args.length < 2 || args[1].type !== 'ObjectExpression') {
           return;
         }
 

--- a/tests/lib/rules/void-dom-elements-no-children.js
+++ b/tests/lib/rules/void-dom-elements-no-children.js
@@ -55,6 +55,11 @@ ruleTester.run('void-dom-elements-no-children', rule, {
       code: 'React.createElement("img");'
     }, {
       code: [
+        'const props = {}',
+        'React.createElement("img", props)'
+      ].join('\n')
+    }, {
+      code: [
         'import React from "react";',
         'const { createElement } = React;',
         'createElement("div")'

--- a/tests/lib/rules/void-dom-elements-no-children.js
+++ b/tests/lib/rules/void-dom-elements-no-children.js
@@ -63,28 +63,25 @@ ruleTester.run('void-dom-elements-no-children', rule, {
         'import React from "react";',
         'const { createElement } = React;',
         'createElement("div")'
-      ].join('\n'),
-      parser: 'babel-eslint'
+      ].join('\n')
     }, {
       code: [
         'import React from "react";',
         'const { createElement } = React;',
         'createElement("img")'
-      ].join('\n'),
-      parser: 'babel-eslint'
+      ].join('\n')
     }, {
       code: [
         'import React, {createElement, PureComponent} from \'react\';',
         'class Button extends PureComponent {',
-        '  handleClick = ev => {',
+        '  handleClick(ev) {',
         '    ev.preventDefault();',
         '  }',
         '  render() {',
         '    return <div onClick={this.handleClick}>Hello</div>;',
         '  }',
         '}'
-      ].join('\n'),
-      parser: 'babel-eslint'
+      ].join('\n')
     }
   ],
   invalid: [


### PR DESCRIPTION
For some reason, we were using the following pattern that eslint **don't like**:
```js
const props = {}
React.createElement('img', props)
```