### PR TITLE
Fix crash in jsx-no-target-blank

### DIFF
--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -25,7 +25,7 @@ function hasExternalLink(element) {
 
 function hasSecureRel(element) {
   return element.attributes.find(function (attr) {
-    if (attr.name.name === 'rel') {
+    if (attr.type === 'JSXAttribute' && attr.name.name === 'rel') {
       const tags = attr.value && attr.value.type === 'Literal' && attr.value.value.toLowerCase().split(' ');
       return tags && (tags.indexOf('noopener') >= 0 && tags.indexOf('noreferrer') >= 0);
     }

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -15,7 +15,7 @@ function isTargetBlank(attr) {
 }
 
 function hasExternalLink(element) {
-  return element.attributes.find(function (attr) {
+  return element.attributes.some(function (attr) {
     return attr.name &&
       attr.name.name === 'href' &&
       attr.value.type === 'Literal' &&

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -31,6 +31,7 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {code: '<a randomTag></a>'},
     {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>'},
     {code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>'},
+    {code: '<a {...spreadProps} target="_blank" rel="noopener noreferrer" href="http://example.com">s</a>'},
     {code: '<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>'},
     {code: '<p target="_blank"></p>'},
     {code: '<a href="foobar" target="_BLANK" rel="NOOPENER noreferrer"></a>'},


### PR DESCRIPTION
`{...spreadProps}` was not working correctly in case there was an external url. Added test case + fix + a small code refactor.

Should fix https://github.com/yannickcr/eslint-plugin-react/issues/1296