### PR TITLE
Treat "key" without value as a valid case instead for "no-array-index-key"

### DIFF
--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -177,8 +177,8 @@ module.exports = {
         }
 
         var value = node.value;
-        if (value.type !== 'JSXExpressionContainer') {
-          // key='foo'
+        if (!value || value.type !== 'JSXExpressionContainer') {
+          // key='foo' or just simply 'key'
           return;
         }
 

--- a/tests/lib/rules/no-array-index-key.js
+++ b/tests/lib/rules/no-array-index-key.js
@@ -30,6 +30,7 @@ ruleTester.run('no-array-index-key', rule, {
   valid: [
     {code: '<Foo key="foo" />;'},
     {code: '<Foo key={i} />;'},
+    {code: '<Foo key />;'},
     {code: '<Foo key={`foo-${i}`} />;'},
     {code: '<Foo key={\'foo-\' + i} />;'},
 
@@ -69,6 +70,10 @@ ruleTester.run('no-array-index-key', rule, {
         '  })',
         '})'
       ].join('\n')
+    },
+
+    {
+      code: 'foo.map((baz, i) => <Foo key />)'
     },
 
     {


### PR DESCRIPTION
Fixes https://github.com/yannickcr/eslint-plugin-react/issues/1242