### PR TITLE
Fix incorrect propType warning inside .map

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -617,7 +617,7 @@ module.exports = {
           throw new Error(`${node.type} ASTNodes are not handled by markPropTypesAsUsed`);
       }
 
-      const component = components.get(utils.getParentComponent());
+      const component = components.get(utils.getParentComponent() || node, true);
       const usedPropTypes = component && component.usedPropTypes || [];
       let ignorePropsValidation = component && component.ignorePropsValidation || false;
 

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -49,11 +49,14 @@ Components.prototype.add = function(node, confidence) {
  * Find a component in the list using its node
  *
  * @param {ASTNode} node The AST node being searched.
+ * @param {Boolean} findParent True if the node's parent can be returned if the node isn't found, false if not
  * @returns {Object} Component object, undefined if the component is not found
  */
-Components.prototype.get = function(node) {
-  const id = this._getId(node);
-  return this._list[id];
+Components.prototype.get = function(node, findParent) {
+  while (findParent && node && !this._list[this._getId(node)]) {
+    node = node.parent;
+  }
+  return this._list[this._getId(node)];
 };
 
 /**

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -739,6 +739,21 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: [
+        'const Inner = (props) => <span>{props.innerOne} {props.innerTwo}</span>;',
+        'const Outer = (props) => {',
+        '  let team = props.names.map(() => (',
+        '      <Inner innerOne={props.one} innerTwo={props.two} />',
+        '    ));',
+        '  return <ul>{team}</ul>;',
+        '};',
+        'Outer.propTypes = {',
+        '  names: PropTypes.array,',
+        '  one: PropTypes.string,',
+        '  two: PropTypes.string',
+        '};'
+      ].join('\n')
+    }, {
+      code: [
         'export default {',
         '  renderHello() {',
         '    let {name} = this.props;',


### PR DESCRIPTION
Opening this PR for discussion. This PR fixes this false error:

 'one' PropType is defined but prop is never used

Caused by this test case:
```
const Inner = (props) => <span>{props.innerOne} {props.innerTwo}</span>;
const Outer = (props) => {
    let team = props.names.map(() => (
        <Inner innerOne={props.one} innerTwo={props.two} />
    ));
    return <ul>{team}</ul>;
};
Outer.propTypes = {
    names: PropTypes.array,
    one: PropTypes.string,
    two: PropTypes.string
};
```

However, looks like my fix caused a few other tests to fail. I intend to push an update once I do some more investigation.