### PR TITLE
Fix another crash in boolean-prop-naming

### DIFF
--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -118,7 +118,7 @@ module.exports = {
       const component = components.get(node) || node;
       const invalidProps = component.invalidProps || [];
 
-      proptypes.forEach(prop => {
+      (proptypes || []).forEach(prop => {
         const propKey = getPropKey(prop);
         const flowCheck = (
           prop.type === 'ObjectTypeProperty' &&

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -257,6 +257,18 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
+  }, {
+    // Ensure rule doesn't crash on on components reference old-style Flow props
+    code: [
+      'class Hello extends PureComponent {',
+      '  props: PropsType;',
+      '  render () { return <div /> }',
+      '}'
+    ].join('\n'),
+    options: [{
+      rule: '^is[A-Z]([A-Za-z0-9]?)+'
+    }],
+    parser: 'babel-eslint'
   }],
 
   invalid: [{


### PR DESCRIPTION
Fixes another crash in the `boolean-prop-naming` rule related to old-style Flow prop types.