### PR TITLE
Fix regression bug in jsx-sort-props

### DIFF
--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -150,6 +150,8 @@ module.exports = {
           var currentPropName = propName(decl);
           var previousValue = memo.value;
           var currentValue = decl.value;
+          var previousIsCallback = isCallbackPropName(previousPropName);
+          var currentIsCallback = isCallbackPropName(currentPropName);
 
           if (ignoreCase) {
             previousPropName = previousPropName.toLowerCase();
@@ -186,9 +188,6 @@ module.exports = {
           }
 
           if (callbacksLast) {
-            var previousIsCallback = isCallbackPropName(previousPropName);
-            var currentIsCallback = isCallbackPropName(currentPropName);
-
             if (!previousIsCallback && currentIsCallback) {
               // Entering the callback prop section
               return decl;

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -56,6 +56,10 @@ var expectedInvalidReservedFirstError = {
 var callbacksLastArgs = [{
   callbacksLast: true
 }];
+var ignoreCaseAndCallbackLastArgs = [{
+  callbacksLast: true,
+  ignoreCase: true
+}];
 var shorthandFirstArgs = [{
   shorthandFirst: true
 }];
@@ -109,6 +113,7 @@ ruleTester.run('jsx-sort-props', rule, {
     {code: '<App A b C />;', options: ignoreCaseArgs},
     // Sorting callbacks below all other props
     {code: '<App a z onBar onFoo />;', options: callbacksLastArgs},
+    {code: '<App z onBar onFoo />;', options: ignoreCaseAndCallbackLastArgs},
     // Sorting shorthand props before others
     {code: '<App a b="b" />;', options: shorthandFirstArgs},
     {code: '<App z a="a" />;', options: shorthandFirstArgs},


### PR DESCRIPTION
This is a fix for: https://github.com/yannickcr/eslint-plugin-react/issues/1175

I have explained the problem already in the issue, but a quick recap:

* Bug only occurs when using `ignoreCase: true` and `callbacksLast: true`
* `isCallbackPropName(propName)` looks for pattern: `on[A-Z]`
* This pattern can't be found after `toLowerCase()` has been executed (because of `ignoreCase: true`

Bug was introduced in 7.0.0. Reverted the code to how it was working originally, and added a test case to cover this specific combination of options.