### PR TITLE
Fix crash for no-typos: Cannot read property 'name' of undefined

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -117,13 +117,21 @@ module.exports = {
       },
 
       MemberExpression: function(node) {
+        const propertyName = node.property.name;
+
+        if (
+          !propertyName ||
+          STATIC_CLASS_PROPERTIES.map(prop => prop.toLocaleLowerCase()).indexOf(propertyName.toLowerCase()) === -1
+        ) {
+          return;
+        }
+
         const relatedComponent = utils.getRelatedComponent(node);
 
         if (
           relatedComponent &&
           (utils.isES6Component(relatedComponent.node) || utils.isReturningJSX(relatedComponent.node))
         ) {
-          const propertyName = node.property.name;
           reportErrorIfClassPropertyCasingTypo(node, propertyName);
         }
       },

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -119,12 +119,12 @@ module.exports = {
       MemberExpression: function(node) {
         const propertyName = node.property.name;
 
-        // if (
-        //   !propertyName ||
-        //   STATIC_CLASS_PROPERTIES.map(prop => prop.toLocaleLowerCase()).indexOf(propertyName.toLowerCase()) === -1
-        // ) {
-        //   return;
-        // }
+        if (
+          !propertyName ||
+          STATIC_CLASS_PROPERTIES.map(prop => prop.toLocaleLowerCase()).indexOf(propertyName.toLowerCase()) === -1
+        ) {
+          return;
+        }
 
         const relatedComponent = utils.getRelatedComponent(node);
 

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -119,12 +119,12 @@ module.exports = {
       MemberExpression: function(node) {
         const propertyName = node.property.name;
 
-        if (
-          !propertyName ||
-          STATIC_CLASS_PROPERTIES.map(prop => prop.toLocaleLowerCase()).indexOf(propertyName.toLowerCase()) === -1
-        ) {
-          return;
-        }
+        // if (
+        //   !propertyName ||
+        //   STATIC_CLASS_PROPERTIES.map(prop => prop.toLocaleLowerCase()).indexOf(propertyName.toLowerCase()) === -1
+        // ) {
+        //   return;
+        // }
 
         const relatedComponent = utils.getRelatedComponent(node);
 

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -537,7 +537,7 @@ function componentRule(rule, context) {
           continue;
         }
         for (k = 0, l = componentNode.properties.length; k < l; k++) {
-          if (componentNode.properties[k].key.name === componentPath[i]) {
+          if (componentNode.properties[k].key && componentNode.properties[k].key.name === componentPath[i]) {
             componentNode = componentNode.properties[k];
             break;
           }

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -336,6 +336,14 @@ ruleTester.run('no-typos', rule, {
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
+  }, {
+    code: `
+      const fn = (err, res) => {
+        const { body: data = {} } = { ...res };
+        data.time = data.time || {};
+      };
+    `,
+    parser: 'babel-eslint'
   }],
 
   invalid: [{


### PR DESCRIPTION
There was another report of a crash with `no-typos` rule: https://github.com/yannickcr/eslint-plugin-react/issues/1373#issuecomment-325717418

Fixed this one 2 ways:

* Added a null check around the code that was causing this crash
* Added an extra validation on the `MemberExpression" visitor to make sure we are dealing with one of the supported properties

The second point may not be needed, but I think it's a nice addition to the rule... currently we visit **all MemberExpressions**, including those outside of React-related code. There are probably a whole bunch of these in any given code-base, and it's not needed to find the related component for that MemberExpression if we're not going to report a typo issue for the property name.