### PR TITLE
Fix false positives in no-literals

### DIFF
--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -44,6 +44,7 @@ module.exports = {
 
     function getValidation(node) {
       const standard = !/^[\s]+$/.test(node.value) &&
+          typeof node.value === 'string' &&
           node.parent &&
           node.parent.type.indexOf('JSX') !== -1 &&
           node.parent.type !== 'JSXAttribute';

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -64,6 +64,12 @@ module.exports = {
         if (getValidation(node)) {
           reportLiteralNode(node);
         }
+      },
+
+      TemplateLiteral: function(node) {
+        if (isNoStrings && node.parent.type === 'JSXExpressionContainer') {
+          reportLiteralNode(node);
+        }
       }
 
     };

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -127,6 +127,18 @@ ruleTester.run('jsx-no-literals', rule, {
       parser: 'babel-eslint',
       options: [{noStrings: true}]
     }, {
+      code: '<Foo bar={true} />',
+      parser: 'babel-eslint',
+      options: [{noStrings: true}]
+    }, {
+      code: '<Foo bar={false} />',
+      parser: 'babel-eslint',
+      options: [{noStrings: true}]
+    }, {
+      code: '<Foo bar={100} />',
+      parser: 'babel-eslint',
+      options: [{noStrings: true}]
+    }, {
       code: `
         <Foo bar="test">
           {intl.formatText(message)}
@@ -140,7 +152,17 @@ ruleTester.run('jsx-no-literals', rule, {
         </Foo>
       `,
       options: [{noStrings: true}]
+    }, {
+      code: '<Foo bar={true} />',
+      options: [{noStrings: true}]
+    }, {
+      code: '<Foo bar={false} />',
+      options: [{noStrings: true}]
+    }, {
+      code: '<Foo bar={100} />',
+      options: [{noStrings: true}]
     }
+
   ],
 
   invalid: [

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -127,48 +127,6 @@ ruleTester.run('jsx-no-literals', rule, {
       parser: 'babel-eslint',
       options: [{noStrings: true}]
     }, {
-      code: '<Foo bar={true} />',
-      parser: 'babel-eslint',
-      options: [{noStrings: true}]
-    }, {
-      code: '<Foo bar={false} />',
-      parser: 'babel-eslint',
-      options: [{noStrings: true}]
-    }, {
-      code: '<Foo bar={100} />',
-      parser: 'babel-eslint',
-      options: [{noStrings: true}]
-    }, {
-      code: '<Foo bar={null} />',
-      parser: 'babel-eslint',
-      options: [{noStrings: true}]
-    }, {
-      code: '<Foo bar={{}} />',
-      parser: 'babel-eslint',
-      options: [{noStrings: true}]
-    }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  asdf() {}',
-        '  render() {',
-        '    return <Foo bar={this.asdf} />;',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint',
-      options: [{noStrings: true}]
-    }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    let foo = `bar`;',
-        '    return <div />;',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint',
-      options: [{noStrings: true}]
-    }, {
       code: `
         <Foo bar="test">
           {intl.formatText(message)}
@@ -351,20 +309,6 @@ ruleTester.run('jsx-no-literals', rule, {
         '  {`Test`}',
         '</Foo>'
       ].join('\n'),
-      parser: 'babel-eslint',
-      options: [{noStrings: true}],
-      errors: [{message: 'Strings not allowed in JSX files'}]
-    }, {
-      code: [
-        '<Foo>',
-        '  {`Test`}',
-        '</Foo>'
-      ].join('\n'),
-      options: [{noStrings: true}],
-      errors: [{message: 'Strings not allowed in JSX files'}]
-    }, {
-      code: '<Foo bar={`Test`} />',
-      parser: 'babel-eslint',
       options: [{noStrings: true}],
       errors: [{message: 'Strings not allowed in JSX files'}]
     }, {

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -139,6 +139,36 @@ ruleTester.run('jsx-no-literals', rule, {
       parser: 'babel-eslint',
       options: [{noStrings: true}]
     }, {
+      code: '<Foo bar={null} />',
+      parser: 'babel-eslint',
+      options: [{noStrings: true}]
+    }, {
+      code: '<Foo bar={{}} />',
+      parser: 'babel-eslint',
+      options: [{noStrings: true}]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  asdf() {}',
+        '  render() {',
+        '    return <Foo bar={this.asdf} />;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      options: [{noStrings: true}]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    let foo = `bar`;',
+        '    return <div />;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      options: [{noStrings: true}]
+    }, {
       code: `
         <Foo bar="test">
           {intl.formatText(message)}
@@ -160,6 +190,32 @@ ruleTester.run('jsx-no-literals', rule, {
       options: [{noStrings: true}]
     }, {
       code: '<Foo bar={100} />',
+      options: [{noStrings: true}]
+    }, {
+      code: '<Foo bar={null} />',
+      options: [{noStrings: true}]
+    }, {
+      code: '<Foo bar={{}} />',
+      options: [{noStrings: true}]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  asdf() {}',
+        '  render() {',
+        '    return <Foo bar={this.asdf} />;',
+        '  }',
+        '}'
+      ].join('\n'),
+      options: [{noStrings: true}]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    let foo = `bar`;',
+        '    return <div />;',
+        '  }',
+        '}'
+      ].join('\n'),
       options: [{noStrings: true}]
     }
 
@@ -287,6 +343,32 @@ ruleTester.run('jsx-no-literals', rule, {
           Test
         </Foo>
       `,
+      options: [{noStrings: true}],
+      errors: [{message: 'Strings not allowed in JSX files'}]
+    }, {
+      code: [
+        '<Foo>',
+        '  {`Test`}',
+        '</Foo>'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      options: [{noStrings: true}],
+      errors: [{message: 'Strings not allowed in JSX files'}]
+    }, {
+      code: [
+        '<Foo>',
+        '  {`Test`}',
+        '</Foo>'
+      ].join('\n'),
+      options: [{noStrings: true}],
+      errors: [{message: 'Strings not allowed in JSX files'}]
+    }, {
+      code: '<Foo bar={`Test`} />',
+      parser: 'babel-eslint',
+      options: [{noStrings: true}],
+      errors: [{message: 'Strings not allowed in JSX files'}]
+    }, {
+      code: '<Foo bar={`Test`} />',
       options: [{noStrings: true}],
       errors: [{message: 'Strings not allowed in JSX files'}]
     }


### PR DESCRIPTION
This rule should only check strings.

Fixes #1301