### PR TITLE
no-unused-props: not ignoring components with no used props

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -175,7 +175,6 @@ module.exports = {
     function mustBeValidated(component) {
       return Boolean(
         component &&
-        component.usedPropTypes &&
         !component.ignorePropsValidation
       );
     }
@@ -234,8 +233,9 @@ module.exports = {
      * @returns {Boolean} True if the prop is used, false if not.
      */
     function isPropUsed(node, prop) {
-      for (let i = 0, l = node.usedPropTypes.length; i < l; i++) {
-        const usedProp = node.usedPropTypes[i];
+      const usedPropTypes = node.usedPropTypes || [];
+      for (let i = 0, l = usedPropTypes.length; i < l; i++) {
+        const usedProp = usedPropTypes[i];
         if (
           prop.type === 'shape' ||
           prop.name === '__ANY_KEY__' ||
@@ -895,6 +895,13 @@ module.exports = {
           default:
             break;
         }
+      },
+
+      JSXSpreadAttribute: function(node) {
+        const component = components.get(utils.getParentComponent());
+        components.set(component ? component.node : node, {
+          ignorePropsValidation: true
+        });
       },
 
       MethodDefinition: function(node) {

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -559,26 +559,6 @@ ruleTester.run('no-unused-prop-types', rule, {
       options: [{customValidators: ['CustomValidator']}]
     }, {
       code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return <span />;',
-        '  }',
-        '}',
-        'Comp1.propTypes = {',
-        '  prop1: PropTypes.number',
-        '};',
-        'class Comp2 extends Component {',
-        '  render() {',
-        '    return <span />;',
-        '  }',
-        '}',
-        'Comp2.propTypes = {',
-        '  prop2: PropTypes.arrayOf(Comp1.propTypes.prop1)',
-        '};'
-      ].join('\n'),
-      parser: 'babel-eslint'
-    }, {
-      code: [
         'const SomeComponent = createReactClass({',
         '  propTypes: SomeOtherComponent.propTypes',
         '});'
@@ -781,54 +761,6 @@ ruleTester.run('no-unused-prop-types', rule, {
         '    );',
         '  }',
         '});'
-      ].join('\n')
-    }, {
-      code: [
-        'const statelessComponent = (props) => {',
-        '  const subRender = () => {',
-        '    return <span>{props.someProp}</span>;',
-        '  };',
-        '  return <div>{subRender()}</div>;',
-        '};',
-        'statelessComponent.propTypes = {',
-        '  someProp: PropTypes.string',
-        '};'
-      ].join('\n')
-    }, {
-      code: [
-        'const statelessComponent = ({ someProp }) => {',
-        '  const subRender = () => {',
-        '    return <span>{someProp}</span>;',
-        '  };',
-        '  return <div>{subRender()}</div>;',
-        '};',
-        'statelessComponent.propTypes = {',
-        '  someProp: PropTypes.string',
-        '};'
-      ].join('\n')
-    }, {
-      code: [
-        'const statelessComponent = function({ someProp }) {',
-        '  const subRender = () => {',
-        '    return <span>{someProp}</span>;',
-        '  };',
-        '  return <div>{subRender()}</div>;',
-        '};',
-        'statelessComponent.propTypes = {',
-        '  someProp: PropTypes.string',
-        '};'
-      ].join('\n')
-    }, {
-      code: [
-        'function statelessComponent({ someProp }) {',
-        '  const subRender = () => {',
-        '    return <span>{someProp}</span>;',
-        '  };',
-        '  return <div>{subRender()}</div>;',
-        '};',
-        'statelessComponent.propTypes = {',
-        '  someProp: PropTypes.string',
-        '};'
       ].join('\n')
     }, {
       code: [
@@ -3214,6 +3146,21 @@ ruleTester.run('no-unused-prop-types', rule, {
         message: '\'foo\' PropType is defined but prop is never used',
         line: 11,
         column: 8
+      }]
+    }, { // None of the props are used issue #1162
+      code: [
+        'import React from "react"; ',
+        'var Hello = React.createReactClass({',
+        ' propTypes: {',
+        '   name: React.PropTypes.string',
+        ' },',
+        ' render: function() {',
+        '   return <div>Hello Bob</div>;',
+        '  }',
+        '});'
+      ].join('\n'),
+      errors: [{
+        message: '\'name\' PropType is defined but prop is never used'
       }]
     }
     /* , {

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -3162,6 +3162,34 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'name\' PropType is defined but prop is never used'
       }]
+    }, {
+      code: [
+        'class Comp1 extends Component {',
+        '  render() {',
+        '    return <span />;',
+        '  }',
+        '}',
+        'Comp1.propTypes = {',
+        '  prop1: PropTypes.number',
+        '};',
+        'class Comp2 extends Component {',
+        '  render() {',
+        '    return <span />;',
+        '  }',
+        '}',
+        'Comp2.propTypes = {',
+        '  prop2: PropTypes.arrayOf(Comp1.propTypes.prop1)',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'prop1\' PropType is defined but prop is never used'
+      }, {
+        message: '\'prop2\' PropType is defined but prop is never used'
+      }, {
+        message: '\'prop2.*\' PropType is defined but prop is never used'
+      }]
+
     }
     /* , {
       // Enable this when the following issue is fixed


### PR DESCRIPTION
This is tackling one of the many issues with the rule (issue #1162).

The problem was that the rule simply ignored the components that had no used properties. Once this condition was removed I had to fix some tests and remove some other (that were never actually worked correctly but were passing because of the component had no used props and thus was excluded from validation).

This change might fix few more false positives that users reported. I am planning to go through the list of open issues for the rule and close/fix some more after I get some feedback on my change.
