### PR TITLE
Fix typo in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,10 +3,10 @@
        "es6": true,
        "node": true
     },
-    parserOptions: {
-      ecmaVersion: 6,
-      ecmaFeatures: {
-          jsx: true
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "ecmaFeatures": {
+          "jsx": true
       }
     },
     "rules": {


### PR DESCRIPTION
While checking the source the code, I found in the **.eslintrc** missing the doublequote in the parserOptions, made a quick fix on this PR.