### PR TITLE
Support lifecycle methods with nextProps/prevProps in no-unused-prop-types

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -16,8 +16,10 @@ var annotations = require('../util/annotations');
 // Constants
 // ------------------------------------------------------------------------------
 
-var DIRECT_PROPS_REGEX = /^props\s*(\.|\[)/;
-var DIRECT_NEXT_PROPS_REGEX = /^nextProps\s*(\.|\[)/;
+const DIRECT_PROPS_REGEX = /^props\s*(\.|\[)/;
+const DIRECT_NEXT_PROPS_REGEX = /^nextProps\s*(\.|\[)/;
+const DIRECT_PREV_PROPS_REGEX = /^prevProps\s*(\.|\[)/;
+const LIFE_CYCLE_METHODS = ['componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -78,15 +80,16 @@ module.exports = {
     }
 
     /**
-     * Check if we are in a class constructor
+     * Check if we are in a lifecycle method
      * @return {boolean} true if we are in a class constructor, false if not
      **/
-    function inComponentWillReceiveProps() {
+    function inLifeCycleMethod() {
       var scope = context.getScope();
       while (scope) {
         if (
           scope.block && scope.block.parent &&
-          scope.block.parent.key && scope.block.parent.key.name === 'componentWillReceiveProps'
+          scope.block.parent.key &&
+            LIFE_CYCLE_METHODS.includes(scope.block.parent.key.name)
         ) {
           return true;
         }
@@ -106,8 +109,7 @@ module.exports = {
         node.object.type === 'ThisExpression' && node.property.name === 'props'
       );
       var isStatelessFunctionUsage = node.object.name === 'props';
-      var isNextPropsUsage = node.object.name === 'nextProps' && inComponentWillReceiveProps();
-      return isClassUsage || isStatelessFunctionUsage || isNextPropsUsage;
+      return isClassUsage || isStatelessFunctionUsage || inLifeCycleMethod();
     }
 
     /**
@@ -511,16 +513,17 @@ module.exports = {
     function getPropertyName(node) {
       var isDirectProp = DIRECT_PROPS_REGEX.test(sourceCode.getText(node));
       var isDirectNextProp = DIRECT_NEXT_PROPS_REGEX.test(sourceCode.getText(node));
+      var isDirectPrevProp = DIRECT_PREV_PROPS_REGEX.test(sourceCode.getText(node));
       var isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
       var isNotInConstructor = !inConstructor(node);
-      var isNotInComponentWillReceiveProps = !inComponentWillReceiveProps();
-      if ((isDirectProp || isDirectNextProp)
+      var isNotInLifeCycleMethod = !inLifeCycleMethod();
+      if ((isDirectProp || isDirectNextProp || isDirectPrevProp)
         && isInClassComponent
         && isNotInConstructor
-        && isNotInComponentWillReceiveProps) {
+        && isNotInLifeCycleMethod) {
         return void 0;
       }
-      if (!isDirectProp && !isDirectNextProp) {
+      if (!isDirectProp && !isDirectNextProp && !isDirectPrevProp) {
         node = node.parent;
       }
       var property = node.property;

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -89,7 +89,7 @@ module.exports = {
         if (
           scope.block && scope.block.parent &&
           scope.block.parent.key &&
-            LIFE_CYCLE_METHODS.includes(scope.block.parent.key.name)
+            LIFE_CYCLE_METHODS.indexOf(scope.block.parent.key.name) >= 0
         ) {
           return true;
         }

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2696,8 +2696,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
-        line: 19,
-        column: 10
+        line: 10,
+        column: 8
       }]
     }, {
       code: [
@@ -2736,8 +2736,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
-        line: 19,
-        column: 10
+        line: 10,
+        column: 8
       }]
     }, {
       code: [
@@ -2776,8 +2776,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
-        line: 19,
-        column: 10
+        line: 10,
+        column: 8
       }]
     }
     /* , {

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2572,7 +2572,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         line: 4,
         column: 10
       }]
-    }, , {
+    }, {
       code: [
         'class Hello extends Component {',
         '  static propTypes = {',
@@ -2593,7 +2593,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         line: 4,
         column: 10
       }]
-    }, , {
+    }, {
       code: [
         'class Hello extends Component {',
         '  static propTypes = {',

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1484,6 +1484,127 @@ ruleTester.run('no-unused-prop-types', rule, {
         '    c: React.PropTypes.string.isRequired,',
         '};'
       ].join('\n')
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  shouldComponentUpdate (props) {',
+        '    if (props.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  componentWillUpdate (props) {',
+        '    if (props.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  componentWillReceiveProps (nextProps) {',
+        '    const {foo} = nextProps;',
+        '    if (foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  shouldComponentUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  componentWillUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  componentDidUpdate (prevProps) {',
+        '    if (prevProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
     }
   ],
 
@@ -2430,7 +2551,71 @@ ruleTester.run('no-unused-prop-types', rule, {
         line: 3,
         column: 16
       }]
-    }/* , {
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  componentWillUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'bar\' PropType is defined but prop is never used',
+        line: 4,
+        column: 10
+      }]
+    }, , {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  shouldComponentUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'bar\' PropType is defined but prop is never used',
+        line: 4,
+        column: 10
+      }]
+    }, , {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string,',
+        '    bar: PropTypes.string,',
+        '  };',
+        '',
+        '  componentDidUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'bar\' PropType is defined but prop is never used',
+        line: 4,
+        column: 10
+      }]
+    }
+    /* , {
       // Enable this when the following issue is fixed
       // https://github.com/yannickcr/eslint-plugin-react/issues/296
       code: [

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1507,6 +1507,24 @@ ruleTester.run('no-unused-prop-types', rule, {
     }, {
       code: [
         'class Hello extends Component {',
+        '  shouldComponentUpdate (props) {',
+        '    if (props.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n')
+    }, {
+      code: [
+        'class Hello extends Component {',
         '  static propTypes = {',
         '    foo: PropTypes.string,',
         '    bar: PropTypes.string,',
@@ -1524,6 +1542,24 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  componentWillUpdate (props) {',
+        '    if (props.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n')
     }, {
       code: [
         'class Hello extends Component {',
@@ -1548,6 +1584,24 @@ ruleTester.run('no-unused-prop-types', rule, {
     }, {
       code: [
         'class Hello extends Component {',
+        '  componentWillReceiveProps (props) {',
+        '    if (props.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n')
+    }, {
+      code: [
+        'class Hello extends Component {',
         '  static propTypes = {',
         '    foo: PropTypes.string,',
         '    bar: PropTypes.string,',
@@ -1565,6 +1619,24 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  shouldComponentUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n')
     }, {
       code: [
         'class Hello extends Component {',
@@ -1588,6 +1660,24 @@ ruleTester.run('no-unused-prop-types', rule, {
     }, {
       code: [
         'class Hello extends Component {',
+        '  componentWillUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n')
+    }, {
+      code: [
+        'class Hello extends Component {',
         '  static propTypes = {',
         '    foo: PropTypes.string,',
         '    bar: PropTypes.string,',
@@ -1605,6 +1695,24 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  componentDidUpdate (prevProps) {',
+        '    if (prevProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '',
+        '  render() {',
+        '    return (<div>{this.props.bar}</div>);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n')
     }
   ],
 
@@ -2575,6 +2683,25 @@ ruleTester.run('no-unused-prop-types', rule, {
     }, {
       code: [
         'class Hello extends Component {',
+        '  componentWillUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n'),
+      errors: [{
+        message: '\'bar\' PropType is defined but prop is never used',
+        line: 19,
+        column: 10
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
         '  static propTypes = {',
         '    foo: PropTypes.string,',
         '    bar: PropTypes.string,',
@@ -2596,6 +2723,25 @@ ruleTester.run('no-unused-prop-types', rule, {
     }, {
       code: [
         'class Hello extends Component {',
+        '  shouldComponentUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n'),
+      errors: [{
+        message: '\'bar\' PropType is defined but prop is never used',
+        line: 19,
+        column: 10
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
         '  static propTypes = {',
         '    foo: PropTypes.string,',
         '    bar: PropTypes.string,',
@@ -2612,6 +2758,25 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 4,
+        column: 10
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  componentDidUpdate (nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return true;',
+        '    }',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string,',
+        '  bar: PropTypes.string,',
+        '};'
+      ].join('\n'),
+      errors: [{
+        message: '\'bar\' PropType is defined but prop is never used',
+        line: 19,
         column: 10
       }]
     }


### PR DESCRIPTION
https://github.com/yannickcr/eslint-plugin-react/issues/1213 https://github.com/yannickcr/eslint-plugin-react/issues/1142#issuecomment-304737468

This makes the no-unused-prop-types work when a prop is used in React lifecycle components other than `componentWillReceiveProps` using the "dot-operator". E.g:

```
shouldComponentUpdate(nextProps) {
   if (nextProps.foo) { // This will now be detected
       ...
  }
```

There is one thing to keep in mind: under the current implementation the rule will only work if the parameter is named `nextProps`, `prevProps` or `props`. This logic already existed and I did not want to touch it, though I thought it was kind of odd. Do we want to keep it that way? 

Perhaps we could introduce a rule that validates the parameter names in lifecycle methods - sometimes it's confusing anyway whether `shouldComponentUpdate` has `prevProps` or `nextProps` as the parameter, and what is the order of `nextProps` or `nextState`. Anyway, this would be for another issue.