### PR TITLE
Add support for Flow TypedArgument in no-unsed-prop-types rule

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -11,6 +11,7 @@ const has = require('has');
 const Components = require('../util/Components');
 const variable = require('../util/variable');
 const annotations = require('../util/annotations');
+const versionUtil = require('../util/version');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -134,17 +135,23 @@ module.exports = {
     }
 
     /**
-     * Resolve the type annotation for a given node.
-     * Flow annotations are sometimes wrapped in outer `TypeAnnotation`
-     * and `NullableTypeAnnotation` nodes which obscure the annotation we're
-     * interested in.
-     * This method also resolves type aliases where possible.
+     * Resolve the type annotation for a given class declaration node with superTypeParameters.
      *
      * @param {ASTNode} node The annotation or a node containing the type annotation.
      * @returns {ASTNode} The resolved type annotation for the node.
      */
-    function resolveTypeAnnotation(node) {
-      let annotation = node.typeAnnotation || node;
+    function resolveSuperParameterPropsType(node) {
+      let propsParameterPosition;
+      try {
+        // Flow <=0.52 had 3 required TypedParameters of which the second one is the Props.
+        // Flow >=0.53 has 2 optional TypedParameters of which the first one is the Props.
+        propsParameterPosition = versionUtil.testFlowVersion(context, '0.53.0') ? 0 : 1;
+      } catch (e) {
+        // In case there is no flow version defined, we can safely assume that when there are 3 Props we are dealing with version <= 0.52
+        propsParameterPosition = node.superTypeParameters.params.length <= 2 ? 0 : 1;
+      }
+
+      let annotation = node.superTypeParameters.params[propsParameterPosition];
       while (annotation && (annotation.type === 'TypeAnnotation' || annotation.type === 'NullableTypeAnnotation')) {
         annotation = annotation.typeAnnotation;
       }

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -134,6 +134,42 @@ module.exports = {
     }
 
     /**
+     * Resolve the type annotation for a given node.
+     * Flow annotations are sometimes wrapped in outer `TypeAnnotation`
+     * and `NullableTypeAnnotation` nodes which obscure the annotation we're
+     * interested in.
+     * This method also resolves type aliases where possible.
+     *
+     * @param {ASTNode} node The annotation or a node containing the type annotation.
+     * @returns {ASTNode} The resolved type annotation for the node.
+     */
+    function resolveTypeAnnotation(node) {
+      let annotation = node.typeAnnotation || node;
+      while (annotation && (annotation.type === 'TypeAnnotation' || annotation.type === 'NullableTypeAnnotation')) {
+        annotation = annotation.typeAnnotation;
+      }
+      if (annotation.type === 'GenericTypeAnnotation' && typeScope(annotation.id.name)) {
+        return typeScope(annotation.id.name);
+      }
+      return annotation;
+    }
+
+    /**
+     * Checks if we are declaring a props as a generic type in a flow-annotated class.
+     *
+     * @param {ASTNode} node  the AST node being checked.
+     * @returns {Boolean} True if the node is a class with generic prop types, false if not.
+     */
+    function isSuperTypeParameterPropsDeclaration(node) {
+      if (node && node.type === 'ClassDeclaration') {
+        if (node.superTypeParameters && node.superTypeParameters.params.length > 0) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    /**
      * Checks if we are declaring a prop
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if we are declaring a prop, false if not.
@@ -866,6 +902,12 @@ module.exports = {
     // --------------------------------------------------------------------------
 
     return {
+      ClassDeclaration: function(node) {
+        if (isSuperTypeParameterPropsDeclaration(node)) {
+          markPropTypesAsDeclared(node, resolveSuperParameterPropsType(node));
+        }
+      },
+
       ClassProperty: function(node) {
         if (isAnnotatedClassPropsDeclaration(node)) {
           markPropTypesAsDeclared(node, resolveTypeAnnotation(node));

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -12,6 +12,7 @@ const Components = require('../util/Components');
 const variable = require('../util/variable');
 const annotations = require('../util/annotations');
 const versionUtil = require('../util/version');
+
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2069,6 +2069,30 @@ ruleTester.run('no-unused-prop-types', rule, {
       };
     `,
       parser: 'babel-eslint'
+    }, {
+      code: `
+        type Person = {
+          firstname: string
+        }
+        class MyComponent extends React.Component<void, Props, void> {
+          render() {
+            return <div>Hello {this.props.firstname}</div>
+          }
+        }
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        type Person = {
+          firstname: string
+        }
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div>Hello {this.props.firstname}</div>
+          }
+        }
+      `,
+      parser: 'babel-eslint'
     }
   ],
 
@@ -3468,6 +3492,22 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint',
       errors: [{
         message: '\'aProp\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: `
+        type Props = {
+          firstname: string,
+          lastname: string,
+        }
+        class MyComponent extends React.Component<void, Props, void> {
+          render() {
+            return <div>Hello {this.props.firstname}</div>
+          }
+        }
+      `,
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
       }]
     }
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2086,12 +2086,38 @@ ruleTester.run('no-unused-prop-types', rule, {
         type Person = {
           firstname: string
         }
+        class MyComponent extends React.Component<void, Props, void> {
+          render() {
+            return <div>Hello {this.props.firstname}</div>
+          }
+        }
+      `,
+      settings: {react: {flowVersion: '0.52'}},
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        type Person = {
+          firstname: string
+        }
         class MyComponent extends React.Component<Props> {
           render() {
             return <div>Hello {this.props.firstname}</div>
           }
         }
       `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        type Person = {
+          firstname: string
+        }
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div>Hello {this.props.firstname}</div>
+          }
+        }
+      `,
+      settings: {react: {flowVersion: '0.53'}},
       parser: 'babel-eslint'
     }
   ],
@@ -3505,6 +3531,56 @@ ruleTester.run('no-unused-prop-types', rule, {
           }
         }
       `,
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: `
+        type Props = {
+          firstname: string,
+          lastname: string,
+        }
+        class MyComponent extends React.Component<void, Props, void> {
+          render() {
+            return <div>Hello {this.props.firstname}</div>
+          }
+        }
+      `,
+      settings: {react: {flowVersion: '0.52'}},
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: `
+        type Props = {
+          firstname: string,
+          lastname: string,
+        }
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div>Hello {this.props.firstname}</div>
+          }
+        }
+      `,
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: `
+        type Props = {
+          firstname: string,
+          lastname: string,
+        }
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div>Hello {this.props.firstname}</div>
+          }
+        }
+      `,
+      settings: {react: {flowVersion: '0.53'}},
       parser: 'babel-eslint',
       errors: [{
         message: '\'lastname\' PropType is defined but prop is never used'


### PR DESCRIPTION
While working on https://github.com/yannickcr/eslint-plugin-react/issues/1393 I noticed that `no-unused-prop-types` rule supports way more cases than `prop-types` rule already supports.

Since we would release Flow 0.53 support in the next release for the `prop-types` rule, I felt it wouldn't be really complete if we supported the Flow TypedArgument syntax for this rule either.

Since https://github.com/yannickcr/eslint-plugin-react/issues/1393 will take a bit more time for me to complete, I figured that an additional extra small PR to add this support to this rule would be very useful.

The code is 100% copy-paste from the `prop-types` rule. The goal for https://github.com/yannickcr/eslint-plugin-react/issues/1393 is to actually eliminate that duplication.