### PR TITLE
Add support for conditional rendering to jsx-multiline-wrap

### DIFF
--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -133,7 +133,7 @@ The following patterns are considered warnings when configured `{conditional: tr
 </div>
 ```
 
-The following patterns are not considered warnings when configured `{arrow: true}`.
+The following patterns are not considered warnings when configured `{conditional: true}`.
 
 ```jsx
 <div>

--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -6,7 +6,7 @@ Wrapping multiline JSX in parentheses can improve readability and/or convenience
 
 ## Rule Details
 
-This rule optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, all the syntax listed below will be checked, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior (become enabled).
+This rule optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, all the syntax listed below will be checked except the conditionals, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior (become enabled).
 
 There are the possible syntax available:
 
@@ -14,6 +14,7 @@ There are the possible syntax available:
 * `assignment`
 * `return`
 * `arrow`
+* `conditional` (not enabled by default)
 
 The following patterns are considered warnings:
 
@@ -101,6 +102,7 @@ function hello() {
   );
 }
 ```
+
 The following patterns are considered warnings when configured `{arrow: true}`.
 
 ```jsx
@@ -117,4 +119,28 @@ var hello = () => (
     <p>World</p>
   </div>
 );
+```
+
+The following patterns are considered warnings when configured `{conditional: true}`.
+
+```jsx
+<div>
+  {myExpression &&
+    <div>
+      <p>Hello World</p>
+    </div>
+  }
+</div>
+```
+
+The following patterns are not considered warnings when configured `{arrow: true}`.
+
+```jsx
+<div>
+  {myExpression && (
+    <div>
+      <p>Hello World</p>
+    </div>
+  )}
+</div>
 ```

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -137,12 +137,10 @@ module.exports = {
 
         const rightNode = node.expression.right;
 
-        check(rightNode, (fixer) => {
-          return [
-            fixer.insertTextAfterRange(sourceCode.getTokenBefore(rightNode).range, ' ('),
-            fixer.insertTextBeforeRange(sourceCode.getLastToken(node).range, ')')
-          ];
-        });
+        check(rightNode, fixer => ([
+          fixer.insertTextAfterRange(sourceCode.getTokenBefore(rightNode).range, ' ('),
+          fixer.insertTextBeforeRange(sourceCode.getLastToken(node).range, ')')
+        ]));
       },
 
       'ArrowFunctionExpression:exit': function (node) {

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -70,7 +70,7 @@ module.exports = {
       return node.loc.start.line !== node.loc.end.line;
     }
 
-    function check(node) {
+    function check(node, fixerFn) {
       if (!node || node.type !== 'JSXElement') {
         return;
       }
@@ -79,7 +79,7 @@ module.exports = {
         context.report({
           node: node,
           message: 'Missing parentheses around multilines JSX',
-          fix: function(fixer) {
+          fix: fixerFn || function(fixer) {
             return fixer.replaceText(node, `(${sourceCode.getText(node)})`);
           }
         });
@@ -135,7 +135,14 @@ module.exports = {
           return;
         }
 
-        check(node.expression.right);
+        const rightNode = node.expression.right;
+
+        check(rightNode, (fixer) => {
+          return [
+            fixer.insertTextAfterRange(sourceCode.getTokenBefore(rightNode).range, ' ('),
+            fixer.insertTextBeforeRange(sourceCode.getLastToken(node).range, ')')
+          ];
+        });
       },
 
       'ArrowFunctionExpression:exit': function (node) {

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -14,7 +14,8 @@ const DEFAULTS = {
   declaration: true,
   assignment: true,
   return: true,
-  arrow: true
+  arrow: true,
+  conditional: false
 };
 
 // ------------------------------------------------------------------------------
@@ -43,6 +44,9 @@ module.exports = {
           type: 'boolean'
         },
         arrow: {
+          type: 'boolean'
+        },
+        conditional: {
           type: 'boolean'
         }
       },
@@ -124,6 +128,14 @@ module.exports = {
         if (isEnabled('return')) {
           check(node.argument);
         }
+      },
+
+      JSXExpressionContainer: function(node) {
+        if (!isEnabled('conditional')) {
+          return;
+        }
+
+        check(node.expression.right);
       },
 
       'ArrowFunctionExpression:exit': function (node) {

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -134,6 +134,12 @@ const ARROW_NO_PAREN = `
   </div>;
 `;
 
+const CONDITIONAL_SINGLE_LINE = `
+  <div>
+    {unreadMessages.length > 0 && <div>Hello World</div>}
+  </div>
+`;
+
 const CONDITIONAL_PAREN = `
   <div>
     {unreadMessages.length > 0 &&
@@ -211,6 +217,9 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: CONDITIONAL_PAREN
     }, {
       code: CONDITIONAL_PAREN,
+      options: [{conditional: true}]
+    }, {
+      code: CONDITIONAL_SINGLE_LINE,
       options: [{conditional: true}]
     }, {
       code: CONDITIONAL_NO_PAREN

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -142,16 +142,6 @@ const CONDITIONAL_SINGLE_LINE = `
 
 const CONDITIONAL_PAREN = `
   <div>
-    {unreadMessages.length > 0 &&
-      (<h2>
-        You have {unreadMessages.length} unread messages.
-      </h2>)
-    }
-  </div>
-`;
-
-const CONDITIONAL_PAREN_DIFFERENT_LINE = `
-  <div>
     {unreadMessages.length > 0 && (
       <h2>
         You have {unreadMessages.length} unread messages.
@@ -227,9 +217,6 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: CONDITIONAL_PAREN
     }, {
       code: CONDITIONAL_PAREN,
-      options: [{conditional: true}]
-    }, {
-      code: CONDITIONAL_PAREN_DIFFERENT_LINE,
       options: [{conditional: true}]
     }, {
       code: CONDITIONAL_SINGLE_LINE,

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -150,6 +150,16 @@ const CONDITIONAL_PAREN = `
   </div>
 `;
 
+const CONDITIONAL_PAREN_DIFFERENT_LINE = `
+  <div>
+    {unreadMessages.length > 0 && (
+      <h2>
+        You have {unreadMessages.length} unread messages.
+      </h2>
+    )}
+  </div>
+`;
+
 const CONDITIONAL_NO_PAREN = `
   <div>
     {unreadMessages.length > 0 &&
@@ -217,6 +227,9 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: CONDITIONAL_PAREN
     }, {
       code: CONDITIONAL_PAREN,
+      options: [{conditional: true}]
+    }, {
+      code: CONDITIONAL_PAREN_DIFFERENT_LINE,
       options: [{conditional: true}]
     }, {
       code: CONDITIONAL_SINGLE_LINE,

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -134,6 +134,26 @@ const ARROW_NO_PAREN = `
   </div>;
 `;
 
+const CONDITIONAL_PAREN = `
+  <div>
+    {unreadMessages.length > 0 &&
+      (<h2>
+        You have {unreadMessages.length} unread messages.
+      </h2>)
+    }
+  </div>
+`;
+
+const CONDITIONAL_NO_PAREN = `
+  <div>
+    {unreadMessages.length > 0 &&
+      <h2>
+        You have {unreadMessages.length} unread messages.
+      </h2>
+    }
+  </div>
+`;
+
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -187,6 +207,13 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     }, {
       code: ARROW_NO_PAREN,
       options: [{arrow: false}]
+    }, {
+      code: CONDITIONAL_PAREN
+    }, {
+      code: CONDITIONAL_PAREN,
+      options: [{conditional: true}]
+    }, {
+      code: CONDITIONAL_NO_PAREN
     }
   ],
 
@@ -236,6 +263,11 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: ARROW_NO_PAREN,
       output: ARROW_PAREN,
       options: [{arrow: true}],
+      errors: [{message: 'Missing parentheses around multilines JSX'}]
+    }, {
+      code: CONDITIONAL_NO_PAREN,
+      output: CONDITIONAL_PAREN,
+      options: [{conditional: true}],
       errors: [{message: 'Missing parentheses around multilines JSX'}]
     }
   ]


### PR DESCRIPTION
Main issue: https://github.com/yannickcr/eslint-plugin-react/issues/1282

I tried to make the fixer better so the output has the parens in the correct place. Probably, need to add a few more tests, but I think the current solution looks quite solid.

The rule is defaulted to `false` initially. If enabling it by default, a bigger version bump would be required?

See also some comments on another issue regarding `jsx-multiline-wrap`: https://github.com/yannickcr/eslint-plugin-react/issues/1207#issuecomment-313086986

