### PR TITLE
require-default-props - fixing an edge case where linting stops early

### DIFF
--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -578,7 +578,7 @@ module.exports = {
 
           // If no propTypes could be found, we don't report anything.
           if (!list[component].propTypes) {
-            return;
+            continue;
           }
 
           reportPropTypesWithoutDefault(

--- a/tests/lib/rules/require-default-props.js
+++ b/tests/lib/rules/require-default-props.js
@@ -1307,6 +1307,25 @@ ruleTester.run('require-default-props', rule, {
       }]
     },
 
+    // component with no declared props followed by a failing component
+    {
+      code: [
+        'var ComponentWithNoProps = ({ bar = "bar" }) => {',
+        '  return <div>Hello {this.props.foo}</div>;',
+        '}',
+        'var Greetings = ({ foo = "foo" }) => {',
+        '  return <div>Hello {this.props.foo}</div>;',
+        '}',
+        'Greetings.propTypes = {',
+        '  foo: PropTypes.string',
+        '};'
+      ].join('\n'),
+      errors: [{
+        message: 'propType "foo" is not required, but has no corresponding defaultProp declaration.',
+        line: 8,
+        column: 3
+      }]
+    },
     //
     // with Flow annotations
     {


### PR DESCRIPTION
This is to fix an edge case where linting stops when it finds a component without props.  Instead it should move on to the next component in the file.