### PR TITLE
Fix crash for no-typos rule

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -66,6 +66,10 @@ module.exports = {
       },
 
       MemberExpression: function(node) {
+        if (node.parent.type !== 'AssignmentExpression') {
+          return;
+        }
+
         const relatedComponent = utils.getRelatedComponent(node);
 
         if (

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -240,6 +240,15 @@ ruleTester.run('no-typos', rule, {
       '}'
     ].join('\n'),
     parserOptions: parserOptions
+  }, {
+    // https://github.com/yannickcr/eslint-plugin-react/issues/1353
+    code: `
+      function test(b) {
+        return a.bind(b);
+      }
+      function a() {}
+    `,
+    parserOptions: parserOptions
   }],
 
   invalid: [{


### PR DESCRIPTION
This is a fix for: https://github.com/yannickcr/eslint-plugin-react/issues/1353

I'm not particularly happy with how I fixed this issue, but I think it should be fine for now. At least, the rule will not crash anymore.

There's more info in the ticket + there is a related ticket on the eslint repo with additional info.