### PR TITLE
Fix false positive in no-unused-proptype

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -99,9 +99,12 @@ Components.prototype.list = function() {
       component = this.get(node);
     }
     if (component) {
-      usedPropTypes[this._getId(component.node)] = (this._list[i].usedPropTypes || []).filter(function(propType) {
+      var newUsedProps = (this._list[i].usedPropTypes || []).filter(function(propType) {
         return !propType.node || propType.node.kind !== 'init';
       });
+
+      var componentId = this._getId(component.node);
+      usedPropTypes[componentId] = (usedPropTypes[componentId] || []).concat(newUsedProps);
     }
   }
   // Assign used props in not confident components to the parent component

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -99,11 +99,11 @@ Components.prototype.list = function() {
       component = this.get(node);
     }
     if (component) {
-      var newUsedProps = (this._list[i].usedPropTypes || []).filter(function(propType) {
+      const newUsedProps = (this._list[i].usedPropTypes || []).filter(function(propType) {
         return !propType.node || propType.node.kind !== 'init';
       });
 
-      var componentId = this._getId(component.node);
+      const componentId = this._getId(component.node);
       usedPropTypes[componentId] = (usedPropTypes[componentId] || []).concat(newUsedProps);
     }
   }

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1439,6 +1439,51 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // The next two test cases are related to: https://github.com/yannickcr/eslint-plugin-react/issues/1183
+      code: [
+        'export default function SomeComponent(props) {',
+        '    const callback = () => {',
+        '        props.a(props.b);',
+        '    };',
+        '',
+        '    const anotherCallback = () => {};',
+        '',
+        '    return (',
+        '        <SomeOtherComponent',
+        '            name={props.c}',
+        '            callback={callback}',
+        '        />',
+        '    );',
+        '}',
+        '',
+        'SomeComponent.propTypes = {',
+        '    a: React.PropTypes.func.isRequired,',
+        '    b: React.PropTypes.string.isRequired,',
+        '    c: React.PropTypes.string.isRequired,',
+        '};'
+      ].join('\n')
+    }, {
+      code: [
+        'export default function SomeComponent(props) {',
+        '    const callback = () => {',
+        '        props.a(props.b);',
+        '    };',
+        '',
+        '    return (',
+        '        <SomeOtherComponent',
+        '            name={props.c}',
+        '            callback={callback}',
+        '        />',
+        '    );',
+        '}',
+        '',
+        'SomeComponent.propTypes = {',
+        '    a: React.PropTypes.func.isRequired,',
+        '    b: React.PropTypes.string.isRequired,',
+        '    c: React.PropTypes.string.isRequired,',
+        '};'
+      ].join('\n')
     }
   ],
 


### PR DESCRIPTION
This related to the following issue: https://github.com/yannickcr/eslint-plugin-react/issues/1183. It also seems to fix: https://github.com/yannickcr/eslint-plugin-react/issues/1135

**Note**: I am not very experienced with the code base. I took a look at this bug to learn a bit more about the code. Therefore I am not sure if my solution is the right solution - but in the worst case perhaps it can help someone else figure out the real issue if it is completely wrong. All the tests continue to pass and I added tests that were failing before my changes.

I tracked the issue down to `components.list()` function.

* It seems that both these callbacks are somehow evaluated to `true` for the condition on line 101: `if (component) {` -- this part seems a bit weird to me? Why are these functions components?
* The existing code then assigned the list of `usedPropTypes` for that "component" to `usedPropTypes[this._getId(component.node)]`

But because of the direct assigning, the second time the code here is executed it will overwrite the values that were stored the first time.

So with the example false positive we have:

```
    const callback = () => {
        props.a(props.b);
    };

    const anotherCallback = () => {};
```

* When the loop function detects `callback`, it then assigns `prop a` and `prop b` to `usedPropTypes[myComponentId]`
* When the loop function detects `anotherCallback`, it then overwrites the existing array of usedPropTypes and replaces it with an empty list (since no props are used in `anotherCallback`).

This also explains why the other examples work:

```
    const callback = () => {
        props.a(props.b);
    };
```

In here there is no second callback that overwrites the first array.

```
    const anotherCallback = () => {};

    const callback = () => {
        props.a(props.b);
    };
```

In here we overwrite the first callback that assigns an empty array with an array that contains the used props.

My fix includes not a direct assignment, but adding the detected propTypes to the existing list if a list already exists.
