### PR TITLE
[no-unused-state] Add ability to handle arrow function class method

### DIFF
--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -54,7 +54,7 @@ function getInitialClassInfo() {
     // shadowing, assignments, etc. To keep things simple, we only
     // maintain one set of aliases per method and accept that it will
     // produce some false negatives.
-    aliases: null
+    aliases: new Set()
   };
 }
 

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -51,10 +51,10 @@ function getInitialClassInfo() {
 
     // Names of local variables that may be pointing to this.state. To
     // track this properly, we would need to keep track of all locals,
-    // shadowing, assignments, etc. To keep things simple, we only
-    // maintain one set of aliases per method and accept that it will
-    // produce some false negatives.
-    aliases: null
+    // shadowing, assignments, etc. To keep things simple, we clear the
+    // current set of aliases after each method definition and accept
+    // that it will produce some false negatives.
+    aliases: new Set()
   };
 }
 
@@ -86,7 +86,6 @@ module.exports = {
 
       const isAliasedStateReference =
         node.type === 'Identifier' &&
-        classInfo.aliases &&
         classInfo.aliases.has(node.name);
 
       return isDirectStateReference || isAliasedStateReference;
@@ -125,10 +124,7 @@ module.exports = {
       for (const prop of node.properties) {
         if (prop.type === 'Property') {
           addUsedStateField(prop.key);
-        } else if (
-          prop.type === 'ExperimentalRestProperty' &&
-          classInfo.aliases
-        ) {
+        } else if (prop.type === 'ExperimentalRestProperty') {
           classInfo.aliases.add(getName(prop.argument));
         }
       }
@@ -139,14 +135,14 @@ module.exports = {
     function handleAssignment(left, right) {
       switch (left.type) {
         case 'Identifier':
-          if (isStateReference(right) && classInfo.aliases) {
+          if (isStateReference(right)) {
             classInfo.aliases.add(left.name);
           }
           break;
         case 'ObjectPattern':
           if (isStateReference(right)) {
             handleStateDestructuring(left);
-          } else if (isThisExpression(right) && classInfo.aliases) {
+          } else if (isThisExpression(right)) {
             for (const prop of left.properties) {
               if (prop.type === 'Property' && getName(prop.key) === 'state') {
                 const name = getName(prop.value);
@@ -237,6 +233,15 @@ module.exports = {
         ) {
           addStateFields(node.value);
         }
+
+        if (
+          !node.static &&
+          node.value &&
+          node.value.type === 'ArrowFunctionExpression'
+        ) {
+          // Create a new set for this.state aliases local to this method.
+          classInfo.aliases = new Set();
+        }
       },
 
       MethodDefinition() {
@@ -245,14 +250,6 @@ module.exports = {
         }
         // Create a new set for this.state aliases local to this method.
         classInfo.aliases = new Set();
-      },
-
-      'MethodDefinition:exit'() {
-        if (!classInfo) {
-          return;
-        }
-        // Forget our set of local aliases.
-        classInfo.aliases = null;
       },
 
       FunctionExpression(node) {

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -54,7 +54,7 @@ function getInitialClassInfo() {
     // shadowing, assignments, etc. To keep things simple, we only
     // maintain one set of aliases per method and accept that it will
     // produce some false negatives.
-    aliases: new Set()
+    aliases: null
   };
 }
 
@@ -86,6 +86,7 @@ module.exports = {
 
       const isAliasedStateReference =
         node.type === 'Identifier' &&
+        classInfo.aliases &&
         classInfo.aliases.has(node.name);
 
       return isDirectStateReference || isAliasedStateReference;
@@ -124,7 +125,10 @@ module.exports = {
       for (const prop of node.properties) {
         if (prop.type === 'Property') {
           addUsedStateField(prop.key);
-        } else if (prop.type === 'ExperimentalRestProperty') {
+        } else if (
+          prop.type === 'ExperimentalRestProperty' &&
+          classInfo.aliases
+        ) {
           classInfo.aliases.add(getName(prop.argument));
         }
       }
@@ -135,14 +139,14 @@ module.exports = {
     function handleAssignment(left, right) {
       switch (left.type) {
         case 'Identifier':
-          if (isStateReference(right)) {
+          if (isStateReference(right) && classInfo.aliases) {
             classInfo.aliases.add(left.name);
           }
           break;
         case 'ObjectPattern':
           if (isStateReference(right)) {
             handleStateDestructuring(left);
-          } else if (isThisExpression(right)) {
+          } else if (isThisExpression(right) && classInfo.aliases) {
             for (const prop of left.properties) {
               if (prop.type === 'Property' && getName(prop.key) === 'state') {
                 const name = getName(prop.value);
@@ -244,12 +248,32 @@ module.exports = {
         }
       },
 
+      'ClassProperty:exit'(node) {
+        if (
+          classInfo &&
+          !node.static &&
+          node.value &&
+          node.value.type === 'ArrowFunctionExpression'
+        ) {
+          // Forget our set of local aliases.
+          classInfo.aliases = null;
+        }
+      },
+
       MethodDefinition() {
         if (!classInfo) {
           return;
         }
         // Create a new set for this.state aliases local to this method.
         classInfo.aliases = new Set();
+      },
+
+      'MethodDefinition:exit'() {
+        if (!classInfo) {
+          return;
+        }
+        // Forget our set of local aliases.
+        classInfo.aliases = null;
       },
 
       FunctionExpression(node) {

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -51,10 +51,10 @@ function getInitialClassInfo() {
 
     // Names of local variables that may be pointing to this.state. To
     // track this properly, we would need to keep track of all locals,
-    // shadowing, assignments, etc. To keep things simple, we clear the
-    // current set of aliases after each method definition and accept
-    // that it will produce some false negatives.
-    aliases: new Set()
+    // shadowing, assignments, etc. To keep things simple, we only
+    // maintain one set of aliases per method and accept that it will
+    // produce some false negatives.
+    aliases: null
   };
 }
 

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -387,6 +387,22 @@ eslintTester.run('no-unused-state', rule, {
           return <SomeComponent foo={foo} />;
         }
       }`,
+    `class NonRenderClassMethodFalseNegativeTest extends React.Component {
+        constructor() {
+          this.state = { foo: 0, bar: 0 };
+        }
+        doSomething() {
+          const { foo } = this.state;
+          return this.state.foo;
+        }
+        doSomethingElse() {
+          const { state: { bar }} = this;
+          return bar;
+        }
+        render() {
+          return <SomeComponent />;
+        }
+      }`,
     {
       code: `class TypeCastExpressionSpreadFalseNegativeTest extends React.Component {
         constructor() {
@@ -394,6 +410,72 @@ eslintTester.run('no-unused-state', rule, {
         }
         render() {
           return <SomeComponent {...(this.state: any)} />;
+        }
+      }`,
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class ArrowFunctionClassMethodDestructuringFalseNegativeTest extends React.Component {
+        constructor() {
+          this.state = { foo: 0 };
+        }
+
+        doSomething = () => {
+          const { state: { foo } } = this;
+
+          return foo;
+        }
+
+        render() {
+          return <SomeComponent />;
+        }
+      }`,
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class ArrowFunctionClassMethodWithClassPropertyTransformFalseNegativeTest extends React.Component {
+        state = { foo: 0 };
+
+        doSomething = () => {
+          const { state:{ foo } } = this;
+
+          return foo;
+        }
+
+        render() {
+          return <SomeComponent />;
+        }
+      }`,
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class ArrowFunctionClassMethodDeepDestructuringFalseNegativeTest extends React.Component {
+        state = { foo: { bar: 0 } };
+
+        doSomething = () => {
+          const { state: { foo: { bar }}} = this;
+
+          return bar;
+        }
+
+        render() {
+          return <SomeComponent />;
+        }
+      }`,
+      parser: 'babel-eslint'
+    },
+    {
+      code: `class ArrowFunctionClassMethodDestructuringAssignmentFalseNegativeTest extends React.Component {
+        state = { foo: 0 };
+
+        doSomething = () => {
+          const { state: { foo: bar }} = this;
+
+          return bar;
+        }
+
+        render() {
+          return <SomeComponent />;
         }
       }`,
       parser: 'babel-eslint'
@@ -641,6 +723,21 @@ eslintTester.run('no-unused-state', rule, {
           }
         }`,
       errors: getErrorMessages(['foo'])
+    },
+    {
+      code: `class UnusedStateArrowFunctionMethodTest extends React.Component {
+          constructor() {
+            this.state = { foo: 0 };
+          }
+          doSomething = () => {
+            return null;
+          }
+          render() {
+            return <SomeComponent />;
+          }
+        }`,
+      errors: getErrorMessages(['foo']),
+      parser: 'babel-eslint'
     },
     {
       code: `class TypeCastExpressionTest extends React.Component {


### PR DESCRIPTION
For https://github.com/yannickcr/eslint-plugin-react/issues/1363, so that state property usage by object destructuring assignment in a class method defined with an arrow function gets recorded. Examples:

```js
class ArrowFunctionClassMethodTest extends React.Component {
  constructor() {
    this.state = { foo: 0 };
  }

  doSomething = () => {
    const { state: { foo } } = this;

    return foo;
  }

  render() {
    return <SomeComponent />;
  }
}
```

should not be warned.

Let me know if there is anything I can do to improve this PR. Also, just to confirm, this rule doesn't care about whether the class method is used or not, right?