### PR TITLE
[jsx-no-target-blank] Allow either noopener or noreferrer

### DIFF
--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -2,9 +2,10 @@
 
 When creating a JSX element that has an `a` tag, it is often desired to have
 the link open in a new tab using the `target='_blank'` attribute. Using this
-attribute unaccompanied by `rel='noreferrer noopener'`, however, is a severe
-security vulnerability ([see here for more details](https://mathiasbynens.github.io/rel-noopener))
-This rules requires that you accompany all `target='_blank'` attributes with `rel='noreferrer noopener'`.
+attribute unaccompanied by `rel='noopener'` or `rel='noreferrer'`, however,
+is a severe security vulnerability ([see here for more details](https://mathiasbynens.github.io/rel-noopener))
+This rule requires that you accompany all `target='_blank'` attributes with
+`rel='noopener'` or `rel='noreferrer'`.
 
 ## Rule Details
 
@@ -18,6 +19,8 @@ The following patterns are not considered errors:
 
 ```jsx
 var Hello = <p target='_blank'></p>
+var Hello = <a target='_blank' rel='noopener' href="http://example.com"></a>
+var Hello = <a target='_blank' rel='noreferrer' href="http://example.com"></a>
 var Hello = <a target='_blank' rel='noopener noreferrer' href="http://example.com"></a>
 var Hello = <a target='_blank' href="relative/path/in/the/host"></a>
 var Hello = <a target='_blank' href="/absolute/path/in/the/host"></a>

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -25,7 +25,7 @@ function hasSecureRel(element) {
   return element.attributes.find(attr => {
     if (attr.type === 'JSXAttribute' && attr.name.name === 'rel') {
       const tags = attr.value && attr.value.type === 'Literal' && attr.value.value.toLowerCase().split(' ');
-      return tags && (tags.indexOf('noopener') >= 0 && tags.indexOf('noreferrer') >= 0);
+      return tags && (tags.indexOf('noopener') >= 0 || tags.indexOf('noreferrer') >= 0);
     }
     return false;
   });
@@ -34,7 +34,7 @@ function hasSecureRel(element) {
 module.exports = {
   meta: {
     docs: {
-      description: 'Forbid target="_blank" attribute without rel="noopener noreferrer"',
+      description: 'Forbid target="_blank" attribute without rel="noopener" or rel="noreferrer"',
       category: 'Best Practices',
       recommended: true
     },
@@ -53,7 +53,7 @@ module.exports = {
           hasExternalLink(node.parent) &&
           !hasSecureRel(node.parent)
         ) {
-          context.report(node, 'Using target="_blank" without rel="noopener noreferrer" ' +
+          context.report(node, 'Using target="_blank" without rel="noopener" or rel="noreferrer" ' +
           'is a security risk: see https://mathiasbynens.github.io/rel-noopener');
         }
       }

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -31,6 +31,8 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {code: '<a randomTag></a>'},
     {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>'},
     {code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>'},
+    {code: '<a {...spreadProps} target="_blank" rel="noopener" href="http://example.com">s</a>'},
+    {code: '<a {...spreadProps} target="_blank" rel="noreferrer" href="http://example.com">s</a>'},
     {code: '<a {...spreadProps} target="_blank" rel="noopener noreferrer" href="http://example.com">s</a>'},
     {code: '<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>'},
     {code: '<p target="_blank"></p>'},
@@ -43,55 +45,55 @@ ruleTester.run('jsx-no-target-blank', rule, {
   invalid: [{
     code: '<a target="_blank" href="http://example.com"></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }, {
     code: '<a target="_blank" rel="" href="http://example.com"></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }, {
     code: '<a target="_blank" rel="noopenernoreferrer" href="http://example.com"></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }, {
     code: '<a target="_BLANK" href="http://example.com"></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }, {
     code: '<a target="_blank" href="//example.com"></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }, {
     code: '<a target="_blank" href="//example.com" rel={true}></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }, {
     code: '<a target="_blank" href="//example.com" rel={3}></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }, {
     code: '<a target="_blank" href="//example.com" rel={null}></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }, {
     code: '<a target="_blank" href="//example.com" rel></a>',
     errors: [{
-      message: 'Using target="_blank" without rel="noopener noreferrer" is a security risk:' +
+      message: 'Using target="_blank" without rel="noopener" or rel="noreferrer" is a security risk:' +
       ' see https://mathiasbynens.github.io/rel-noopener'
     }]
   }]


### PR DESCRIPTION
I use `noreferrer` for my external links which also disables `window.opener`, but the rule insists on requiring `noopener` even though it's redundant.

According to the [HTML5 Standard spec](https://html.spec.whatwg.org/multipage/links.html#link-type-noreferrer):

> For historical reasons, the _noreferrer_ keyword implies the behavior associated with the _noopener_ keyword when present on a hyperlink that creates a new browsing context. That is, `<a href="..." rel="noreferrer" target="_blank">` has the same behavior as `<a href="..." rel="noreferrer noopener" target="_blank">`.

Also fixes https://github.com/yannickcr/eslint-plugin-react/issues/776

See also https://github.com/GoogleChrome/lighthouse/issues/2482 and https://github.com/GoogleChrome/lighthouse/pull/2485