### PR TITLE
Add support for Flow IntersectionTypeAnnotation to prop-types and no-unused-prop-types

### DIFF
--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -203,7 +203,6 @@ module.exports = {
             properties = annotation ? (annotation.properties || []) : [];
           }
 
-
           break;
 
         case 'UnionTypeAnnotation':

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -164,22 +164,46 @@ module.exports = {
     }
 
     /**
+     * Handles Props defined in IntersectionTypeAnnotation nodes
+     * e.g. type Props = PropsA & PropsB
+     * @param   {ASTNode} intersectionTypeAnnotation ObjectExpression node.
+     * @returns {Object[]}
+     */
+    function getPropertiesFromIntersectionTypeAnnotationNode(annotation) {
+      return annotation.types.reduce((properties, type) => {
+        annotation = resolveGenericTypeAnnotation(type);
+
+        if (annotation && annotation.id) {
+          annotation = findVariableByName(annotation.id.name);
+        }
+
+        return properties.concat(annotation.properties);
+      }, []);
+    }
+
+    /**
      * Extracts a PropType from a TypeAnnotation node.
      * @param   {ASTNode} node TypeAnnotation node.
      * @returns {Object[]}     Array of PropType object representations, to be consumed by `addPropTypesToComponent`.
      */
     function getPropTypesFromTypeAnnotation(node) {
-      let properties;
+      let properties = [];
 
       switch (node.typeAnnotation.type) {
         case 'GenericTypeAnnotation':
           let annotation = resolveGenericTypeAnnotation(node.typeAnnotation);
 
-          if (annotation && annotation.id) {
-            annotation = findVariableByName(annotation.id.name);
+          if (annotation && annotation.type === 'IntersectionTypeAnnotation') {
+            properties = getPropertiesFromIntersectionTypeAnnotationNode(annotation);
+          } else {
+            if (annotation && annotation.id) {
+              annotation = findVariableByName(annotation.id.name);
+            }
+
+            properties = annotation ? (annotation.properties || []) : [];
           }
 
-          properties = annotation ? (annotation.properties || []) : [];
+
           break;
 
         case 'UnionTypeAnnotation':
@@ -314,7 +338,6 @@ module.exports = {
       if (!component) {
         return;
       }
-
       addPropTypesToComponent(component, getPropTypesFromTypeAnnotation(node.typeAnnotation, context));
     }
 

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -736,6 +736,26 @@ module.exports = {
             return;
           }
           break;
+        case 'IntersectionTypeAnnotation':
+          propTypes.types.forEach(annotation => {
+            const propsType = typeScope(annotation.id.name);
+            iterateProperties(propsType.properties, (key, value) => {
+              if (!value) {
+                ignorePropsValidation = true;
+                return;
+              }
+
+              let types = buildTypeAnnotationDeclarationTypes(value, key);
+              if (types === true) {
+                types = {};
+              }
+              types.fullName = key;
+              types.name = key;
+              types.node = value;
+              declaredPropTypes.push(types);
+            });
+          });
+          break;
         case null:
           break;
         default:

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -8,7 +8,6 @@
 // https://github.com/yannickcr/eslint-plugin-react/issues/7
 
 const has = require('has');
-const util = require('util');
 const Components = require('../util/Components');
 const variable = require('../util/variable');
 const annotations = require('../util/annotations');

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -8,11 +8,11 @@
 // https://github.com/yannickcr/eslint-plugin-react/issues/7
 
 const has = require('has');
+const util = require('util');
 const Components = require('../util/Components');
 const variable = require('../util/variable');
 const annotations = require('../util/annotations');
 const versionUtil = require('../util/version');
-
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
@@ -793,6 +793,18 @@ module.exports = {
             markPropTypesAsDeclared(node, propTypes.arguments[0]);
             return;
           }
+          break;
+        case 'IntersectionTypeAnnotation':
+          propTypes.types.forEach(annotation => {
+            const propsType = typeScope(annotation.id.name);
+            iterateProperties(propsType.properties, (key, value) => {
+              if (!value) {
+                ignorePropsValidation = true;
+                return;
+              }
+              declaredPropTypes[key] = buildTypeAnnotationDeclarationTypes(value);
+            });
+          });
           break;
         case null:
           break;

--- a/tests/lib/rules/default-props-match-prop-types.js
+++ b/tests/lib/rules/default-props-match-prop-types.js
@@ -692,7 +692,6 @@ ruleTester.run('default-props-match-prop-types', rule, {
           props: Props;
           static defaultProps = {
             foo: "foo",
-            bar: "bar",
           }
 
           render() {

--- a/tests/lib/rules/default-props-match-prop-types.js
+++ b/tests/lib/rules/default-props-match-prop-types.js
@@ -683,6 +683,26 @@ ruleTester.run('default-props-match-prop-types', rule, {
       parser: 'babel-eslint'
     },
     {
+      code: `
+        type PropsA = { foo?: string };
+        type PropsB = { bar?: string, fooBar: string };
+        type Props = PropsA & PropsB;
+
+        class Bar extends React.Component {
+          props: Props;
+          static defaultProps = {
+            foo: "foo",
+            bar: "bar",
+          }
+
+          render() {
+            return <div>{this.props.foo} - {this.props.bar}</div>
+          }
+        }
+      `,
+      parser: 'babel-eslint'
+    },
+    {
       code: [
         'import type Props from "fake";',
         'class Hello extends React.Component {',
@@ -1507,6 +1527,34 @@ ruleTester.run('default-props-match-prop-types', rule, {
           message: 'defaultProp "frob" has no corresponding propTypes declaration.',
           line: 12,
           column: 36
+        }
+      ]
+    },
+    {
+      code: `
+        type PropsA = { foo: string };
+        type PropsB = { bar: string };
+        type Props = PropsA & PropsB;
+
+        class Bar extends React.Component {
+          props: Props;
+          static defaultProps = {
+            fooBar: "fooBar",
+            foo: "foo",
+          }
+
+          render() {
+            return <div>{this.props.foo} - {this.props.bar}</div>
+          }
+        }
+      `,
+      parser: 'babel-eslint',
+      errors: [
+        {
+          message: 'defaultProp "fooBar" has no corresponding propTypes declaration.'
+        },
+        {
+          message: 'defaultProp "foo" defined for isRequired propType.'
         }
       ]
     }

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -825,6 +825,21 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      code: `
+      type PropsA = { a: string }
+      type PropsB = { b: string }
+      type Props = PropsA & PropsB;
+      
+      class MyComponent extends React.Component {
+        props: Props;
+        
+        render() {
+          return <div>{this.props.a} - {this.props.b}</div>
+        }
+      }
+      `,
+      parser: 'babel-eslint'
+    }, {
       code: [
         'import type Props from "fake";',
         'class Hello extends React.Component {',
@@ -2636,6 +2651,24 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint',
       errors: [
         {message: '\'unused\' PropType is defined but prop is never used'}
+      ]
+    }, {
+      code: `
+      type PropsA = { a: string }
+      type PropsB = { b: string }
+      type Props = PropsA & PropsB;
+      
+      class MyComponent extends React.Component {
+        props: Props;
+        
+        render() {
+          return <div>{this.props.a}</div>
+        }
+      }
+      `,
+      parser: 'babel-eslint',
+      errors: [
+        {message: '\'b\' PropType is defined but prop is never used'}
       ]
     }, {
       code: [

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1669,7 +1669,29 @@ ruleTester.run('prop-types', rule, {
       `,
       settings: {react: {flowVersion: '0.53'}},
       parser: 'babel-eslint'
+    }, {
+      code: `
+        type PropsA = {
+          foo: string,
+        };
+
+        type PropsB = {
+          bar: string,
+        };
+
+        type Props = PropsA & PropsB;
+
+        class Bar extends React.Component {
+          props: Props;
+          
+          render() {
+            return <div>{this.props.foo} - {this.props.bar}</div>
+          }
+        }
+      `,
+      parser: 'babel-eslint'
     },
+
     // issue #1288
     `function Foo() {
       const props = {}
@@ -3256,6 +3278,30 @@ ruleTester.run('prop-types', rule, {
         type: 'Identifier'
       }],
       parser: 'babel-eslint'
+    }, {
+      code: `
+        type PropsA = {
+          foo: string,
+        };
+
+        type PropsB = {
+          bar: string,
+        };
+
+        type Props = PropsA & PropsB;
+
+        class Bar extends React.Component {
+          props: Props;
+          
+          render() {
+            return <div>{this.props.foo} - {this.props.bar} - {this.props.fooBar}</div>
+          }
+        }
+      `,
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'fooBar\' is missing in props validation'
+      }]
     }
   ]
 });

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1671,14 +1671,8 @@ ruleTester.run('prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: `
-        type PropsA = {
-          foo: string,
-        };
-
-        type PropsB = {
-          bar: string,
-        };
-
+        type PropsA = { foo: string };
+        type PropsB = { bar: string };
         type Props = PropsA & PropsB;
 
         class Bar extends React.Component {

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3280,17 +3280,11 @@ ruleTester.run('prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: `
-        type PropsA = {
-          foo: string,
-        };
-
-        type PropsB = {
-          bar: string,
-        };
-
+        type PropsA = {foo: string };
+        type PropsB = { bar: string };
         type Props = PropsA & PropsB;
 
-        class Bar extends React.Component {
+        class MyComponent extends React.Component {
           props: Props;
           
           render() {


### PR DESCRIPTION
Fixes #1364. Fixes #1323.

The following snippet creates an `IntersectionTypeAnnotation` which was not handled in both rules.

```js
type Props = PropsA & PropsB;
```

I hope the tests/implementation are speaking for themselves on this one 😄 If anyone has any advice for additional test cases please let me know. I didn't test the `React.Component<Props>` syntax because I figured these shouldn't affect that implementation, but perhaps it's worth it?