### PR TITLE
Fix nested object type spread

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -480,13 +480,23 @@ module.exports = {
           }
           return true;
         case 'ObjectTypeAnnotation':
+          let containsObjectTypeSpread = false;
           var shapeTypeDefinition = {
             type: 'shape',
             children: {}
           };
           iterateProperties(annotation.properties, function(childKey, childValue) {
-            shapeTypeDefinition.children[childKey] = buildTypeAnnotationDeclarationTypes(childValue);
+            if (!childKey && !childValue) {
+              containsObjectTypeSpread = true;
+            } else {
+              shapeTypeDefinition.children[childKey] = buildTypeAnnotationDeclarationTypes(childValue);
+            }
           });
+
+          // nested object type spread means we need to ignore/accept everything in this object
+          if (containsObjectTypeSpread) {
+            return true;
+          }
           return shapeTypeDefinition;
         case 'UnionTypeAnnotation':
           var unionTypeDefinition = {

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1417,6 +1417,67 @@ ruleTester.run('prop-types', rule, {
     }, {
       code: [
         'type Person = {',
+        '  ...$Exact<data>,',
+        '  lastname: string',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'import type {Data} from \'./Data\'',
+        'type Person = {',
+        '  ...Data,',
+        '  lastname: string',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.bar}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'import type {Data} from \'some-libdef-like-flow-typed-provides\'',
+        'type Person = {',
+        '  ...Data,',
+        '  lastname: string',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.bar}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'import type {BasePerson} from \'./types\'',
+        'type Props = {',
+        '  person: {',
+        '   ...$Exact<BasePerson>,',
+        '   lastname: string',
+        '  }',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  render () {',
+        '    return <div>Hello {this.props.person.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'type Person = {',
         '  firstname: string',
         '};',
         'class Hello extends React.Component<void, Person, void> {',


### PR DESCRIPTION
Closes #1255 

Object type spreads are ignored, but only at the top level.  This ignores object type spreads at any level.