### PR TITLE
`no-unused-prop-types`: add `.map` test case from #1107

### DIFF
--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1914,6 +1914,21 @@ ruleTester.run('no-unused-prop-types', rule, {
         '    test: React.PropTypes.bool',
         '};'
       ].join('\n')
+    }, {
+      // issue 1107
+      code: [
+        'const Test = props => <div>',
+        '  {someArray.map(l => <div',
+        '    key={l}>',
+        '      {props.property + props.property2}',
+        '    </div>)}',
+        '</div>',
+
+        'Test.propTypes = {',
+        '  property: React.propTypes.string.isRequired,',
+        '  property2: React.propTypes.string.isRequired',
+        '}'
+      ].join('\n')
     }
   ],
 


### PR DESCRIPTION
Fixes #1107 