### PR TITLE
Add lifecycle methods check to no-typos rule

### DIFF
--- a/docs/rules/no-typos.md
+++ b/docs/rules/no-typos.md
@@ -1,17 +1,30 @@
 # Prevents common casing typos (react/no-typos)
 
-Ensure no casing typos were made declaring static class properties
+Ensure no casing typos were made declaring static class properties and lifecycle methods.
 
 ## Rule Details
 
-This rule checks whether the declared static class properties related to React components
-do not contain any typos. It currently makes sure that the following class properties have
+This rule checks whether the declared static class properties and lifecycle methods related to React components
+do not contain any typos.
+
+It currently makes sure that the following class properties have
 no casing typos:
 
 * propTypes
 * contextTypes
 * childContextTypes
 * defaultProps
+
+and the following react lifecycle methods:
+
+* componentWillMount
+* componentDidMount
+* componentWillReceiveProps
+* shouldComponentUpdate
+* componentWillUpdate
+* componentDidUpdate
+* componentWillUnmount
+
 
 The following patterns are considered warnings:
 
@@ -47,6 +60,18 @@ class MyComponent extends React.Component {
 class MyComponent extends React.Component {
   static defaultprops = {}
 }
+
+class MyComponent extends React.Component {
+  componentwillMount() {}
+}
+
+class MyComponent extends React.Component {
+  ComponentWillReceiveProps() {}
+}
+
+class MyComponent extends React.Component {
+  componentdidupdate() {}
+}
 ```
 
 The following patterns are not considered warnings:
@@ -66,5 +91,17 @@ class MyComponent extends React.Component {
 
 class MyComponent extends React.Component {
   static defaultProps = {}
+}
+
+class MyComponent extends React.Component {
+  componentWillMount() {}
+}
+
+class MyComponent extends React.Component {
+  componentWillReceiveProps() {}
+}
+
+class MyComponent extends React.Component {
+  componentDidUpdate() {}
 }
 ```

--- a/docs/rules/no-typos.md
+++ b/docs/rules/no-typos.md
@@ -24,6 +24,7 @@ and the following react lifecycle methods:
 * componentWillUpdate
 * componentDidUpdate
 * componentWillUnmount
+* render
 
 
 The following patterns are considered warnings:

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -78,7 +78,7 @@ module.exports = {
       },
 
       MethodDefinition: function (node) {
-        if (!utils.isES6Component(node.parent.parent) || utils.isReturningJSX(node.parent.parent)) {
+        if (!utils.isES6Component(node.parent.parent)) {
           return;
         }
 

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -17,7 +17,8 @@ const LIFECYCLE_METHODS = [
   'shouldComponentUpdate',
   'componentWillUpdate',
   'componentDidUpdate',
-  'componentWillUnmount'
+  'componentWillUnmount',
+  'render'
 ];
 
 module.exports = {

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -31,7 +31,7 @@ module.exports = {
   },
 
   create: Components.detect((context, components, utils) => {
-    function reportErrorIfCasingTypo(node, propertyName) {
+    function reportErrorIfClassPropertyCasingTypo(node, propertyName) {
       STATIC_CLASS_PROPERTIES.forEach(CLASS_PROP => {
         if (propertyName && CLASS_PROP.toLowerCase() === propertyName.toLowerCase() && CLASS_PROP !== propertyName) {
           context.report({
@@ -43,7 +43,7 @@ module.exports = {
     }
 
     function reportErrorIfLifecycleMethodCasingTypo(node) {
-      LIFECYCLE_METHODS.forEach(function(method) {
+      LIFECYCLE_METHODS.forEach(method => {
         if (method.toLowerCase() === node.key.name.toLowerCase() && method !== node.key.name) {
           context.report({
             node: node,
@@ -61,7 +61,7 @@ module.exports = {
 
         const tokens = context.getFirstTokens(node, 2);
         const propertyName = tokens[1].value;
-        reportErrorIfCasingTypo(node, propertyName);
+        reportErrorIfClassPropertyCasingTypo(node, propertyName);
       },
 
       MemberExpression: function(node) {
@@ -72,7 +72,7 @@ module.exports = {
           (utils.isES6Component(relatedComponent.node) || utils.isReturningJSX(relatedComponent.node))
         ) {
           const propertyName = node.property.name;
-          reportErrorIfCasingTypo(node, propertyName);
+          reportErrorIfClassPropertyCasingTypo(node, propertyName);
         }
       },
 

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -10,6 +10,15 @@ const Components = require('../util/Components');
 // ------------------------------------------------------------------------------
 
 const STATIC_CLASS_PROPERTIES = ['propTypes', 'contextTypes', 'childContextTypes', 'defaultProps'];
+const LIFECYCLE_METHODS = [
+  'componentWillMount',
+  'componentDidMount',
+  'componentWillReceiveProps',
+  'shouldComponentUpdate',
+  'componentWillUpdate',
+  'componentDidUpdate',
+  'componentWillUnmount'
+];
 
 module.exports = {
   meta: {
@@ -28,6 +37,17 @@ module.exports = {
           context.report({
             node: node,
             message: 'Typo in static class property declaration'
+          });
+        }
+      });
+    }
+
+    function reportErrorIfLifecycleMethodCasingTypo(node) {
+      LIFECYCLE_METHODS.forEach(function(method) {
+        if (method.toLowerCase() === node.key.name.toLowerCase() && method !== node.key.name) {
+          context.report({
+            node: node,
+            message: 'Typo in component lifecycle method declaration'
           });
         }
       });
@@ -54,6 +74,14 @@ module.exports = {
           const propertyName = node.property.name;
           reportErrorIfCasingTypo(node, propertyName);
         }
+      },
+
+      MethodDefinition: function (node) {
+        if (!utils.isES6Component(node.parent.parent) || utils.isReturningJSX(node.parent.parent)) {
+          return;
+        }
+
+        reportErrorIfLifecycleMethodCasingTypo(node);
       }
     };
   })

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -185,43 +185,58 @@ ruleTester.run('no-typos', rule, {
   }, {
     code: [
       'class Hello extends React.Component {',
-      '  componentDidUpdate() { }',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
-    parserOptions: parserOptions
-  }, {
-    code: [
-      'class Hello extends React.Component {',
       '  componentWillMount() { }',
-      '  componentDidUpdate() { }',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
-    parserOptions: parserOptions
-  }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentWillUnmount() { }',
-      '  componentWillMount() { }',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
-    parserOptions: parserOptions
-  }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  shouldComponentUpdate() { }',
+      '  componentDidMount() { }',
       '  componentWillReceiveProps() { }',
+      '  shouldComponentUpdate() { }',
+      '  componentWillUpdate() { }',
+      '  componentDidUpdate() { }',
+      '  componentWillUnmount() { }',
       '  render() {',
       '    return <div>Hello {this.props.name}</div>;',
       '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class MyClass {',
+      '  componentWillMount() { }',
+      '  componentDidMount() { }',
+      '  componentWillReceiveProps() { }',
+      '  shouldComponentUpdate() { }',
+      '  componentWillUpdate() { }',
+      '  componentDidUpdate() { }',
+      '  componentWillUnmount() { }',
+      '  render() { }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class MyClass {',
+      '  componentwillmount() { }',
+      '  componentdidmount() { }',
+      '  componentwillreceiveprops() { }',
+      '  shouldcomponentupdate() { }',
+      '  componentwillupdate() { }',
+      '  componentdidupdate() { }',
+      '  componentwillUnmount() { }',
+      '  render() { }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class MyClass {',
+      '  Componentwillmount() { }',
+      '  Componentdidmount() { }',
+      '  Componentwillreceiveprops() { }',
+      '  Shouldcomponentupdate() { }',
+      '  Componentwillupdate() { }',
+      '  Componentdidupdate() { }',
+      '  ComponentwillUnmount() { }',
+      '  Render() { }',
       '}'
     ].join('\n'),
     parserOptions: parserOptions
@@ -414,7 +429,13 @@ ruleTester.run('no-typos', rule, {
   }, {
     code: [
       'class Hello extends React.Component {',
+      '  ComponentWillMount() { }',
+      '  ComponentDidMount() { }',
+      '  ComponentWillReceiveProps() { }',
+      '  ShouldComponentUpdate() { }',
+      '  ComponentWillUpdate() { }',
       '  ComponentDidUpdate() { }',
+      '  ComponentWillUnmount() { }',
       '  render() {',
       '    return <div>Hello {this.props.name}</div>;',
       '  }',
@@ -424,11 +445,76 @@ ruleTester.run('no-typos', rule, {
     errors: [{
       message: ERROR_MESSAGE_LIFECYCLE_METHOD,
       type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
     }]
   }, {
     code: [
       'class Hello extends React.Component {',
+      '  Componentwillmount() { }',
+      '  Componentdidmount() { }',
+      '  Componentwillreceiveprops() { }',
+      '  Shouldcomponentupdate() { }',
+      '  Componentwillupdate() { }',
+      '  Componentdidupdate() { }',
+      '  Componentwillunmount() { }',
+      '  Render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  componentwillmount() { }',
+      '  componentdidmount() { }',
       '  componentwillreceiveprops() { }',
+      '  shouldcomponentupdate() { }',
+      '  componentwillupdate() { }',
+      '  componentdidupdate() { }',
+      '  componentwillunmount() { }',
       '  render() {',
       '    return <div>Hello {this.props.name}</div>;',
       '  }',
@@ -438,19 +524,22 @@ ruleTester.run('no-typos', rule, {
     errors: [{
       message: ERROR_MESSAGE_LIFECYCLE_METHOD,
       type: 'MethodDefinition'
-    }]
-  }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentWillReceiveProps() { }',
-      '  componentWillupdate() { }',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
-    parserOptions: parserOptions,
-    errors: [{
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }, {
       message: ERROR_MESSAGE_LIFECYCLE_METHOD,
       type: 'MethodDefinition'
     }]

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -22,6 +22,7 @@ const parserOptions = {
 // -----------------------------------------------------------------------------
 
 const ERROR_MESSAGE = 'Typo in static class property declaration';
+const ERROR_MESSAGE_LIFECYCLE_METHOD = 'Typo in component lifecycle method declaration';
 
 const ruleTester = new RuleTester();
 ruleTester.run('no-typos', rule, {
@@ -179,6 +180,49 @@ ruleTester.run('no-typos', rule, {
       'First[contextTypes] = {};',
       'First[childContextTypes] = {};',
       'First[defautProps] = {};'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  componentDidUpdate() { }',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  componentWillMount() { }',
+      '  componentDidUpdate() { }',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  componentWillUnmount() { }',
+      '  componentWillMount() { }',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  shouldComponentUpdate() { }',
+      '  componentWillReceiveProps() { }',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
     ].join('\n'),
     parserOptions: parserOptions
   }],
@@ -367,5 +411,48 @@ ruleTester.run('no-typos', rule, {
     ].join('\n'),
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  ComponentDidUpdate() { }',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  componentwillreceiveprops() { }',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  componentWillReceiveProps() { }',
+      '  componentWillupdate() { }',
+      '  render() {',
+      '    return <div>Hello {this.props.name}</div>;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: ERROR_MESSAGE_LIFECYCLE_METHOD,
+      type: 'MethodDefinition'
+    }]
   }]
 });


### PR DESCRIPTION
`no-typos` rule currently checks for class properties (`defaultProps`, `childContextTypes` etc.) only. 

My attempt is to make sure that react lifecycle methods also do not have any casing typos.

The following patterns are considered warnings:

```js
class MyComponent extends React.Component {
  componentwillMount() {}
}

class MyComponent extends React.Component {
  ComponentWillReceiveProps() {}
}

class MyComponent extends React.Component {
  componentdidupdate() {}
}
```

The following patterns are not considered warnings:

```js
class MyComponent extends React.Component {
  componentWillMount() {}
}

class MyComponent extends React.Component {
  componentWillReceiveProps() {}
}

class MyComponent extends React.Component {
  componentDidUpdate() {}
}
```
I'm open to improvements to this rule. Thanks!