### PR TITLE
ES6-ify void-dom-elements-no-children rule and test file

### DIFF
--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -5,9 +5,9 @@
  */
 'use strict';
 
-var has = require('has');
+const has = require('has');
 
-var Components = require('../util/Components');
+const Components = require('../util/Components');
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -15,7 +15,7 @@ var Components = require('../util/Components');
 
 // Using an object here to avoid array scan. We should switch to Set once
 // support is good enough.
-var VOID_DOM_ELEMENTS = {
+const VOID_DOM_ELEMENTS = {
   area: true,
   base: true,
   br: true,
@@ -56,10 +56,10 @@ module.exports = {
     schema: []
   },
 
-  create: Components.detect(function(context, components, utils) {
+  create: Components.detect((context, components, utils) => {
     return {
       JSXElement: function(node) {
-        var elementName = node.openingElement.name.name;
+        const elementName = node.openingElement.name.name;
 
         if (!isVoidDOMElement(elementName)) {
           // e.g. <div />
@@ -74,9 +74,9 @@ module.exports = {
           });
         }
 
-        var attributes = node.openingElement.attributes;
+        const attributes = node.openingElement.attributes;
 
-        var hasChildrenAttributeOrDanger = attributes.some(function(attribute) {
+        const hasChildrenAttributeOrDanger = attributes.some((attribute) => {
           if (!attribute.name) {
             return false;
           }
@@ -102,8 +102,8 @@ module.exports = {
           return;
         }
 
-        var args = node.arguments;
-        var elementName = args[0].value;
+        const args = node.arguments;
+        const elementName = args[0].value;
 
         if (!isVoidDOMElement(elementName)) {
           // e.g. React.createElement('div');
@@ -114,7 +114,7 @@ module.exports = {
           return;
         }
 
-        var firstChild = args[2];
+        const firstChild = args[2];
         if (firstChild) {
           // e.g. React.createElement('br', undefined, 'Foo')
           context.report({
@@ -123,9 +123,9 @@ module.exports = {
           });
         }
 
-        var props = args[1].properties;
+        const props = args[1].properties;
 
-        var hasChildrenPropOrDanger = props.some(function(prop) {
+        const hasChildrenPropOrDanger = props.some((prop) => {
           if (!prop.key) {
             return false;
           }

--- a/tests/lib/rules/void-dom-elements-no-children.js
+++ b/tests/lib/rules/void-dom-elements-no-children.js
@@ -9,10 +9,10 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-var rule = require('../../../lib/rules/void-dom-elements-no-children');
-var RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/void-dom-elements-no-children');
+const RuleTester = require('eslint').RuleTester;
 
-var parserOptions = {
+const parserOptions = {
   ecmaVersion: 8,
   sourceType: 'module',
   ecmaFeatures: {
@@ -29,7 +29,7 @@ function errorMessage(elementName) {
 // Tests
 // -----------------------------------------------------------------------------
 
-var ruleTester = new RuleTester({parserOptions});
+const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('void-dom-elements-no-children', rule, {
   valid: [
     {
@@ -49,39 +49,39 @@ ruleTester.run('void-dom-elements-no-children', rule, {
     },
     {
       code: 'React.createElement("div", { dangerouslySetInnerHTML: { __html: "Foo" } });'
-    }, {
-      code: 'document.createElement("img")'
-    }, {
+    },
+    {
+      code: 'document.createElement("img");'
+    },
+    {
       code: 'React.createElement("img");'
     }, {
-      code: [
-        'const props = {}',
-        'React.createElement("img", props)'
-      ].join('\n')
+      code: `
+        const props = {};
+        React.createElement("img", props);
+      `
     }, {
-      code: [
-        'import React from "react";',
-        'const { createElement } = React;',
-        'createElement("div")'
-      ].join('\n')
+      code: `
+        import React, {createElement} from "react";
+        createElement("div");
+      `
     }, {
-      code: [
-        'import React from "react";',
-        'const { createElement } = React;',
-        'createElement("img")'
-      ].join('\n')
+      code: `
+        import React, {createElement} from "react";
+        createElement("img");
+      `
     }, {
-      code: [
-        'import React, {createElement, PureComponent} from \'react\';',
-        'class Button extends PureComponent {',
-        '  handleClick(ev) {',
-        '    ev.preventDefault();',
-        '  }',
-        '  render() {',
-        '    return <div onClick={this.handleClick}>Hello</div>;',
-        '  }',
-        '}'
-      ].join('\n')
+      code: `
+        import React, {createElement, PureComponent} from "react";
+        class Button extends PureComponent {
+          handleClick(ev) {
+            ev.preventDefault();
+          }
+          render() {
+            return <div onClick={this.handleClick}>Hello</div>;
+          }
+        }
+      `
     }
   ],
   invalid: [
@@ -114,29 +114,26 @@ ruleTester.run('void-dom-elements-no-children', rule, {
       errors: [{message: errorMessage('br')}]
     },
     {
-      code: [
-        'import React from "react";',
-        'const createElement = React.createElement;',
-        'createElement("img", {}, "Foo");'
-      ].join('\n'),
+      code: `
+        import React, {createElement} from "react";
+        createElement("img", {}, "Foo");
+      `,
       errors: [{message: errorMessage('img')}],
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'import React from "react";',
-        'const createElement = React.createElement;',
-        'createElement("img", { children: "Foo" });'
-      ].join('\n'),
+      code: `
+        import React, {createElement} from "react";
+        createElement("img", { children: "Foo" });
+      `,
       errors: [{message: errorMessage('img')}],
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'import React from "react";',
-        'const createElement = React.createElement;',
-        'createElement("img", { dangerouslySetInnerHTML: { __html: "Foo" } });'
-      ].join('\n'),
+      code: `
+        import React, {createElement} from "react";
+        createElement("img", { dangerouslySetInnerHTML: { __html: "Foo" } });
+      `,
       errors: [{message: errorMessage('img')}],
       parser: 'babel-eslint'
     }


### PR DESCRIPTION
I've seen in issue #1240 that using some new patterns from node 4 would be a nice addition. 

Starting out I only updated the ```void-dom-elements-no-children``` rule and test file to use:
* ```const``` and ```let``` instead of ```var```
* Arrow funtions
* Template literals instead of ```[].join()```
* Some minor unification of formatting

I've also seen a [comment](https://github.com/yannickcr/eslint-plugin-react/blob/master/lib/rules/void-dom-elements-no-children.js#L16) in the rule file that using Set would be nice, which is also available with node 4. Can I make that conversion too?

Is this PR okay, and if so, is there a preferred way I should continue with updating?