### PR TITLE
Use full name of the rule

### DIFF
--- a/docs/rules/default-props-match-prop-types.md
+++ b/docs/rules/default-props-match-prop-types.md
@@ -154,7 +154,7 @@ NotAComponent.propTypes = {
 
 ```js
 ...
-"default-props-match-prop-types": [<enabled>, { "allowRequiredDefaults": <boolean> }]
+"react/default-props-match-prop-types": [<enabled>, { "allowRequiredDefaults": <boolean> }]
 ...
 ```
 


### PR DESCRIPTION
When adding this rule in my project, I wasn't sure if it's `react/default-props-match-prop-types` or `default-props-match-prop-types`... Use the full name should be clear.