### PR TITLE
More robust no typos fix

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -66,10 +66,6 @@ module.exports = {
       },
 
       MemberExpression: function(node) {
-        if (node.parent.type !== 'AssignmentExpression') {
-          return;
-        }
-
         const relatedComponent = utils.getRelatedComponent(node);
 
         if (

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -218,7 +218,8 @@ function componentRule(rule, context) {
       let comment;
       // Sometimes the passed node may not have been parsed yet by eslint, and this function call crashes.
       // Can be removed when eslint sets "parent" property for all nodes on initial AST traversal: https://github.com/eslint/eslint-scope/issues/27
-      // Remove try/catch when https://github.com/eslint/eslint-scope/issues/27 is implemented.
+      // eslint-disable-next-line no-warning-comments
+      // FIXME: Remove try/catch when https://github.com/eslint/eslint-scope/issues/27 is implemented.
       try {
         comment = sourceCode.getJSDocComment(node);
       } catch (e) {

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -218,6 +218,7 @@ function componentRule(rule, context) {
       let comment;
       // Sometimes the passed node may not have been parsed yet by eslint, and this function call crashes.
       // Can be removed when eslint sets "parent" property for all nodes on initial AST traversal: https://github.com/eslint/eslint-scope/issues/27
+      // FIXME: Remove try/catch when https://github.com/eslint/eslint-scope/issues/27 is implemented.
       try {
         comment = sourceCode.getJSDocComment(node);
       } catch (e) {

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -218,7 +218,7 @@ function componentRule(rule, context) {
       let comment;
       // Sometimes the passed node may not have been parsed yet by eslint, and this function call crashes.
       // Can be removed when eslint sets "parent" property for all nodes on initial AST traversal: https://github.com/eslint/eslint-scope/issues/27
-      // FIXME: Remove try/catch when https://github.com/eslint/eslint-scope/issues/27 is implemented.
+      // Remove try/catch when https://github.com/eslint/eslint-scope/issues/27 is implemented.
       try {
         comment = sourceCode.getJSDocComment(node);
       } catch (e) {

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -215,7 +215,12 @@ function componentRule(rule, context) {
      * @returns {Boolean} True if the node is explicitly declared as a descendant of a React Component, false if not
      */
     isExplicitComponent: function(node) {
-      const comment = sourceCode.getJSDocComment(node);
+      let comment;
+      try {
+        comment = sourceCode.getJSDocComment(node);
+      } catch (e) {
+        comment = null;
+      }
 
       if (comment === null) {
         return false;

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -216,6 +216,8 @@ function componentRule(rule, context) {
      */
     isExplicitComponent: function(node) {
       let comment;
+      // Sometimes the passed node may not have been parsed yet by eslint, and this function call crashes.
+      // Can be removed when eslint sets "parent" property for all nodes on initial AST traversal: https://github.com/eslint/eslint-scope/issues/27
       try {
         comment = sourceCode.getJSDocComment(node);
       } catch (e) {

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -241,6 +241,15 @@ ruleTester.run('no-typos', rule, {
     ].join('\n'),
     parserOptions: parserOptions
   }, {
+    // PropTypes declared on a component that is detected through JSDoc comments and is
+    // declared AFTER the PropTypes assignment does not work.
+    code: `
+      MyComponent.PROPTYPES = {}
+      /** @extends React.Component */
+      class MyComponent extends BaseComponent {}
+    `,
+    parserOptions: parserOptions
+  }, {
     // https://github.com/yannickcr/eslint-plugin-react/issues/1353
     code: `
       function test(b) {
@@ -433,6 +442,21 @@ ruleTester.run('no-typos', rule, {
       'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
       'MyComponent.defaultprops = {}'
     ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{message: ERROR_MESSAGE}]
+  }, {
+    code: [
+      'Component.defaultprops = {}',
+      'class Component extends React.Component {}'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{message: ERROR_MESSAGE}]
+  }, {
+    code: `
+      /** @extends React.Component */
+      class MyComponent extends BaseComponent {}
+      MyComponent.PROPTYPES = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {


### PR DESCRIPTION
Second attempt at fixing https://github.com/yannickcr/eslint-plugin-react/issues/1353

I think this is a better approach, but it means that currently one case is not supported. See the added test:

```js
      MyComponent.PROPTYPES = {}
      /** @extends React.Component */
      class MyComponent extends BaseComponent {}
```

I suppose that is acceptable for now, at least it is better than having the rule crash.

Also explained why the try/catch is needed and linked to relevant eslint-scope issue that needs to be implemented before it can be removed.