### PR TITLE
Fix typo in jsx-no-bind doc

### DIFF
--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -10,7 +10,7 @@ The following patterns are considered warnings:
 <div onClick={this._handleClick.bind(this)}></div>
 ```
 ```jsx
-<div onClick={() => console.log('Hello!'))}></div>
+<div onClick={() => console.log('Hello!')}></div>
 ```
 
 The following patterns are not considered warnings:


### PR DESCRIPTION
#1306 - what has been seen, cannot be unseen.