### PR TITLE
jsx-handler-names update for better error messaging

### DIFF
--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -36,8 +36,10 @@ module.exports = {
     const eventHandlerPrefix = configuration.eventHandlerPrefix || 'handle';
     const eventHandlerPropPrefix = configuration.eventHandlerPropPrefix || 'on';
 
+    const eventHandlerPropRegex = `${eventHandlerPropPrefix}[A-Z]`;
+
     const EVENT_HANDLER_REGEX = new RegExp(`^((props\\.${eventHandlerPropPrefix})|((.*\\.)?${eventHandlerPrefix}))[A-Z].*$`);
-    const PROP_EVENT_HANDLER_REGEX = new RegExp(`^(${eventHandlerPropPrefix}[A-Z].*|ref)$`);
+    const PROP_EVENT_HANDLER_REGEX = new RegExp(`^(${eventHandlerPropRegex}.*|ref)$`);
 
     return {
       JSXAttribute: function(node) {
@@ -63,7 +65,7 @@ module.exports = {
         } else if (propFnIsNamedCorrectly && !propIsEventHandler) {
           context.report({
             node: node,
-            message: `Prop key for ${propValue} must begin with '${eventHandlerPropPrefix}'`
+            message: `Prop key for ${propValue} must begin with '${eventHandlerPropRegex}'`
           });
         }
       }


### PR DESCRIPTION
For example right now a user will see with default settings:
`<Component onhandleclick={this.handleClick} />`

"Prop key for onclick must begin with on"

Well that error doesn't help me....
The code is really looking for on[A-Z]

so now it will say in the error "on[A-Z]"