### PR TITLE
Add support to ClassExpressions in the prop-types rule

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -65,6 +65,7 @@ module.exports = {
     // Used to track the type annotations in scope.
     // Necessary because babel's scopes do not track type annotations.
     let stack = null;
+    const classExpressions = [];
 
     const MISSING_MESSAGE = '\'{{name}}\' is missing in props validation';
 
@@ -872,6 +873,7 @@ module.exports = {
       while (annotation && (annotation.type === 'TypeAnnotation' || annotation.type === 'NullableTypeAnnotation')) {
         annotation = annotation.typeAnnotation;
       }
+
       if (annotation.type === 'GenericTypeAnnotation' && typeScope(annotation.id.name)) {
         return typeScope(annotation.id.name);
       }
@@ -921,9 +923,10 @@ module.exports = {
       },
 
       ClassExpression: function(node) {
-        if (isSuperTypeParameterPropsDeclaration(node)) {
-          markPropTypesAsDeclared(node, resolveSuperParameterPropsType(node));
-        }
+        // TypeParameterDeclaration need to be added to typeScope in order to handle ClassExpressions.
+        // This visitor is executed before TypeParameterDeclaration are scoped, therefore we postpone
+        // processing class expressions until when the program exists.
+        classExpressions.push(node);
       },
 
       ClassProperty: function(node) {
@@ -1017,6 +1020,14 @@ module.exports = {
         typeScope(node.id.name, node.right);
       },
 
+      TypeParameterDeclaration: function(node) {
+        const identifier = node.params[0];
+
+        if (identifier.typeAnnotation) {
+          typeScope(identifier.name, identifier.typeAnnotation.typeAnnotation);
+        }
+      },
+
       Program: function() {
         stack = [{}];
       },
@@ -1030,6 +1041,12 @@ module.exports = {
       },
 
       'Program:exit': function() {
+        classExpressions.forEach(node => {
+          if (isSuperTypeParameterPropsDeclaration(node)) {
+            markPropTypesAsDeclared(node, resolveSuperParameterPropsType(node));
+          }
+        });
+
         stack = null;
         const list = components.list();
         // Report undeclared proptypes for all classes

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -173,7 +173,7 @@ module.exports = {
      * @returns {Boolean} True if the node is a class with generic prop types, false if not.
      */
     function isSuperTypeParameterPropsDeclaration(node) {
-      if (node && node.type === 'ClassDeclaration') {
+      if (node && (node.type === 'ClassDeclaration' || node.type === 'ClassExpression')) {
         if (node.superTypeParameters && node.superTypeParameters.params.length > 0) {
           return true;
         }
@@ -915,6 +915,12 @@ module.exports = {
 
     return {
       ClassDeclaration: function(node) {
+        if (isSuperTypeParameterPropsDeclaration(node)) {
+          markPropTypesAsDeclared(node, resolveSuperParameterPropsType(node));
+        }
+      },
+
+      ClassExpression: function(node) {
         if (isSuperTypeParameterPropsDeclaration(node)) {
           markPropTypesAsDeclared(node, resolveSuperParameterPropsType(node));
         }

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1669,6 +1669,45 @@ ruleTester.run('prop-types', rule, {
       `,
       settings: {react: {flowVersion: '0.53'}},
       parser: 'babel-eslint'
+    }, {
+      code: `
+        type Props = { foo: string }
+        function higherOrderComponent<Props>() {
+          return class extends React.Component<Props> {
+            render() {
+              return <div>{this.props.foo}</div>
+            }
+          }
+        }
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        function higherOrderComponent<P: { foo: string }>() {
+          return class extends React.Component<P> {
+            render() {
+              return <div>{this.props.foo}</div>
+            }
+          }
+        }
+      `,
+      parser: 'babel-eslint'
+    },
+    {
+      code: `
+        const withOverlayState = <P: {foo: string}>(WrappedComponent: ComponentType<P>): CpmponentType<P> => (
+          class extends React.Component<P> {
+            constructor(props) {
+              super(props);
+              this.state = {foo: props.foo}
+            }
+            render() {
+              return <div>Hello World</div>
+            }
+          }
+        )
+      `,
+      parser: 'babel-eslint'
     },
     // issue #1288
     `function Foo() {

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3295,6 +3295,35 @@ ruleTester.run('prop-types', rule, {
         type: 'Identifier'
       }],
       parser: 'babel-eslint'
+    }, {
+      code: `
+        type Props = { foo: string }
+        function higherOrderComponent<Props>() {
+          return class extends React.Component<Props> {
+            render() {
+              return <div>{this.props.foo} - {this.props.bar}</div>
+            }
+          }
+        }
+      `,
+      errors: [{
+        message: '\'bar\' is missing in props validation'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        function higherOrderComponent<P: { foo: string }>() {
+          return class extends React.Component<P> {
+            render() {
+              return <div>{this.props.foo} - {this.props.bar}</div>
+            }
+          }
+        }
+      `,
+      errors: [{
+        message: '\'bar\' is missing in props validation'
+      }],
+      parser: 'babel-eslint'
     }
   ]
 });

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1692,8 +1692,7 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       parser: 'babel-eslint'
-    },
-    {
+    }, {
       code: `
         const withOverlayState = <P: {foo: string}>(WrappedComponent: ComponentType<P>): CpmponentType<P> => (
           class extends React.Component<P> {
@@ -3319,6 +3318,24 @@ ruleTester.run('prop-types', rule, {
             }
           }
         }
+      `,
+      errors: [{
+        message: '\'bar\' is missing in props validation'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        const withOverlayState = <P: {foo: string}>(WrappedComponent: ComponentType<P>): CpmponentType<P> => (
+          class extends React.Component<P> {
+            constructor(props) {
+              super(props);
+              this.state = {foo: props.foo, bar: props.bar}
+            }
+            render() {
+              return <div>Hello World</div>
+            }
+          }
+        )
       `,
       errors: [{
         message: '\'bar\' is missing in props validation'


### PR DESCRIPTION
I'm not super happy with the solution, perhaps others have a better idea?

It turns out that ESLint visits `ClassExpression` before it visits `TypeParameterDeclaration`, but I want it the other way around.

I tried using the `ClassExpression:exit` key, but it doesn't change anything.

Therefore, I needed a way to defer class expressions evaluations util after `TypeParameterDeclaration` has been visited, by storing the nodes in an array and looping through it in `Program:exit`.

This fixes https://github.com/yannickcr/eslint-plugin-react/issues/1376#issuecomment-325166909 and several other cases which we didn't catch before.

I'm not sure it will cover all of the issues related to Flow Props yet.

I'll add the same support to `no-unused-prop-types`  in https://github.com/yannickcr/eslint-plugin-react/issues/1393