### PR TITLE
Add "ctors" option to @no-direct-mutation-state" rule

### DIFF
--- a/docs/rules/no-direct-mutation-state.md
+++ b/docs/rules/no-direct-mutation-state.md
@@ -66,10 +66,10 @@ This rule can take one argument to ignore some specific props during validation.
 ```js
 ...
 "react/no-direct-mutation-state": [<enabled>, {
-  ctors: <ctors>
+  constructors: <constructors>
 }]
 ...
 ```
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
-* `ctors`: optional array of methods name to check like constructor
+* `constructors`: optional array of methods name to check like constructor

--- a/docs/rules/no-direct-mutation-state.md
+++ b/docs/rules/no-direct-mutation-state.md
@@ -58,3 +58,18 @@ class Hello extends React.Component {
   }
 }
 ```
+
+## Rule Options
+
+This rule can take one argument to ignore some specific props during validation.
+
+```js
+...
+"react/no-direct-mutation-state": [<enabled>, {
+  ctors: <ctors>
+}]
+...
+```
+
+* `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
+* `ctors`: optional array of methods name to check like constructor

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -22,7 +22,7 @@ module.exports = {
     schema: [{
       type: 'object',
       properties: {
-        ctors: {
+        constructors: {
           type: 'array',
           items: {
             type: 'string'
@@ -35,7 +35,7 @@ module.exports = {
 
   create: Components.detect((context, components, utils) => {
     const configuration = context.options[0] || {};
-    const ctorsMethod = configuration.ctors || [];
+    const ctorsMethod = configuration.constructors || [];
 
     /**
      * Checks if the component is valid

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -17,10 +17,26 @@ module.exports = {
       description: 'Prevent direct mutation of this.state',
       category: 'Possible Errors',
       recommended: true
-    }
+    },
+
+    schema: [{
+      type: 'object',
+      properties: {
+        ctors: {
+          type: 'array',
+          items: {
+            type: 'string'
+          }
+        }
+      },
+      additionalProperties: false
+    }]
   },
 
   create: Components.detect((context, components, utils) => {
+    const configuration = context.options[0] || {};
+    const ctorsMethod = configuration.ctors || [];
+
     /**
      * Checks if the component is valid
      * @param {Object} component The component to process
@@ -28,6 +44,24 @@ module.exports = {
      */
     function isValid(component) {
       return Boolean(component && !component.mutateSetState);
+    }
+
+    /**
+     * Checks if the method is ignored
+     * @param {String} name Name of the method to check.
+     * @returns {Boolean} True if the method is ignored, false if not.
+     */
+    function isCtorMethod(name) {
+      return ctorsMethod.indexOf(name) !== -1;
+    }
+
+    /**
+     * Checks if the node is constructor or ignored
+     * @param {ASTNode} node The AST node being checked.
+     * @returns {Boolean} True if the method is is constructor or ignored, false if not.
+     */
+    function isConstructor(node) {
+      return node.kind === 'constructor' || (node.kind === 'method' && isCtorMethod(node.key.name));
     }
 
     /**
@@ -48,13 +82,13 @@ module.exports = {
     // --------------------------------------------------------------------------
     // Public
     // --------------------------------------------------------------------------
-    let inConstructor = false;
+    let inConstructorOrIgnored = false;
     let inCallExpression = false;
 
     return {
       MethodDefinition(node) {
-        if (node.kind === 'constructor') {
-          inConstructor = true;
+        if (isConstructor(node)) {
+          inConstructorOrIgnored = true;
         }
       },
 
@@ -64,7 +98,7 @@ module.exports = {
 
       AssignmentExpression(node) {
         let item;
-        if ((inConstructor && !inCallExpression) || !node.left || !node.left.object) {
+        if ((inConstructorOrIgnored && !inCallExpression) || !node.left || !node.left.object) {
           return;
         }
         item = node.left;
@@ -90,8 +124,8 @@ module.exports = {
       },
 
       'MethodDefinition:exit': function (node) {
-        if (node.kind === 'constructor') {
-          inConstructor = false;
+        if (isConstructor(node)) {
+          inConstructorOrIgnored = false;
         }
       },
 

--- a/tests/lib/rules/no-direct-mutation-state.js
+++ b/tests/lib/rules/no-direct-mutation-state.js
@@ -69,6 +69,17 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n')
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  myMethod() {',
+      '    this.state = {' +
+      '       boo: "bar" ' +
+      '    };' +
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{ctors: ['myMethod']}]
   }],
 
   invalid: [{
@@ -151,6 +162,20 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
+    errors: [{
+      message: 'Do not mutate state directly. Use setState().'
+    }]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  myMethod(props) {',
+      '    doSomethingAsync(() => {',
+      '      this.state = "bad";',
+      '    });',
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{ctors: ['myMethod']}],
     errors: [{
       message: 'Do not mutate state directly. Use setState().'
     }]

--- a/tests/lib/rules/no-direct-mutation-state.js
+++ b/tests/lib/rules/no-direct-mutation-state.js
@@ -79,7 +79,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    options: [{ctors: ['myMethod']}]
+    options: [{constructors: ['myMethod']}]
   }],
 
   invalid: [{
@@ -175,7 +175,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    options: [{ctors: ['myMethod']}],
+    options: [{constructors: ['myMethod']}],
     errors: [{
       message: 'Do not mutate state directly. Use setState().'
     }]


### PR DESCRIPTION
This option allow to check specified methods like constructor.

**Motivation**
I have BaseComponent in my project and use it in this way:
```
class BaseComponent extends React.PureComponent {
   constructor(props, context) {
        try {
            this._init(props, context)
        } catch(e) {
           // log error
        }
   }
}

class MyComponent extends BaseComponent {
    _init() {
        this.state = {
            foo: 'bar'
        };
    }
}
```
`_init` method is actual constructor for `MyComponent` and I want to check it like constructor with the "ctors" options
```
"react/no-direct-mutation-state": [<enabled>, {
  ctors: ['_init']
}]
```