### PR TITLE
#969 fix: exception for jsx-no-duplicate-props

### DIFF
--- a/lib/rules/jsx-no-duplicate-props.js
+++ b/lib/rules/jsx-no-duplicate-props.js
@@ -45,7 +45,11 @@ module.exports = {
 
           let name = decl.name.name;
 
-          if (ignoreCase && typeof name === 'string') {
+          if (typeof name !== 'string') {
+            return;
+          }
+
+          if (ignoreCase) {
             name = name.toLowerCase();
           }
 

--- a/lib/rules/jsx-no-duplicate-props.js
+++ b/lib/rules/jsx-no-duplicate-props.js
@@ -45,7 +45,7 @@ module.exports = {
 
           let name = decl.name.name;
 
-          if (ignoreCase) {
+          if (ignoreCase && typeof name === 'string') {
             name = name.toLowerCase();
           }
 

--- a/tests/lib/rules/jsx-no-duplicate-props.js
+++ b/tests/lib/rules/jsx-no-duplicate-props.js
@@ -49,7 +49,8 @@ ruleTester.run('jsx-no-duplicate-props', rule, {
     {code: '<App c="a" {...this.props} a="c" b="b" />;'},
     {code: '<App A a />;'},
     {code: '<App A b a />;'},
-    {code: '<App A="a" b="b" B="B" />;'}
+    {code: '<App A="a" b="b" B="B" />;'},
+    {code: '<App a:b="c" />;', options: ignoreCaseArgs}
   ],
   invalid: [
     {code: '<App a a />;', errors: [expectedError]},


### PR DESCRIPTION
jsx-no-duplicate-props is causing error. 
TypeError: name.toLowerCase is not a function. 
When <Element {...props}> is used.