### PR TITLE
Refactor Components into ES6 class syntax

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -13,7 +13,6 @@ const astUtil = require('./ast');
 
 /**
  * Components
- * @class
  */
 class Components {
   constructor() {
@@ -99,6 +98,7 @@ class Components {
   list() {
     const list = {};
     const usedPropTypes = {};
+
     // Find props used in components for which we are not confident
     for (const i in this._list) {
       if (!has(this._list, i) || this._list[i].confidence >= 2) {
@@ -122,6 +122,7 @@ class Components {
         usedPropTypes[componentId] = (usedPropTypes[componentId] || []).concat(newUsedProps);
       }
     }
+
     // Assign used props in not confident components to the parent component
     for (const j in this._list) {
       if (!has(this._list, j) || this._list[j].confidence < 2) {

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -19,11 +19,6 @@ class Components {
     this._list = {};
   }
 
-  static detect(rule) {
-    return componentRule.bind(this, rule); // eslint-disable-line no-use-before-define
-  }
-
-
   _getId(node) {
     return node && node.range.join(':');
   }
@@ -662,4 +657,8 @@ function componentRule(rule, context) {
   return updatedRuleInstructions;
 }
 
-module.exports = Components;
+module.exports = {
+  detect(rule) {
+    return componentRule.bind(this, rule);
+  }
+};

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -11,16 +11,40 @@ const variableUtil = require('./variable');
 const pragmaUtil = require('./pragma');
 const astUtil = require('./ast');
 
+function getId(node) {
+  return node && node.range.join(':');
+}
+
+
+function usedPropTypesAreEquivalent(propA, propB) {
+  if (propA.name === propB.name) {
+    if (!propA.allNames && !propB.allNames) {
+      return true;
+    } else if (Array.isArray(propA.allNames) && Array.isArray(propB.allNames) && propA.allNames.join('') === propB.allNames.join('')) {
+      return true;
+    }
+    return false;
+  }
+  return false;
+}
+
+function mergeUsedPropTypes(propsList, newPropsList) {
+  const propsToAdd = [];
+  newPropsList.forEach(newProp => {
+    const newPropisAlreadyInTheList = propsList.some(prop => usedPropTypesAreEquivalent(prop, newProp));
+    if (!newPropisAlreadyInTheList) {
+      propsToAdd.push(newProp);
+    }
+  });
+  return propsList.concat(propsToAdd);
+}
+
 /**
  * Components
  */
 class Components {
   constructor() {
     this._list = {};
-  }
-
-  _getId(node) {
-    return node && node.range.join(':');
   }
 
   /**
@@ -31,7 +55,7 @@ class Components {
    * @returns {Object} Added component object
    */
   add(node, confidence) {
-    const id = this._getId(node);
+    const id = getId(node);
     if (this._list[id]) {
       if (confidence === 0 || this._list[id].confidence === 0) {
         this._list[id].confidence = 0;
@@ -54,7 +78,7 @@ class Components {
    * @returns {Object} Component object, undefined if the component is not found
    */
   get(node) {
-    const id = this._getId(node);
+    const id = getId(node);
     return this._list[id];
   }
 
@@ -65,13 +89,13 @@ class Components {
    * @param {Object} props Additional properties to add to the component.
    */
   set(node, props) {
-    while (node && !this._list[this._getId(node)]) {
+    while (node && !this._list[getId(node)]) {
       node = node.parent;
     }
     if (!node) {
       return;
     }
-    const id = this._getId(node);
+    const id = getId(node);
     let copyUsedPropTypes;
     if (this._list[id]) {
       // usedPropTypes is an array. _extend replaces existing array with a new one which caused issue #1309.
@@ -80,7 +104,7 @@ class Components {
     }
     this._list[id] = util._extend(this._list[id], props);
     if (this._list[id] && props.usedPropTypes) {
-      this._list[id].usedPropTypes = this._mergeUsedPropTypes(copyUsedPropTypes || [], props.usedPropTypes);
+      this._list[id].usedPropTypes = mergeUsedPropTypes(copyUsedPropTypes || [], props.usedPropTypes);
     }
   }
 
@@ -113,7 +137,7 @@ class Components {
       if (component) {
         const newUsedProps = (this._list[i].usedPropTypes || []).filter(propType => !propType.node || propType.node.kind !== 'init');
 
-        const componentId = this._getId(component.node);
+        const componentId = getId(component.node);
         usedPropTypes[componentId] = (usedPropTypes[componentId] || []).concat(newUsedProps);
       }
     }
@@ -123,7 +147,7 @@ class Components {
       if (!has(this._list, j) || this._list[j].confidence < 2) {
         continue;
       }
-      const id = this._getId(this._list[j].node);
+      const id = getId(this._list[j].node);
       list[j] = this._list[j];
       if (usedPropTypes[id]) {
         list[j].usedPropTypes = (list[j].usedPropTypes || []).concat(usedPropTypes[id]);
@@ -147,29 +171,6 @@ class Components {
       length++;
     }
     return length;
-  }
-
-  _mergeUsedPropTypes(propsList, newPropsList) {
-    const propsToAdd = [];
-    newPropsList.forEach(newProp => {
-      const newPropisAlreadyInTheList = propsList.some(prop => this._usedPropTypesAreEquivalent(prop, newProp));
-      if (!newPropisAlreadyInTheList) {
-        propsToAdd.push(newProp);
-      }
-    });
-    return propsList.concat(propsToAdd);
-  }
-
-  _usedPropTypesAreEquivalent(propA, propB) {
-    if (propA.name === propB.name) {
-      if (!propA.allNames && !propB.allNames) {
-        return true;
-      } else if (Array.isArray(propA.allNames) && Array.isArray(propB.allNames) && propA.allNames.join('') === propB.allNames.join('')) {
-        return true;
-      }
-      return false;
-    }
-    return false;
   }
 }
 

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -20,6 +20,11 @@ class Components {
     this._list = {};
   }
 
+  static detect(rule) {
+    return componentRule.bind(this, rule); // eslint-disable-line no-use-before-define
+  }
+
+
   _getId(node) {
     return node && node.range.join(':');
   }
@@ -655,9 +660,5 @@ function componentRule(rule, context) {
   // Return the updated rule instructions
   return updatedRuleInstructions;
 }
-
-Components.detect = function(rule) {
-  return componentRule.bind(this, rule);
-};
 
 module.exports = Components;

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -658,8 +658,8 @@ function componentRule(rule, context) {
   return updatedRuleInstructions;
 }
 
-module.exports = {
+module.exports = Object.assign(Components, {
   detect(rule) {
     return componentRule.bind(this, rule);
   }
-};
+});

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -11,164 +11,166 @@ const variableUtil = require('./variable');
 const pragmaUtil = require('./pragma');
 const astUtil = require('./ast');
 
-const usedPropTypesAreEquivalent = (propA, propB) => {
-  if (propA.name === propB.name) {
-    if (!propA.allNames && !propB.allNames) {
-      return true;
-    } else if (Array.isArray(propA.allNames) && Array.isArray(propB.allNames) && propA.allNames.join('') === propB.allNames.join('')) {
-      return true;
-    }
-    return false;
-  }
-  return false;
-};
-
-const mergeUsedPropTypes = (propsList, newPropsList) => {
-  const propsToAdd = [];
-  newPropsList.forEach(newProp => {
-    const newPropisAlreadyInTheList = propsList.some(prop => usedPropTypesAreEquivalent(prop, newProp));
-    if (!newPropisAlreadyInTheList) {
-      propsToAdd.push(newProp);
-    }
-  });
-  return propsList.concat(propsToAdd);
-};
-
-
 /**
  * Components
  * @class
  */
-function Components() {
-  this._list = {};
-  this._getId = function(node) {
-    return node && node.range.join(':');
-  };
-}
+class Components {
+  constructor() {
+    this._list = {};
+  }
 
-/**
- * Add a node to the components list, or update it if it's already in the list
- *
- * @param {ASTNode} node The AST node being added.
- * @param {Number} confidence Confidence in the component detection (0=banned, 1=maybe, 2=yes)
- * @returns {Object} Added component object
- */
-Components.prototype.add = function(node, confidence) {
-  const id = this._getId(node);
-  if (this._list[id]) {
-    if (confidence === 0 || this._list[id].confidence === 0) {
-      this._list[id].confidence = 0;
-    } else {
-      this._list[id].confidence = Math.max(this._list[id].confidence, confidence);
+  _getId(node) {
+    return node && node.range.join(':');
+  }
+
+  /**
+   * Add a node to the components list, or update it if it's already in the list
+   *
+   * @param {ASTNode} node The AST node being added.
+   * @param {Number} confidence Confidence in the component detection (0=banned, 1=maybe, 2=yes)
+   * @returns {Object} Added component object
+   */
+  add(node, confidence) {
+    const id = this._getId(node);
+    if (this._list[id]) {
+      if (confidence === 0 || this._list[id].confidence === 0) {
+        this._list[id].confidence = 0;
+      } else {
+        this._list[id].confidence = Math.max(this._list[id].confidence, confidence);
+      }
+      return this._list[id];
     }
+    this._list[id] = {
+      node: node,
+      confidence: confidence
+    };
     return this._list[id];
   }
-  this._list[id] = {
-    node: node,
-    confidence: confidence
-  };
-  return this._list[id];
-};
 
-/**
- * Find a component in the list using its node
- *
- * @param {ASTNode} node The AST node being searched.
- * @returns {Object} Component object, undefined if the component is not found
- */
-Components.prototype.get = function(node) {
-  const id = this._getId(node);
-  return this._list[id];
-};
+  /**
+   * Find a component in the list using its node
+   *
+   * @param {ASTNode} node The AST node being searched.
+   * @returns {Object} Component object, undefined if the component is not found
+   */
+  get(node) {
+    const id = this._getId(node);
+    return this._list[id];
+  }
 
-/**
- * Update a component in the list
- *
- * @param {ASTNode} node The AST node being updated.
- * @param {Object} props Additional properties to add to the component.
- */
-Components.prototype.set = function(node, props) {
-  while (node && !this._list[this._getId(node)]) {
-    node = node.parent;
-  }
-  if (!node) {
-    return;
-  }
-  const id = this._getId(node);
-  let copyUsedPropTypes;
-  if (this._list[id]) {
-    // usedPropTypes is an array. _extend replaces existing array with a new one which caused issue #1309.
-    // preserving original array so it can be merged later on.
-    copyUsedPropTypes = this._list[id].usedPropTypes && this._list[id].usedPropTypes.slice();
-  }
-  this._list[id] = util._extend(this._list[id], props);
-  if (this._list[id] && props.usedPropTypes) {
-    this._list[id].usedPropTypes = mergeUsedPropTypes(copyUsedPropTypes || [], props.usedPropTypes);
-  }
-};
-
-/**
- * Return the components list
- * Components for which we are not confident are not returned
- *
- * @returns {Object} Components list
- */
-Components.prototype.list = function() {
-  const list = {};
-  const usedPropTypes = {};
-  // Find props used in components for which we are not confident
-  for (const i in this._list) {
-    if (!has(this._list, i) || this._list[i].confidence >= 2) {
-      continue;
-    }
-    let component = null;
-    let node = null;
-    node = this._list[i].node;
-    while (!component && node.parent) {
+  /**
+   * Update a component in the list
+   *
+   * @param {ASTNode} node The AST node being updated.
+   * @param {Object} props Additional properties to add to the component.
+   */
+  set(node, props) {
+    while (node && !this._list[this._getId(node)]) {
       node = node.parent;
-      // Stop moving up if we reach a decorator
-      if (node.type === 'Decorator') {
-        break;
+    }
+    if (!node) {
+      return;
+    }
+    const id = this._getId(node);
+    let copyUsedPropTypes;
+    if (this._list[id]) {
+      // usedPropTypes is an array. _extend replaces existing array with a new one which caused issue #1309.
+      // preserving original array so it can be merged later on.
+      copyUsedPropTypes = this._list[id].usedPropTypes && this._list[id].usedPropTypes.slice();
+    }
+    this._list[id] = util._extend(this._list[id], props);
+    if (this._list[id] && props.usedPropTypes) {
+      this._list[id].usedPropTypes = this._mergeUsedPropTypes(copyUsedPropTypes || [], props.usedPropTypes);
+    }
+  }
+
+  /**
+   * Return the components list
+   * Components for which we are not confident are not returned
+   *
+   * @returns {Object} Components list
+   */
+  list() {
+    const list = {};
+    const usedPropTypes = {};
+    // Find props used in components for which we are not confident
+    for (const i in this._list) {
+      if (!has(this._list, i) || this._list[i].confidence >= 2) {
+        continue;
       }
-      component = this.get(node);
-    }
-    if (component) {
-      const newUsedProps = (this._list[i].usedPropTypes || []).filter(propType => !propType.node || propType.node.kind !== 'init');
+      let component = null;
+      let node = null;
+      node = this._list[i].node;
+      while (!component && node.parent) {
+        node = node.parent;
+        // Stop moving up if we reach a decorator
+        if (node.type === 'Decorator') {
+          break;
+        }
+        component = this.get(node);
+      }
+      if (component) {
+        const newUsedProps = (this._list[i].usedPropTypes || []).filter(propType => !propType.node || propType.node.kind !== 'init');
 
-      const componentId = this._getId(component.node);
-      usedPropTypes[componentId] = (usedPropTypes[componentId] || []).concat(newUsedProps);
+        const componentId = this._getId(component.node);
+        usedPropTypes[componentId] = (usedPropTypes[componentId] || []).concat(newUsedProps);
+      }
     }
+    // Assign used props in not confident components to the parent component
+    for (const j in this._list) {
+      if (!has(this._list, j) || this._list[j].confidence < 2) {
+        continue;
+      }
+      const id = this._getId(this._list[j].node);
+      list[j] = this._list[j];
+      if (usedPropTypes[id]) {
+        list[j].usedPropTypes = (list[j].usedPropTypes || []).concat(usedPropTypes[id]);
+      }
+    }
+    return list;
   }
-  // Assign used props in not confident components to the parent component
-  for (const j in this._list) {
-    if (!has(this._list, j) || this._list[j].confidence < 2) {
-      continue;
-    }
-    const id = this._getId(this._list[j].node);
-    list[j] = this._list[j];
-    if (usedPropTypes[id]) {
-      list[j].usedPropTypes = (list[j].usedPropTypes || []).concat(usedPropTypes[id]);
-    }
-  }
-  return list;
-};
 
-/**
- * Return the length of the components list
- * Components for which we are not confident are not counted
- *
- * @returns {Number} Components list length
- */
-Components.prototype.length = function() {
-  let length = 0;
-  for (const i in this._list) {
-    if (!has(this._list, i) || this._list[i].confidence < 2) {
-      continue;
+  /**
+   * Return the length of the components list
+   * Components for which we are not confident are not counted
+   *
+   * @returns {Number} Components list length
+   */
+  length() {
+    let length = 0;
+    for (const i in this._list) {
+      if (!has(this._list, i) || this._list[i].confidence < 2) {
+        continue;
+      }
+      length++;
     }
-    length++;
+    return length;
   }
-  return length;
-};
+
+  _mergeUsedPropTypes(propsList, newPropsList) {
+    const propsToAdd = [];
+    newPropsList.forEach(newProp => {
+      const newPropisAlreadyInTheList = propsList.some(prop => this._usedPropTypesAreEquivalent(prop, newProp));
+      if (!newPropisAlreadyInTheList) {
+        propsToAdd.push(newProp);
+      }
+    });
+    return propsList.concat(propsToAdd);
+  }
+
+  _usedPropTypesAreEquivalent(propA, propB) {
+    if (propA.name === propB.name) {
+      if (!propA.allNames && !propB.allNames) {
+        return true;
+      } else if (Array.isArray(propA.allNames) && Array.isArray(propB.allNames) && propA.allNames.join('') === propB.allNames.join('')) {
+        return true;
+      }
+      return false;
+    }
+    return false;
+  }
+}
 
 function componentRule(rule, context) {
   const createClass = pragmaUtil.getCreateClassFromContext(context);


### PR DESCRIPTION
While working on https://github.com/yannickcr/eslint-plugin-react/issues/1393 and figuring out how to share code related to prop-types detection based on how `Components` works, I noticed this class is still using the old ES5 syntax for defining classes.

It seems node 4 supports class syntax, and I think it simplifies things slightly. I also changed the exports of the file to be a single object with a `detect()` function, rather than exporting the whole `Components` class that also had `detect` defined on it.

This is purely refactoring of the structure of the file, I didn't change any logic or comments (though some could probably use an update, e.g. `list()` does more than just returning a `list()` and it's not obvious from the code what exactly is going on).