### PR TITLE
Register prop-types when set through Flow SuperTypeParameters

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -151,6 +151,21 @@ module.exports = {
       return false;
     }
 
+/**
+ * Checks if we are declaring a props as a generic type in a flow-annotated class.
+ *
+ * @param {ASTNode} node  the AST node being checked.
+ * @returns {Boolean} True if the node is a class with generic prop types, false if not.
+ */
+    function isSuperTypeParameterPropsDeclaration(node) {
+      if (node && node.type === 'ClassDeclaration') {
+        if (node.superTypeParameters && node.superTypeParameters.params.length >= 2) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     /**
      * Checks if we are declaring a prop
      * @param {ASTNode} node The AST node being checked.
@@ -804,6 +819,23 @@ module.exports = {
     }
 
     /**
+     * Resolve the type annotation for a given class declaration node with superTypeParameters.
+     *
+     * @param {ASTNode} node The annotation or a node containing the type annotation.
+     * @returns {ASTNode} The resolved type annotation for the node.
+     */
+    function resolveSuperParameterPropsType(node) {
+      var annotation = node.superTypeParameters.params[1];
+      while (annotation && (annotation.type === 'TypeAnnotation' || annotation.type === 'NullableTypeAnnotation')) {
+        annotation = annotation.typeAnnotation;
+      }
+      if (annotation.type === 'GenericTypeAnnotation' && typeScope(annotation.id.name)) {
+        return typeScope(annotation.id.name);
+      }
+      return annotation;
+    }
+
+    /**
      * @param {ASTNode} node We expect either an ArrowFunctionExpression,
      *   FunctionDeclaration, or FunctionExpression
      */
@@ -839,6 +871,12 @@ module.exports = {
     // --------------------------------------------------------------------------
 
     return {
+      ClassDeclaration: function(node) {
+        if (isSuperTypeParameterPropsDeclaration(node)) {
+          markPropTypesAsDeclared(node, resolveSuperParameterPropsType(node));
+        }
+      },
+
       ClassProperty: function(node) {
         if (isAnnotatedClassPropsDeclaration(node)) {
           markPropTypesAsDeclared(node, resolveTypeAnnotation(node));

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1414,6 +1414,88 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Person = {',
+        '  firstname: string',
+        '};',
+        'class Hello extends React.Component<void, Person, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Person = {',
+        '  firstname: string',
+        '};',
+        'class Hello extends React.Component<void, Person, void> {',
+        '  render () {',
+        '    const { firstname } = this.props;',
+        '    return <div>Hello {firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Person = {',
+        '  firstname: string',
+        '};',
+        'class Hello extends React.Component<void, Person, void> {',
+        '  render () {',
+        '    const {',
+        '      firstname,',
+        '    } = this.props;',
+        '    return <div>Hello {firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Props = {name: {firstname: string;};};',
+        'class Hello extends React.Component<void, Props, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.name.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'import type Props from "fake";',
+        'class Hello extends React.Component<void, Props, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Person = {',
+        '  firstname: string',
+        '};',
+        'class Hello extends React.Component<void, { person: Person }, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.person.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Props = {result?: {ok?: ?string | boolean;}|{ok?: ?number | Array}};',
+        'class Hello extends React.Component<void, Props, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.result.ok}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
     }
   ],
 
@@ -2603,6 +2685,114 @@ ruleTester.run('prop-types', rule, {
       errors: [
         {message: '\'name\' is missing in props validation'}
       ]
+    }, {
+      code: [
+        'type Person = {',
+        '  firstname: string',
+        '};',
+        'class Hello extends React.Component<void, Person, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.lastname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      errors: [{
+        message: '\'lastname\' is missing in props validation',
+        line: 6,
+        column: 35,
+        type: 'Identifier'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Person = {',
+        '  firstname: string',
+        '};',
+        'class Hello extends React.Component<void, Person, void> {',
+        '  render () {',
+        '    const { lastname } = this.props;',
+        '    return <div>Hello {lastname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      errors: [{
+        message: '\'lastname\' is missing in props validation',
+        line: 6,
+        column: 13,
+        type: 'Property'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Person = {',
+        '  firstname: string',
+        '};',
+        'class Hello extends React.Component<void, Person, void> {',
+        '  render () {',
+        '    const {',
+        '      lastname,',
+        '    } = this.props;',
+        '    return <div>Hello {lastname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      errors: [{
+        message: '\'lastname\' is missing in props validation',
+        line: 7,
+        column: 7,
+        type: 'Property'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Props = {name: {firstname: string;};};',
+        'class Hello extends React.Component<void, Props, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.name.lastname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      errors: [{
+        message: '\'name.lastname\' is missing in props validation',
+        line: 4,
+        column: 40,
+        type: 'Identifier'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Props = {result?: {ok: string | boolean;}|{ok: number | Array}};',
+        'class Hello extends React.Component<void, Props, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.result.notok}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      errors: [{
+        message: '\'result.notok\' is missing in props validation',
+        line: 4,
+        column: 42,
+        type: 'Identifier'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Person = {',
+        '  firstname: string',
+        '};',
+        'class Hello extends React.Component<void, { person: Person }, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.person.lastname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      errors: [{
+        message: '\'person.lastname\' is missing in props validation',
+        line: 6,
+        column: 42,
+        type: 'Identifier'
+      }],
+      parser: 'babel-eslint'
     }
   ]
 });


### PR DESCRIPTION
This picks up prop types when set using flow [SuperTypeParameters ](https://flow.org/en/docs/frameworks/react/) such as:
```
type Props = { /* ... */ };

class MyComponent extends React.Component<void, Props, void> {
  ...
}
```

@ljharb This is modified from the property annotation checks. However, I couldn't test the wrapped `TypeAnnotation` or `NullableTypeAnnotation` resolution checks.