### PR TITLE
Small document improvements

### DIFF
--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -6,11 +6,12 @@ Ensure correct position of the first property.
 
 ## Rule Details
 
-This rule checks whether the first property of all JSX elements is correctly placed. There are three possible configurations:
+This rule checks whether the first property of all JSX elements is correctly placed. There are the possible configurations:
+
 * `always`: The first property should always be placed on a new line.
 * `never` : The first property should never be placed on a new line, e.g. should always be on the same line as the Component opening tag.
 * `multiline`: The first property should always be placed on a new line when the JSX tag takes up multiple lines.
-* `multiline-multiprop`: The first property should always be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties. `default`
+* `multiline-multiprop`: The first property should always be placed on a new line if the JSX tag takes up multiple lines and there are multiple properties. This is the `default` value.
 
 The following patterns are considered warnings when configured `"always"`:
 

--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -1,10 +1,19 @@
 # Prevent missing parentheses around multiline JSX (jsx-wrap-multilines)
 
-Wrapping multiline JSX in parentheses can improve readability and/or convenience. It optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, `"declaration"`, `"assignment"`, `"return"`, and `"arrow"` syntax is checked, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior (become enabled).
+Wrapping multiline JSX in parentheses can improve readability and/or convenience.
 
 **Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
+
+This rule optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, all the syntax listed below will be checked, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior (become enabled).
+
+There are the possible syntax available:
+
+* `declaration`
+* `assignment`
+* `return`
+* `arrow`
 
 The following patterns are considered warnings:
 
@@ -32,20 +41,80 @@ var Hello = createReactClass({
     );
   }
 });
+```
 
-// When [1, {declaration: false}]
+The following patterns are considered warnings when configured `{declaration: true}`.
+
+```jsx
+var hello = <div>
+  <p>Hello</p>
+</div>;
+```
+
+The following patterns are not considered warnings when configured `{declaration: true}`.
+
+```jsx
+var hello = (
+  <div>
+    <p>Hello</p>
+  </div>
+);
+```
+
+The following patterns are considered warnings when configured `{assignment: true}`.
+
+```jsx
 var hello;
 hello = <div>
   <p>Hello</p>
-</div>
+</div>;
+```
 
-// When [1, {declaration: true, assignment: false, return: true}]
-var world = <div>
-  <p>World</p>
-</div>
+The following patterns are not considered warnings when configured `{assignment: true}`.
 
-// When [1, {arrow: false}]
+```jsx
+var hello;
+hello = (
+  <div>
+    <p>Hello</p>
+  </div>
+);
+```
+The following patterns are considered warnings when configured `{return: true}`.
+
+```jsx
+function hello() {
+  return <div>
+    <p>Hello</p>
+  </div>;
+}
+```
+
+The following patterns are not considered warnings when configured `{return: true}`.
+
+```jsx
+function hello() {
+  return (
+    <div>
+      <p>Hello</p>
+    </div>
+  );
+}
+```
+The following patterns are considered warnings when configured `{arrow: true}`.
+
+```jsx
 var hello = () => <div>
   <p>World</p>
-</div>
+</div>;
+```
+
+The following patterns are not considered warnings when configured `{arrow: true}`.
+
+```jsx
+var hello = () => (
+  <div>
+    <p>World</p>
+  </div>
+);
 ```


### PR DESCRIPTION
* Fix typos and clarify default value for `jsx-first-prop-new-line.md`.
* Clarify options and examples for `jsx-wrap-multilines.md`.
