### PR TITLE
[make-no-direct-mutation-state] Handle update expressions

### DIFF
--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -63,6 +63,25 @@ module.exports = {
         });
       },
 
+      UpdateExpression(node) {
+        const argument = node.argument;
+
+        if (
+          argument.type === 'MemberExpression' &&
+          argument.object.type === 'MemberExpression' &&
+          argument.object.object.type === 'ThisExpression' &&
+          argument.object.property.name === 'state'
+        ) {
+          const component = components.get(utils.getParentComponent());
+          const mutations = (component && component.mutations) || [];
+          mutations.push(argument.object);
+          components.set(node, {
+            mutateSetState: true,
+            mutations
+          });
+        }
+      },
+
       AssignmentExpression(node) {
         let item;
         const component = components.get(utils.getParentComponent());

--- a/tests/lib/rules/no-direct-mutation-state.js
+++ b/tests/lib/rules/no-direct-mutation-state.js
@@ -245,6 +245,28 @@ ruleTester.run('no-direct-mutation-state', rule, {
     errors: [{
       message: 'Do not mutate state directly. Use setState().'
     }]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  componentWillUnmount() {',
+      '    this.state.foo++',
+      '  }',
+      '}'
+    ].join('\n'),
+    errors: [{
+      message: 'Do not mutate state directly. Use setState().'
+    }]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  componentWillUnmount() {',
+      '    this.state.foo--',
+      '  }',
+      '}'
+    ].join('\n'),
+    errors: [{
+      message: 'Do not mutate state directly. Use setState().'
+    }]
   }
   /**
    * Would be nice to prevent this too


### PR DESCRIPTION
For https://github.com/yannickcr/eslint-plugin-react/issues/1386, so that code such as 

```this.state.foo++```

or 

```this.state.foo--```

gets warned.

Let me know if there is any improvement you have in mind or any case I haven't covered.
