### PR TITLE
Support read-only props in Flow for no-unused-prop-types

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -276,7 +276,7 @@ module.exports = {
      */
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
-        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].includes(tokenNode.type)});
+        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].indexOf(tokenNode.type) >= 0});
         return stripQuotes(tokens[0].value);
       }
       const key = node.key || node.argument;

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -263,10 +263,7 @@ module.exports = {
      * @param {string} the identifier to strip
      */
     function stripQuotes(string) {
-      if (string[0] === '\'' || string[0] === '"' && string[0] === string[string.length - 1]) {
-        return string.slice(1, string.length - 1);
-      }
-      return string;
+      return string.replace(/^\'|\'$/g, '');
     }
 
     /**

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -265,7 +265,7 @@ module.exports = {
      */
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
-        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => tokenNode.type === 'Identifier'});
+        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].includes(tokenNode.type)});
         return tokens[0].value;
       }
       const key = node.key || node.argument;

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -259,6 +259,17 @@ module.exports = {
     }
 
     /**
+     * Removes quotes from around an identifier.
+     * @param {string} the identifier to strip
+     */
+    function stripQuotes(string) {
+      if (string[0] === '\'' || string[0] === '"' && string[0] === string[string.length - 1]) {
+        return string.slice(1, string.length - 1);
+      }
+      return string;
+    }
+
+    /**
      * Retrieve the name of a key node
      * @param {ASTNode} node The AST node with the key.
      * @return {string} the name of the key
@@ -266,7 +277,7 @@ module.exports = {
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
         const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].includes(tokenNode.type)});
-        return tokens[0].value;
+        return stripQuotes(tokens[0].value);
       }
       const key = node.key || node.argument;
       return key.type === 'Identifier' ? key.name : key.value;

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -273,8 +273,11 @@ module.exports = {
      */
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
-        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].indexOf(tokenNode.type) >= 0});
-        return stripQuotes(tokens[0].value);
+        const tokens = context.getFirstTokens(node, 2);
+        return (tokens[0].value === '+' || tokens[0].value === '-'
+          ? tokens[1].value
+          : stripQuotes(tokens[0].value)
+        );
       }
       const key = node.key || node.argument;
       return key.type === 'Identifier' ? key.name : key.value;

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -265,7 +265,7 @@ module.exports = {
      */
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
-        const tokens = context.getFirstTokens(node, 1);
+        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => tokenNode.type === 'Identifier'});
         return tokens[0].value;
       }
       const key = node.key || node.argument;

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -343,8 +343,11 @@ module.exports = {
      */
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
-        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].indexOf(tokenNode.type) >= 0});
-        return stripQuotes(tokens[0].value);
+        const tokens = context.getFirstTokens(node, 2);
+        return (tokens[0].value === '+' || tokens[0].value === '-'
+          ? tokens[1].value
+          : stripQuotes(tokens[0].value)
+        );
       }
       const key = node.key || node.argument;
       return key.type === 'Identifier' ? key.name : key.value;

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -346,7 +346,7 @@ module.exports = {
      */
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
-        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].includes(tokenNode.type)});
+        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].indexOf(tokenNode.type) >= 0});
         return stripQuotes(tokens[0].value);
       }
       const key = node.key || node.argument;

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -346,11 +346,8 @@ module.exports = {
      */
     function getKeyValue(node) {
       if (node.type === 'ObjectTypeProperty') {
-        const tokens = context.getFirstTokens(node, 2);
-        return (tokens[0].value === '+' || tokens[0].value === '-'
-          ? tokens[1].value
-          : stripQuotes(tokens[0].value)
-        );
+        const tokens = context.getFirstTokens(node, {count: 1, filter: tokenNode => ['Identifier', 'String'].includes(tokenNode.type)});
+        return stripQuotes(tokens[0].value);
       }
       const key = node.key || node.argument;
       return key.type === 'Identifier' ? key.name : key.value;

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -333,10 +333,7 @@ module.exports = {
      * @param {string} the identifier to strip
      */
     function stripQuotes(string) {
-      if (string[0] === '\'' || string[0] === '"' && string[0] === string[string.length - 1]) {
-        return string.slice(1, string.length - 1);
-      }
-      return string;
+      return string.replace(/^\'|\'$/g, '');
     }
 
     /**

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2067,6 +2067,16 @@ ruleTester.run('no-unused-prop-types', rule, {
         }
       `,
       parser: 'babel-eslint'
+    }, {
+      code: `
+        type Props = {
+          \'completed?\': boolean,
+        };
+        const Hello = (props: Props): React.Element => {
+          return <div>{props[\'completed?\']}</div>;
+        }
+      `,
+      parser: 'babel-eslint'
     }
   ],
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2032,27 +2032,40 @@ ruleTester.run('no-unused-prop-types', rule, {
     }, {
       // issue #106
       code: `
-      import React from 'react';
-      import SharedPropTypes from './SharedPropTypes';
+        import React from 'react';
+        import SharedPropTypes from './SharedPropTypes';
 
-      export default class A extends React.Component {
-        render() {
-          return (
-            <span
-              a={this.props.a}
-              b={this.props.b}
-              c={this.props.c}>
-              {this.props.children}
-            </span>
-          );
+        export default class A extends React.Component {
+          render() {
+            return (
+              <span
+                a={this.props.a}
+                b={this.props.b}
+                c={this.props.c}>
+                {this.props.children}
+              </span>
+            );
+          }
         }
-      }
 
-      A.propTypes = {
-        a: React.PropTypes.string,
-        ...SharedPropTypes // eslint-disable-line object-shorthand
-      };
-    `,
+        A.propTypes = {
+          a: React.PropTypes.string,
+          ...SharedPropTypes // eslint-disable-line object-shorthand
+        };
+      `,
+      parser: 'babel-eslint'
+    }, {
+      // issue #933
+      code: `
+        type Props = {
+          +foo: number
+        }
+        class MyComponent extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }
   ],


### PR DESCRIPTION
Fixes https://github.com/yannickcr/eslint-plugin-react/issues/1388

Added a more generic implementation that supports all prefixes, not just `-` and `+` like it was the case in the `prop-types` rule.

Additionally, made both rules implement the same logic. Although, as described in the other PR, the logic for detecting prop-types should really be extracted out to a separate file. I'd like to tackle that separately as well though.