### PR TITLE
[no-unused-state] Ignore computed property keys for no unused state rule

### DIFF
--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -92,7 +92,14 @@ module.exports = {
     // current set of state fields.
     function addStateFields(node) {
       for (const prop of node.properties) {
-        if (prop.type === 'Property' && getName(prop.key) !== null) {
+        const key = prop.key;
+
+        if (
+          prop.type === 'Property' &&
+          (key.type === 'Literal' ||
+          (prop.computed === false && key.type === 'Identifier')) &&
+          getName(prop.key) !== null
+        ) {
           classInfo.stateFields.add(prop);
         }
       }

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -25,10 +25,14 @@ function uncast(node) {
 // method definitions, ObjectExpression property keys).
 function getName(node) {
   node = uncast(node);
-  if (node.type === 'Identifier') {
+  const type = node.type;
+
+  if (type === 'Identifier') {
     return node.name;
-  } else if (node.type === 'Literal') {
+  } else if (type === 'Literal') {
     return String(node.value);
+  } else if (type === 'TemplateLiteral' && node.expressions.length === 0) {
+    return node.quasis[0].value.raw;
   }
   return null;
 }
@@ -97,6 +101,7 @@ module.exports = {
         if (
           prop.type === 'Property' &&
           (key.type === 'Literal' ||
+          (key.type === 'TemplateLiteral' && key.expressions.length === 0) ||
           (prop.computed === false && key.type === 'Identifier')) &&
           getName(prop.key) !== null
         ) {

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -102,6 +102,14 @@ eslintTester.run('no-unused-state', rule, {
         return <SomeComponent />;
       }
     });`,
+    `var ComputedKeyFromTemplateLiteralTest = createReactClass({
+      getInitialState: function() {
+        return { [\`foo\`]: 0 };
+      },
+      render: function() {
+        return <SomeComponent foo={this.state['foo']} />;
+      }
+    });`,
     `var GetInitialStateMethodTest = createReactClass({
       getInitialState() {
         return { foo: 0 };
@@ -196,6 +204,14 @@ eslintTester.run('no-unused-state', rule, {
       }
       render() {
         return <SomeComponent />;
+      }
+    }`,
+    `class ComputedKeyFromTemplateLiteralTest extends React.Component {
+      constructor() {
+        this.state = { [\`foo\`]: 0 };
+      }
+      render() {
+        return <SomeComponent foo={this.state.foo} />;
       }
     }`,
     `class SetStateTest extends React.Component {
@@ -408,6 +424,17 @@ eslintTester.run('no-unused-state', rule, {
       errors: getErrorMessages(['foo'])
     },
     {
+      code: `var UnusedComputedTemplateLiteralKeyStateTest = createReactClass({
+          getInitialState: function() {
+            return { [\`foo\`]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })`,
+      errors: getErrorMessages(['foo'])
+    },
+    {
       code: `var UnusedComputedNumberLiteralKeyStateTest = createReactClass({
           getInitialState: function() {
             return { [123]: 0 };
@@ -491,6 +518,26 @@ eslintTester.run('no-unused-state', rule, {
           }
         }`,
       errors: getErrorMessages(['foo']),
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class UnusedComputedTemplateLiteralKeyStateTest extends React.Component {
+          state = { [\`foo\`]: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }`,
+      errors: getErrorMessages(['foo']),
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class UnusedComputedTemplateLiteralKeyStateTest extends React.Component {
+          state = { [\`foo \\n bar\`]: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }`,
+      errors: getErrorMessages(['foo \\n bar']),
       parser: 'babel-eslint'
     },
     {

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -397,7 +397,7 @@ eslintTester.run('no-unused-state', rule, {
       errors: getErrorMessages(['foo'])
     },
     {
-      code: `var UnusedComputedLiteralKeyStateTest = createReactClass({
+      code: `var UnusedComputedStringLiteralKeyStateTest = createReactClass({
           getInitialState: function() {
             return { ['foo']: 0 };
           },
@@ -406,6 +406,28 @@ eslintTester.run('no-unused-state', rule, {
           }
         })`,
       errors: getErrorMessages(['foo'])
+    },
+    {
+      code: `var UnusedComputedNumberLiteralKeyStateTest = createReactClass({
+          getInitialState: function() {
+            return { [123]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })`,
+      errors: getErrorMessages(['123'])
+    },
+    {
+      code: `var UnusedComputedBooleanLiteralKeyStateTest = createReactClass({
+          getInitialState: function() {
+            return { [true]: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })`,
+      errors: getErrorMessages(['true'])
     },
     {
       code: `var UnusedGetInitialStateMethodTest = createReactClass({

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -62,6 +62,14 @@ eslintTester.run('no-unused-state', rule, {
         return <SomeComponent foo={this.state[true]} />;
       }
     });`,
+    `var ComputedKeyFromNumberLiteralTest = createReactClass({
+      getInitialState: function() {
+        return { [123]: 0 };
+      },
+      render: function() {
+        return <SomeComponent foo={this.state[123]} />;
+      }
+    });`,
     `var ComputedKeyFromExpressionTest = createReactClass({
       getInitialState: function() {
         return { [foo + bar]: 0 };
@@ -148,6 +156,14 @@ eslintTester.run('no-unused-state', rule, {
       }
       render() {
         return <SomeComponent foo={this.state['false']} />;
+      }
+    }`,
+    `class ComputedKeyFromNumberLiteralTest extends React.Component {
+      constructor() {
+        this.state = { [345]: 0 };
+      }
+      render() {
+        return <SomeComponent foo={this.state[345]} />;
       }
     }`,
     `class ComputedKeyFromExpressionTest extends React.Component {
@@ -463,6 +479,26 @@ eslintTester.run('no-unused-state', rule, {
           }
         }`,
       errors: getErrorMessages(['true']),
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class UnusedComputedNumberLiteralKeyStateTest extends React.Component {
+          state = { [123]: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }`,
+      errors: getErrorMessages(['123']),
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class UnusedComputedFloatLiteralKeyStateTest extends React.Component {
+          state = { [123.12]: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }`,
+      errors: getErrorMessages(['123.12']),
       parser: 'babel-eslint'
     },
     {

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -46,6 +46,54 @@ eslintTester.run('no-unused-state', rule, {
         return <SomeComponent foo={this.state.foo} />;
       }
     });`,
+    `var ComputedKeyFromVariableTest = createReactClass({
+      getInitialState: function() {
+        return { [foo]: 0 };
+      },
+      render: function() {
+        return <SomeComponent />;
+      }
+    });`,
+    `var ComputedKeyFromBooleanLiteralTest = createReactClass({
+      getInitialState: function() {
+        return { [true]: 0 };
+      },
+      render: function() {
+        return <SomeComponent foo={this.state[true]} />;
+      }
+    });`,
+    `var ComputedKeyFromExpressionTest = createReactClass({
+      getInitialState: function() {
+        return { [foo + bar]: 0 };
+      },
+      render: function() {
+        return <SomeComponent />;
+      }
+    });`,
+    `var ComputedKeyFromBinaryExpressionTest = createReactClass({
+      getInitialState: function() {
+        return { ['foo' + 'bar' * 8]: 0 };
+      },
+      render: function() {
+        return <SomeComponent />;
+      }
+    });`,
+    `var ComputedKeyFromStringLiteralTest = createReactClass({
+      getInitialState: function() {
+        return { ['foo']: 0 };
+      },
+      render: function() {
+        return <SomeComponent foo={this.state.foo} />;
+      }
+    });`,
+    `var ComputedKeyFromTemplateLiteralTest = createReactClass({
+      getInitialState: function() {
+        return { [\`foo\${bar}\`]: 0 };
+      },
+      render: function() {
+        return <SomeComponent />;
+      }
+    });`,
     `var GetInitialStateMethodTest = createReactClass({
       getInitialState() {
         return { foo: 0 };
@@ -84,6 +132,54 @@ eslintTester.run('no-unused-state', rule, {
       }
       render() {
         return <SomeComponent foo={this.state.foo} />;
+      }
+    }`,
+    `class ComputedKeyFromVariableTest extends React.Component {
+      constructor() {
+        this.state = { [foo]: 0 };
+      }
+      render() {
+        return <SomeComponent />;
+      }
+    }`,
+    `class ComputedKeyFromBooleanLiteralTest extends React.Component {
+      constructor() {
+        this.state = { [false]: 0 };
+      }
+      render() {
+        return <SomeComponent foo={this.state['false']} />;
+      }
+    }`,
+    `class ComputedKeyFromExpressionTest extends React.Component {
+      constructor() {
+        this.state = { [foo + bar]: 0 };
+      }
+      render() {
+        return <SomeComponent />;
+      }
+    }`,
+    `class ComputedKeyFromBinaryExpressionTest extends React.Component {
+      constructor() {
+        this.state = { [1 + 2 * 8]: 0 };
+      }
+      render() {
+        return <SomeComponent />;
+      }
+    }`,
+    `class ComputedKeyFromStringLiteralTest extends React.Component {
+      constructor() {
+        this.state = { ['foo']: 0 };
+      }
+      render() {
+        return <SomeComponent foo={this.state.foo} />;
+      }
+    }`,
+    `class ComputedKeyFromTemplateLiteralTest extends React.Component {
+      constructor() {
+        this.state = { [\`foo\${bar}\`]: 0 };
+      }
+      render() {
+        return <SomeComponent />;
       }
     }`,
     `class SetStateTest extends React.Component {
@@ -285,6 +381,17 @@ eslintTester.run('no-unused-state', rule, {
       errors: getErrorMessages(['foo'])
     },
     {
+      code: `var UnusedComputedLiteralKeyStateTest = createReactClass({
+          getInitialState: function() {
+            return { ['foo']: 0 };
+          },
+          render: function() {
+            return <SomeComponent />;
+          }
+        })`,
+      errors: getErrorMessages(['foo'])
+    },
+    {
       code: `var UnusedGetInitialStateMethodTest = createReactClass({
           getInitialState() {
             return { foo: 0 };
@@ -336,6 +443,26 @@ eslintTester.run('no-unused-state', rule, {
           }
         }`,
       errors: getErrorMessages(['foo']),
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class UnusedComputedStringLiteralKeyStateTest extends React.Component {
+          state = { ['foo']: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }`,
+      errors: getErrorMessages(['foo']),
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class UnusedComputedBooleanLiteralKeyStateTest extends React.Component {
+          state = { [true]: 0 };
+          render() {
+            return <SomeComponent />;
+          }
+        }`,
+      errors: getErrorMessages(['true']),
       parser: 'babel-eslint'
     },
     {


### PR DESCRIPTION
For https://github.com/yannickcr/eslint-plugin-react/issues/1361.

This sets the no-unused-state rule to ignore computed property keys when the contents aren't literal.

I think it should cover all kinds of literals for checking unused state properties because it could happen in types other than string and could be checked. If that is undesirable, I could change it to only checking string literals. 

Other than that, let me know what other improvements you have in mind.