### PR TITLE
Refactor a bunch of tests to use template literal syntax instead of [].join(

### DIFF
--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -29,6 +29,7 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('boolean-prop-naming', rule, {
 
   valid: [{
+    // Should support both `is` and `has` prefixes by default
     code: `
       var Hello = createReactClass({
         propTypes: {isSomething: PropTypes.bool, hasValue: PropTypes.bool},
@@ -36,6 +37,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       });
     `
   }, {
+    // createReactClass components with PropTypes
     code: `
       var Hello = createReactClass({
         propTypes: {isSomething: PropTypes.bool},
@@ -46,6 +48,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
+    // createReactClass components with React.PropTypes
     code: `
       var Hello = createReactClass({
         propTypes: {isSomething: React.PropTypes.bool},
@@ -56,6 +59,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
+    // React.createClass components with PropTypes
     code: `
       var Hello = React.createClass({
         propTypes: {isSomething: PropTypes.bool},
@@ -71,6 +75,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       }
     }
   }, {
+    // React.createClass components with non-boolean PropTypes
     code: `
       var Hello = React.createClass({
         propTypes: {something: PropTypes.any},
@@ -86,6 +91,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       }
     }
   }, {
+    // ES6 components as React.Component with boolean PropTypes
     code: `
       class Hello extends React.Component {
         render () { return <div />; }
@@ -96,6 +102,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
+    // ES6 components as React.Component with non-boolean PropTypes
     code: `
       class Hello extends React.Component {
         render () { return <div />; }
@@ -116,6 +123,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
+    // ES6 components as Component with boolean PropTypes
     code: `
       class Hello extends Component {
         render () { return <div />; }
@@ -126,6 +134,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
+    // ES6 components with static class properties and PropTypes
     code: `
       class Hello extends React.Component {
         static propTypes = {isSomething: PropTypes.bool};
@@ -137,6 +146,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // ES6 components with static class properties and React.PropTypes
     code: `
       class Hello extends React.Component {
         static propTypes = {isSomething: React.PropTypes.bool};
@@ -148,6 +158,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // ES6 components with static class properties an non-booleans
     code: `
       class Hello extends React.Component {
         static propTypes = {something: PropTypes.any};
@@ -159,6 +170,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // ES6 components and Flowtype booleans
     code: `
       class Hello extends React.Component {
         props: {isSomething: boolean};
@@ -170,6 +182,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // ES6 components and Flowtype non-booleans
     code: `
       class Hello extends React.Component {
         props: {something: any};
@@ -181,6 +194,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // Stateless components
     code: `
       var Hello = ({isSomething}) => { return <div /> }
       Hello.propTypes = {isSomething: PropTypes.bool};
@@ -190,6 +204,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // Functional components and Flowtype booleans
     code: `
       type Props = {
         isSomething: boolean;
@@ -201,6 +216,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // Custom `propTypeNames` option
     code: `
       class Hello extends React.Component {
         static propTypes = {
@@ -216,6 +232,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // Custom PropTypes that are specified as variables
     code: `
       class Hello extends React.Component {
         static propTypes = {
@@ -231,6 +248,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // Ensure rule doesn't crash on destructured objects [Issue #1369]
     code: `
       var x = {a: 1}
       var y = {...x}
@@ -240,6 +258,7 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: 'babel-eslint'
   }, {
+    // Ensure rule doesn't crash on on components reference old-style Flow props
     code: `
       class Hello extends PureComponent {
         props: PropsType;
@@ -253,6 +272,7 @@ ruleTester.run('boolean-prop-naming', rule, {
   }],
 
   invalid: [{
+    // createReactClass components with PropTypes
     code: `
       var Hello = createReactClass({
         propTypes: {something: PropTypes.bool},
@@ -266,6 +286,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
+    // createReactClass components with React.PropTypes
     code: `
       var Hello = createReactClass({
         propTypes: {something: React.PropTypes.bool},
@@ -279,6 +300,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
+    // React.createClass components with PropTypes
     code: `
       var Hello = React.createClass({
         propTypes: {something: PropTypes.bool},
@@ -297,6 +319,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
+    // ES6 components as React.Component with boolean PropTypes
     code: `
       class Hello extends React.Component {
         render () { return <div />; }
@@ -310,6 +333,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
+    // ES6 components as Component with non-boolean PropTypes
     code: `
       class Hello extends Component {
         render () { return <div />; }
@@ -323,6 +347,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
+    // ES6 components as React.Component with non-boolean PropTypes
     code: `
       class Hello extends React.Component {
         static propTypes = {something: PropTypes.bool};
@@ -337,6 +362,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
+    // ES6 components as React.Component with non-boolean PropTypes
     code: `
       class Hello extends React.Component {
         props: {something: boolean};
@@ -377,6 +403,7 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
+    // ES6 components and Flowtype non-booleans
     code: `
       class Hello extends React.Component {
         static propTypes = {something: PropTypes.mutuallyExclusiveTrueProps};

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -29,43 +29,39 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('boolean-prop-naming', rule, {
 
   valid: [{
-    // Should support both `is` and `has` prefixes by default
-    code: [
-      'var Hello = createReactClass({',
-      '  propTypes: {isSomething: PropTypes.bool, hasValue: PropTypes.bool},',
-      '  render: function() { return <div />; }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        propTypes: {isSomething: PropTypes.bool, hasValue: PropTypes.bool},
+        render: function() { return <div />; }
+      });
+    `
   }, {
-    // createReactClass components with PropTypes
-    code: [
-      'var Hello = createReactClass({',
-      '  propTypes: {isSomething: PropTypes.bool},',
-      '  render: function() { return <div />; }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        propTypes: {isSomething: PropTypes.bool},
+        render: function() { return <div />; }
+      });
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
-    // createReactClass components with React.PropTypes
-    code: [
-      'var Hello = createReactClass({',
-      '  propTypes: {isSomething: React.PropTypes.bool},',
-      '  render: function() { return <div />; }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        propTypes: {isSomething: React.PropTypes.bool},
+        render: function() { return <div />; }
+      });
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
-    // React.createClass components with PropTypes
-    code: [
-      'var Hello = React.createClass({',
-      '  propTypes: {isSomething: PropTypes.bool},',
-      '  render: function() { return <div />; }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = React.createClass({
+        propTypes: {isSomething: PropTypes.bool},
+        render: function() { return <div />; }
+      });
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -75,13 +71,12 @@ ruleTester.run('boolean-prop-naming', rule, {
       }
     }
   }, {
-    // React.createClass components with non-boolean PropTypes
-    code: [
-      'var Hello = React.createClass({',
-      '  propTypes: {something: PropTypes.any},',
-      '  render: function() { return <div />; }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = React.createClass({
+        propTypes: {something: PropTypes.any},
+        render: function() { return <div />; }
+      });
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -91,180 +86,166 @@ ruleTester.run('boolean-prop-naming', rule, {
       }
     }
   }, {
-    // ES6 components as React.Component with boolean PropTypes
-    code: [
-      'class Hello extends React.Component {',
-      '  render () { return <div />; }',
-      '}',
-      'Hello.propTypes = {isSomething: PropTypes.bool}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render () { return <div />; }
+      }
+      Hello.propTypes = {isSomething: PropTypes.bool}
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  render () { return <div />; }',
-      '}',
-      'Hello.propTypes = wrap({ a: PropTypes.bool })'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render () { return <div />; }
+      }
+      Hello.propTypes = wrap({ a: PropTypes.bool })
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
-    // ES6 components as React.Component with non-boolean PropTypes
-    code: [
-      'class Hello extends React.Component {',
-      '  render () { return <div />; }',
-      '}',
-      'Hello.propTypes = {something: PropTypes.any}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render () { return <div />; }
+      }
+      Hello.propTypes = {something: PropTypes.any}
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
-    // ES6 components as Component with boolean PropTypes
-    code: [
-      'class Hello extends Component {',
-      '  render () { return <div />; }',
-      '}',
-      'Hello.propTypes = {isSomething: PropTypes.bool}'
-    ].join('\n'),
+    code: `
+      class Hello extends Component {
+        render () { return <div />; }
+      }
+      Hello.propTypes = {isSomething: PropTypes.bool}
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }]
   }, {
-    // ES6 components with static class properties and PropTypes
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {isSomething: PropTypes.bool};',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {isSomething: PropTypes.bool};
+        render () { return <div />; }
+      }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // ES6 components with static class properties and React.PropTypes
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {isSomething: React.PropTypes.bool};',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {isSomething: React.PropTypes.bool};
+        render () { return <div />; }
+      }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // ES6 components with static class properties an non-booleans
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {something: PropTypes.any};',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {something: PropTypes.any};
+        render () { return <div />; }
+      }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // ES6 components and Flowtype booleans
-    code: [
-      'class Hello extends React.Component {',
-      '  props: {isSomething: boolean};',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        props: {isSomething: boolean};
+        render () { return <div />; }
+      }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // ES6 components and Flowtype non-booleans
-    code: [
-      'class Hello extends React.Component {',
-      '  props: {something: any};',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        props: {something: any};
+        render () { return <div />; }
+      }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // Stateless components
-    code: [
-      'var Hello = ({isSomething}) => { return <div /> }',
-      'Hello.propTypes = {isSomething: PropTypes.bool};'
-    ].join('\n'),
+    code: `
+      var Hello = ({isSomething}) => { return <div /> }
+      Hello.propTypes = {isSomething: PropTypes.bool};
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // Functional components and Flowtype booleans
-    code: [
-      'type Props = {',
-      '  isSomething: boolean;',
-      '};',
-      'function Hello(props: Props): React.Element { return <div /> }'
-    ].join('\n'),
+    code: `
+      type Props = {
+        isSomething: boolean;
+      };
+      function Hello(props: Props): React.Element { return <div /> }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // Custom `propTypeNames` option
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {',
-      '    isSomething: PropTypes.mutuallyExclusiveTrueProps,',
-      '    something: PropTypes.bool',
-      '  };',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {
+          isSomething: PropTypes.mutuallyExclusiveTrueProps,
+          something: PropTypes.bool
+        };
+        render () { return <div />; }
+      }
+    `,
     options: [{
       propTypeNames: ['mutuallyExclusiveTrueProps'],
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // Custom PropTypes that are specified as variables
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {',
-      '    isSomething: mutuallyExclusiveTrueProps,',
-      '    isSomethingElse: bool',
-      '  };',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {
+          isSomething: mutuallyExclusiveTrueProps,
+          isSomethingElse: bool
+        };
+        render () { return <div />; }
+      }
+    `,
     options: [{
       propTypeNames: ['bool', 'mutuallyExclusiveTrueProps'],
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // Ensure rule doesn't crash on destructured objects [Issue #1369]
-    code: [
-      'var x = {a: 1}',
-      'var y = {...x}'
-    ].join('\n'),
+    code: `
+      var x = {a: 1}
+      var y = {...x}
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
   }, {
-    // Ensure rule doesn't crash on on components reference old-style Flow props
-    code: [
-      'class Hello extends PureComponent {',
-      '  props: PropsType;',
-      '  render () { return <div /> }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends PureComponent {
+        props: PropsType;
+        render () { return <div /> }
+      }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -272,13 +253,12 @@ ruleTester.run('boolean-prop-naming', rule, {
   }],
 
   invalid: [{
-    // createReactClass components with PropTypes
-    code: [
-      'var Hello = createReactClass({',
-      '  propTypes: {something: PropTypes.bool},',
-      '  render: function() { return <div />; }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        propTypes: {something: PropTypes.bool},
+        render: function() { return <div />; }
+      });
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -286,13 +266,12 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // createReactClass components with React.PropTypes
-    code: [
-      'var Hello = createReactClass({',
-      '  propTypes: {something: React.PropTypes.bool},',
-      '  render: function() { return <div />; }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        propTypes: {something: React.PropTypes.bool},
+        render: function() { return <div />; }
+      });
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -300,13 +279,12 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // React.createClass components with PropTypes
-    code: [
-      'var Hello = React.createClass({',
-      '  propTypes: {something: PropTypes.bool},',
-      '  render: function() { return <div />; }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = React.createClass({
+        propTypes: {something: PropTypes.bool},
+        render: function() { return <div />; }
+      });
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -319,13 +297,12 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // ES6 components as React.Component with boolean PropTypes
-    code: [
-      'class Hello extends React.Component {',
-      '  render () { return <div />; }',
-      '}',
-      'Hello.propTypes = {something: PropTypes.bool}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render () { return <div />; }
+      }
+      Hello.propTypes = {something: PropTypes.bool}
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -333,13 +310,12 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // ES6 components as Component with non-boolean PropTypes
-    code: [
-      'class Hello extends Component {',
-      '  render () { return <div />; }',
-      '}',
-      'Hello.propTypes = {something: PropTypes.bool}'
-    ].join('\n'),
+    code: `
+      class Hello extends Component {
+        render () { return <div />; }
+      }
+      Hello.propTypes = {something: PropTypes.bool}
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -347,28 +323,12 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // ES6 components as React.Component with non-boolean PropTypes
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {something: PropTypes.bool};',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
-    options: [{
-      rule: '^is[A-Z]([A-Za-z0-9]?)+'
-    }],
-    parser: 'babel-eslint',
-    errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
-    }]
-  }, {
-    // ES6 components and Flowtype non-booleans
-    code: [
-      'class Hello extends React.Component {',
-      '  props: {something: boolean};',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {something: PropTypes.bool};
+        render () { return <div />; }
+      }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -377,11 +337,12 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // Stateless components
-    code: [
-      'var Hello = ({something}) => { return <div /> }',
-      'Hello.propTypes = {something: PropTypes.bool};'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        props: {something: boolean};
+        render () { return <div />; }
+      }
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -390,13 +351,10 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // Functional components and Flowtype booleans
-    code: [
-      'type Props = {',
-      '  something: boolean;',
-      '};',
-      'function Hello(props: Props): React.Element { return <div /> }'
-    ].join('\n'),
+    code: `
+      var Hello = ({something}) => { return <div /> }
+      Hello.propTypes = {something: PropTypes.bool};
+    `,
     options: [{
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
@@ -405,13 +363,26 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // Custom `propTypeNames` option
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {something: PropTypes.mutuallyExclusiveTrueProps};',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      type Props = {
+        something: boolean;
+      };
+      function Hello(props: Props): React.Element { return <div /> }
+    `,
+    options: [{
+      rule: '^is[A-Z]([A-Za-z0-9]?)+'
+    }],
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+    }]
+  }, {
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {something: PropTypes.mutuallyExclusiveTrueProps};
+        render () { return <div />; }
+      }
+    `,
     options: [{
       propTypeNames: ['bool', 'mutuallyExclusiveTrueProps'],
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
@@ -421,16 +392,15 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // Should fail for every invalid prop
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {',
-      '    something: PropTypes.mutuallyExclusiveTrueProps,',
-      '    somethingElse: PropTypes.bool',
-      '  };',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {
+          something: PropTypes.mutuallyExclusiveTrueProps,
+          somethingElse: PropTypes.bool
+        };
+        render () { return <div />; }
+      }
+    `,
     options: [{
       propTypeNames: ['bool', 'mutuallyExclusiveTrueProps'],
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
@@ -442,16 +412,15 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (somethingElse) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }]
   }, {
-    // Custom PropTypes that are specified as variables
-    code: [
-      'class Hello extends React.Component {',
-      '  static propTypes = {',
-      '    something: mutuallyExclusiveTrueProps,',
-      '    somethingElse: bool',
-      '  };',
-      '  render () { return <div />; }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static propTypes = {
+          something: mutuallyExclusiveTrueProps,
+          somethingElse: bool
+        };
+        render () { return <div />; }
+      }
+    `,
     options: [{
       propTypeNames: ['bool', 'mutuallyExclusiveTrueProps'],
       rule: '^is[A-Z]([A-Za-z0-9]?)+'

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -30,26 +30,26 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('display-name', rule, {
 
   valid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  displayName: \'Hello\',',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        displayName: 'Hello',
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }]
   }, {
-    code: [
-      'var Hello = React.createClass({',
-      '  displayName: \'Hello\',',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = React.createClass({
+        displayName: 'Hello',
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -59,292 +59,292 @@ ruleTester.run('display-name', rule, {
       }
     }
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}',
-      'Hello.displayName = \'Hello\''
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+      Hello.displayName = 'Hello'
+    `,
     options: [{
       ignoreTranspilerName: true
     }]
   }, {
-    code: [
-      'class Hello {',
-      '  render() {',
-      '    return \'Hello World\';',
-      '  }',
-      '}'
-    ].join('\n')
+    code: `
+      class Hello {
+        render() {
+          return 'Hello World';
+        }
+      }
+    `
   }, {
-    code: [
-      'class Hello extends Greetings {',
-      '  static text = \'Hello World\';',
-      '  render() {',
-      '    return Hello.text;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends Greetings {
+        static text = 'Hello World';
+        render() {
+          return Hello.text;
+        }
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'class Hello {',
-      '  method;',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello {
+        method;
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  static get displayName() {',
-      '    return \'Hello\';',
-      '  }',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static get displayName() {
+          return 'Hello';
+        }
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     options: [{
       ignoreTranspilerName: true
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  static displayName = \'Widget\';',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        static displayName = 'Widget';
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'export default class Hello {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      export default class Hello {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Hello;',
-      'Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello;
+      Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'module.exports = createReactClass({',
-      '  "displayName": "Hello",',
-      '  "render": function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      module.exports = createReactClass({
+        "displayName": "Hello",
+        "render": function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  displayName: \'Hello\',',
-      '  render: function() {',
-      '    let { a, ...b } = obj;',
-      '    let c = { ...d };',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        displayName: 'Hello',
+        render: function() {
+          let { a, ...b } = obj;
+          let c = { ...d };
+          return <div />;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }]
   }, {
-    code: [
-      'export default class {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      export default class {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Hello = function() {',
-      '  return <div>Hello {this.props.name}</div>;',
-      '}'
-    ].join('\n'),
+    code: `
+      var Hello = function() {
+        return <div>Hello {this.props.name}</div>;
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'function Hello() {',
-      '  return <div>Hello {this.props.name}</div>;',
-      '}'
-    ].join('\n'),
+    code: `
+      function Hello() {
+        return <div>Hello {this.props.name}</div>;
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Hello = () => {',
-      '  return <div>Hello {this.props.name}</div>;',
-      '}'
-    ].join('\n'),
+    code: `
+      var Hello = () => {
+        return <div>Hello {this.props.name}</div>;
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'module.exports = function Hello() {',
-      '  return <div>Hello {this.props.name}</div>;',
-      '}'
-    ].join('\n'),
+    code: `
+      module.exports = function Hello() {
+        return <div>Hello {this.props.name}</div>;
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'function Hello() {',
-      '  return <div>Hello {this.props.name}</div>;',
-      '}',
-      'Hello.displayName = \'Hello\';'
-    ].join('\n'),
+    code: `
+      function Hello() {
+        return <div>Hello {this.props.name}</div>;
+      }
+      Hello.displayName = 'Hello';
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Hello = () => {',
-      '  return <div>Hello {this.props.name}</div>;',
-      '}',
-      'Hello.displayName = \'Hello\';'
-    ].join('\n'),
+    code: `
+      var Hello = () => {
+        return <div>Hello {this.props.name}</div>;
+      }
+      Hello.displayName = 'Hello';
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Hello = function() {',
-      '  return <div>Hello {this.props.name}</div>;',
-      '}',
-      'Hello.displayName = \'Hello\';'
-    ].join('\n'),
+    code: `
+      var Hello = function() {
+        return <div>Hello {this.props.name}</div>;
+      }
+      Hello.displayName = 'Hello';
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Mixins = {',
-      '  Greetings: {',
-      '    Hello: function() {',
-      '      return <div>Hello {this.props.name}</div>;',
-      '    }',
-      '  }',
-      '}',
-      'Mixins.Greetings.Hello.displayName = \'Hello\';'
-    ].join('\n'),
+    code: `
+      var Mixins = {
+        Greetings: {
+          Hello: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      }
+      Mixins.Greetings.Hello.displayName = 'Hello';
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>{this._renderHello()}</div>;',
-      '  },',
-      '  _renderHello: function() {',
-      '    return <span>Hello {this.props.name}</span>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>{this._renderHello()}</div>;
+        },
+        _renderHello: function() {
+          return <span>Hello {this.props.name}</span>;
+        }
+      });
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  displayName: \'Hello\',',
-      '  render: function() {',
-      '    return <div>{this._renderHello()}</div>;',
-      '  },',
-      '  _renderHello: function() {',
-      '    return <span>Hello {this.props.name}</span>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        displayName: 'Hello',
+        render: function() {
+          return <div>{this._renderHello()}</div>;
+        },
+        _renderHello: function() {
+          return <span>Hello {this.props.name}</span>;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
     parser: 'babel-eslint'
   }, {
-    code: [
-      'const Mixin = {',
-      '  Button() {',
-      '    return (',
-      '      <button />',
-      '    );',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      const Mixin = {
+        Button() {
+          return (
+            <button />
+          );
+        }
+      };
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var obj = {',
-      '  pouf: function() {',
-      '    return any',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      var obj = {
+        pouf: function() {
+          return any
+        }
+      };
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
     parser: 'babel-eslint'
   }, {
-    code: [
-      'var obj = {',
-      '  pouf: function() {',
-      '    return any',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      var obj = {
+        pouf: function() {
+          return any
+        }
+      };
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'export default {',
-      '  renderHello() {',
-      '    let {name} = this.props;',
-      '    return <div>{name}</div>;',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      export default {
+        renderHello() {
+          let {name} = this.props;
+          return <div>{name}</div>;
+        }
+      };
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'import React, { createClass } from \'react\';',
-      'export default createClass({',
-      '  displayName: \'Foo\',',
-      '  render() {',
-      '    return <h1>foo</h1>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      import React, { createClass } from 'react';
+      export default createClass({
+        displayName: 'Foo',
+        render() {
+          return <h1>foo</h1>;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -355,59 +355,59 @@ ruleTester.run('display-name', rule, {
     },
     parser: 'babel-eslint'
   }, {
-    code: [
-      'import React, {Component} from "react";',
-      'function someDecorator(ComposedComponent) {',
-      '  return class MyDecorator extends Component {',
-      '    render() {return <ComposedComponent {...this.props} />;}',
-      '  };',
-      '}',
-      'module.exports = someDecorator;'
-    ].join('\n'),
+    code: `
+      import React, {Component} from "react";
+      function someDecorator(ComposedComponent) {
+        return class MyDecorator extends Component {
+          render() {return <ComposedComponent {...this.props} />;}
+        };
+      }
+      module.exports = someDecorator;
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'const element = (',
-      '  <Media query={query} render={() => {',
-      '    renderWasCalled = true',
-      '    return <div/>',
-      '  }}/>',
-      ')'
-    ].join('\n'),
+    code: `
+      const element = (
+        <Media query={query} render={() => {
+          renderWasCalled = true
+          return <div/>
+        }}/>
+      )
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'const element = (',
-      '  <Media query={query} render={function() {',
-      '    renderWasCalled = true',
-      '    return <div/>',
-      '  }}/>',
-      ')'
-    ].join('\n'),
+    code: `
+      const element = (
+        <Media query={query} render={function() {
+          renderWasCalled = true
+          return <div/>
+        }}/>
+      )
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'module.exports = {',
-      '  createElement: tagName => document.createElement(tagName)',
-      '};'
-    ].join('\n'),
+    code: `
+      module.exports = {
+        createElement: tagName => document.createElement(tagName)
+      };
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'const { createElement } = document;',
-      'createElement("a");'
-    ].join('\n'),
+    code: `
+      const { createElement } = document;
+      createElement("a");
+    `,
     parser: 'babel-eslint'
   }],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return React.createElement("div", {}, "text content");',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return React.createElement("div", {}, "text content");
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -415,13 +415,13 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'var Hello = React.createClass({',
-      '  render: function() {',
-      '    return React.createElement("div", {}, "text content");',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = React.createClass({
+        render: function() {
+          return React.createElement("div", {}, "text content");
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -434,13 +434,13 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -448,13 +448,13 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -462,16 +462,16 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'function HelloComponent() {',
-      '  return createReactClass({',
-      '    render: function() {',
-      '      return <div>Hello {this.props.name}</div>;',
-      '    }',
-      '  });',
-      '}',
-      'module.exports = HelloComponent();'
-    ].join('\n'),
+    code: `
+      function HelloComponent() {
+        return createReactClass({
+          render: function() {
+            return <div>Hello {this.props.name}</div>;
+          }
+        });
+      }
+      module.exports = HelloComponent();
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -479,48 +479,48 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'module.exports = () => {',
-      '  return <div>Hello {props.name}</div>;',
-      '}'
-    ].join('\n'),
+    code: `
+      module.exports = () => {
+        return <div>Hello {props.name}</div>;
+      }
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'module.exports = function() {',
-      '  return <div>Hello {props.name}</div>;',
-      '}'
-    ].join('\n'),
+    code: `
+      module.exports = function() {
+        return <div>Hello {props.name}</div>;
+      }
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'module.exports = createReactClass({',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      module.exports = createReactClass({
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  _renderHello: function() {',
-      '    return <span>Hello {this.props.name}</span>;',
-      '  },',
-      '  render: function() {',
-      '    return <div>{this._renderHello()}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        _renderHello: function() {
+          return <span>Hello {this.props.name}</span>;
+        },
+        render: function() {
+          return <div>{this._renderHello()}</div>;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -529,16 +529,16 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'var Hello = Foo.createClass({',
-      '  _renderHello: function() {',
-      '    return <span>Hello {this.props.name}</span>;',
-      '  },',
-      '  render: function() {',
-      '    return <div>{this._renderHello()}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = Foo.createClass({
+        _renderHello: function() {
+          return <span>Hello {this.props.name}</span>;
+        },
+        render: function() {
+          return <div>{this._renderHello()}</div>;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -553,17 +553,17 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      '/** @jsx Foo */',
-      'var Hello = Foo.createClass({',
-      '  _renderHello: function() {',
-      '    return <span>Hello {this.props.name}</span>;',
-      '  },',
-      '  render: function() {',
-      '    return <div>{this._renderHello()}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      /** @jsx Foo */
+      var Hello = Foo.createClass({
+        _renderHello: function() {
+          return <span>Hello {this.props.name}</span>;
+        },
+        render: function() {
+          return <div>{this._renderHello()}</div>;
+        }
+      });
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -577,15 +577,15 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'const Mixin = {',
-      '  Button() {',
-      '    return (',
-      '      <button />',
-      '    );',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      const Mixin = {
+        Button() {
+          return (
+            <button />
+          );
+        }
+      };
+    `,
     options: [{
       ignoreTranspilerName: true
     }],
@@ -594,36 +594,36 @@ ruleTester.run('display-name', rule, {
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'import React, { createElement } from "react";',
-      'export default (props) => {',
-      '  return createElement("div", {}, "hello");',
-      '};'
-    ].join('\n'),
+    code: `
+      import React, { createElement } from "react";
+      export default (props) => {
+        return createElement("div", {}, "hello");
+      };
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'import React from "react";',
-      'const { createElement } = React;',
-      'export default (props) => {',
-      '  return createElement("div", {}, "hello");',
-      '};'
-    ].join('\n'),
+    code: `
+      import React from "react";
+      const { createElement } = React;
+      export default (props) => {
+        return createElement("div", {}, "hello");
+      };
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Component definition is missing display name'
     }]
   }, {
-    code: [
-      'import React from "react";',
-      'const createElement = React.createElement;',
-      'export default (props) => {',
-      '  return createElement("div", {}, "hello");',
-      '};'
-    ].join('\n'),
+    code: `
+      import React from "react";
+      const createElement = React.createElement;
+      export default (props) => {
+        return createElement("div", {}, "hello");
+      };
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Component definition is missing display name'

--- a/tests/lib/rules/forbid-foreign-prop-types.js
+++ b/tests/lib/rules/forbid-foreign-prop-types.js
@@ -53,58 +53,58 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
   }],
 
   invalid: [{
-    code: [
-      'var Foo = createReactClass({',
-      '  propTypes: Bar.propTypes,',
-      '  render: function() {',
-      '    return <Foo className="bar" />;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Foo = createReactClass({
+        propTypes: Bar.propTypes,
+        render: function() {
+          return <Foo className="bar" />;
+        }
+      });
+    `,
     errors: [{
       message: ERROR_MESSAGE,
       type: 'Identifier'
     }]
   },
   {
-    code: [
-      'var Foo = createReactClass({',
-      '  propTypes: Bar["propTypes"],',
-      '  render: function() {',
-      '    return <Foo className="bar" />;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Foo = createReactClass({
+        propTypes: Bar["propTypes"],
+        render: function() {
+          return <Foo className="bar" />;
+        }
+      });
+    `,
     errors: [{
       message: ERROR_MESSAGE,
       type: 'Literal'
     }]
   },
   {
-    code: [
-      'var { propTypes } = SomeComponent',
-      'var Foo = createReactClass({',
-      '  propTypes,',
-      '  render: function() {',
-      '    return <Foo className="bar" />;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var { propTypes } = SomeComponent
+      var Foo = createReactClass({
+        propTypes,
+        render: function() {
+          return <Foo className="bar" />;
+        }
+      });
+    `,
     errors: [{
       message: ERROR_MESSAGE,
       type: 'Property'
     }]
   },
   {
-    code: [
-      'var { propTypes: things, ...foo } = SomeComponent',
-      'var Foo = createReactClass({',
-      '  propTypes,',
-      '  render: function() {',
-      '    return <Foo className="bar" />;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var { propTypes: things, ...foo } = SomeComponent
+      var Foo = createReactClass({
+        propTypes,
+        render: function() {
+          return <Foo className="bar" />;
+        }
+      });
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: ERROR_MESSAGE,
@@ -112,13 +112,13 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
     }]
   },
   {
-    code: [
-      'class MyComponent extends React.Component {',
-      '  static fooBar = {',
-      '    baz: Qux.propTypes.baz',
-      '  };',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyComponent extends React.Component {
+        static fooBar = {
+          baz: Qux.propTypes.baz
+        };
+      }
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: ERROR_MESSAGE,
@@ -126,15 +126,15 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
     }]
   },
   {
-    code: [
-      'var { propTypes: typesOfProps } = SomeComponent',
-      'var Foo = createReactClass({',
-      '  propTypes: typesOfProps,',
-      '  render: function() {',
-      '    return <Foo className="bar" />;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var { propTypes: typesOfProps } = SomeComponent
+      var Foo = createReactClass({
+        propTypes: typesOfProps,
+        render: function() {
+          return <Foo className="bar" />;
+        }
+      });
+    `,
     errors: [{
       message: ERROR_MESSAGE,
       type: 'Property'

--- a/tests/lib/rules/jsx-closing-tag-location.js
+++ b/tests/lib/rules/jsx-closing-tag-location.js
@@ -27,39 +27,39 @@ const MESSAGE_OWN_LINE = [{message: 'Closing tag of a multiline JSX expression m
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('jsx-closing-tag-location', rule, {
   valid: [{
-    code: [
-      '<App>',
-      '  foo',
-      '</App>'
-    ].join('\n')
+    code: `
+      <App>
+        foo
+      </App>
+    `
   }, {
-    code: [
-      '<App>foo</App>'
-    ].join('\n')
+    code: `
+      <App>foo</App>
+    `
   }],
 
   invalid: [{
-    code: [
-      '<App>',
-      '  foo',
-      '  </App>'
-    ].join('\n'),
-    output: [
-      '<App>',
-      '  foo',
-      '</App>'
-    ].join('\n'),
+    code: `
+      <App>
+        foo
+        </App>
+    `,
+    output: `
+      <App>
+        foo
+      </App>
+    `,
     errors: MESSAGE_MATCH_INDENTATION
   }, {
-    code: [
-      '<App>',
-      '  foo</App>'
-    ].join('\n'),
-    output: [
-      '<App>',
-      '  foo',
-      '</App>'
-    ].join('\n'),
+    code: `
+      <App>
+        foo</App>
+    `,
+    output: `
+      <App>
+        foo
+      </App>
+    `,
     errors: MESSAGE_OWN_LINE
   }]
 });

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -27,105 +27,63 @@ const parserOptions = {
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('jsx-handler-names', rule, {
   valid: [{
-    code: [
-      '<TestComponent onChange={this.handleChange} />'
-    ].join('\n')
+    code: '<TestComponent onChange={this.handleChange} />'
   }, {
-    code: [
-      '<TestComponent onChange={this.props.onChange} />'
-    ].join('\n')
+    code: '<TestComponent onChange={this.props.onChange} />'
   }, {
-    code: [
-      '<TestComponent onChange={this.props.onFoo} />'
-    ].join('\n')
+    code: '<TestComponent onChange={this.props.onFoo} />'
   }, {
-    code: [
-      '<TestComponent isSelected={this.props.isSelected} />'
-    ].join('\n')
+    code: '<TestComponent isSelected={this.props.isSelected} />'
   }, {
-    code: [
-      '<TestComponent shouldDisplay={this.state.shouldDisplay} />'
-    ].join('\n')
+    code: '<TestComponent shouldDisplay={this.state.shouldDisplay} />'
   }, {
-    code: [
-      '<TestComponent shouldDisplay={arr[0].prop} />'
-    ].join('\n')
+    code: '<TestComponent shouldDisplay={arr[0].prop} />'
   }, {
-    code: [
-      '<TestComponent onChange={props.onChange} />'
-    ].join('\n')
+    code: '<TestComponent onChange={props.onChange} />'
   }, {
-    code: [
-      '<TestComponent ref={this.handleRef} />'
-    ].join('\n')
+    code: '<TestComponent ref={this.handleRef} />'
   }, {
-    code: [
-      '<TestComponent ref={this.somethingRef} />'
-    ].join('\n')
+    code: '<TestComponent ref={this.somethingRef} />'
   }, {
-    code: [
-      '<TestComponent test={this.props.content} />'
-    ].join('\n'),
+    code: '<TestComponent test={this.props.content} />',
     options: [{
       eventHandlerPrefix: 'on',
       eventHandlerPropPrefix: 'on'
     }]
   }, {
-    code: [
-      '<TestComponent onChange={props::handleChange} />'
-    ].join('\n'),
+    code: '<TestComponent onChange={props::handleChange} />',
     parser: 'babel-eslint'
   }, {
-    code: [
-      '<TestComponent onChange={::props.onChange} />'
-    ].join('\n'),
+    code: '<TestComponent onChange={::props.onChange} />',
     parser: 'babel-eslint'
   }, {
-    code: [
-      '<TestComponent onChange={props.foo::handleChange} />'
-    ].join('\n'),
+    code: '<TestComponent onChange={props.foo::handleChange} />',
     parser: 'babel-eslint'
   }, {
-    code: [
-      '<TestComponent only={this.only} />'
-    ].join('\n')
+    code: '<TestComponent only={this.only} />'
   }],
 
   invalid: [{
-    code: [
-      '<TestComponent onChange={this.doSomethingOnChange} />'
-    ].join('\n'),
+    code: '<TestComponent onChange={this.doSomethingOnChange} />',
     errors: [{message: 'Handler function for onChange prop key must begin with \'handle\''}]
   }, {
-    code: [
-      '<TestComponent onChange={this.handlerChange} />'
-    ].join('\n'),
+    code: '<TestComponent onChange={this.handlerChange} />',
     errors: [{message: 'Handler function for onChange prop key must begin with \'handle\''}]
   }, {
-    code: [
-      '<TestComponent only={this.handleChange} />'
-    ].join('\n'),
+    code: '<TestComponent only={this.handleChange} />',
     errors: [{message: 'Prop key for handleChange must begin with \'on\''}]
   }, {
-    code: [
-      '<TestComponent handleChange={this.handleChange} />'
-    ].join('\n'),
+    code: '<TestComponent handleChange={this.handleChange} />',
     errors: [{message: 'Prop key for handleChange must begin with \'on\''}]
   }, {
-    code: [
-      '<TestComponent onChange={this.onChange} />'
-    ].join('\n'),
+    code: '<TestComponent onChange={this.onChange} />',
     errors: [{message: 'Handler function for onChange prop key must begin with \'handle\''}]
   }, {
-    code: [
-      '<TestComponent onChange={props::onChange} />'
-    ].join('\n'),
+    code: '<TestComponent onChange={props::onChange} />',
     parser: 'babel-eslint',
     errors: [{message: 'Handler function for onChange prop key must begin with \'handle\''}]
   }, {
-    code: [
-      '<TestComponent onChange={props.foo::onChange} />'
-    ].join('\n'),
+    code: '<TestComponent onChange={props.foo::onChange} />',
     parser: 'babel-eslint',
     errors: [{message: 'Handler function for onChange prop key must begin with \'handle\''}]
   }]

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -71,49 +71,49 @@ ruleTester.run('jsx-no-bind', rule, {
 
     // Redux connect
     {
-      code: [
-        'class Hello extends Component {',
-        '  render() {',
-        '    return <div>Hello</div>;',
-        '  }',
-        '}',
-        'export default connect()(Hello);'
-      ].join('\n'),
+      code: `
+        class Hello extends Component {
+          render() {
+            return <div>Hello</div>;
+          }
+        }
+        export default connect()(Hello);
+      `,
       options: [{allowBind: true}],
       parser: 'babel-eslint'
     },
     // Backbone view with a bind
     {
-      code: [
-        'var DocumentRow = Backbone.View.extend({',
-        '  tagName: "li",',
-        '  render: function() {',
-        '    this.onTap.bind(this);',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var DocumentRow = Backbone.View.extend({
+          tagName: "li",
+          render: function() {
+            this.onTap.bind(this);
+          }
+        });
+      `,
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'const foo = {',
-        '  render: function() {',
-        '    this.onTap.bind(this);',
-        '    return true;',
-        '  }',
-        '};'
-      ].join('\n'),
+      code: `
+        const foo = {
+          render: function() {
+            this.onTap.bind(this);
+            return true;
+          }
+        };
+      `,
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'const foo = {',
-        '  render() {',
-        '    this.onTap.bind(this);',
-        '    return true;',
-        '  }',
-        '};'
-      ].join('\n'),
+      code: `
+        const foo = {
+          render() {
+            this.onTap.bind(this);
+            return true;
+          }
+        };
+      `,
       parser: 'babel-eslint'
     }
   ],
@@ -141,61 +141,61 @@ ruleTester.run('jsx-no-bind', rule, {
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    const click = this.someMethod.bind(this);',
-        '    return <div onClick={click}>Hello {this.state.name}</div>;',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            const click = this.someMethod.bind(this);
+            return <div onClick={click}>Hello {this.state.name}</div>;
+          }
+        });
+      `,
       errors: [{message: 'JSX props should not use .bind()'}],
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'class Hello23 extends React.Component {',
-        '  render() {',
-        '    const click = this.someMethod.bind(this);',
-        '    return <div onClick={click}>Hello {this.state.name}</div>;',
-        '  }',
-        '};'
-      ].join('\n'),
+      code: `
+        class Hello23 extends React.Component {
+          render() {
+            const click = this.someMethod.bind(this);
+            return <div onClick={click}>Hello {this.state.name}</div>;
+          }
+        };
+      `,
       errors: [{message: 'JSX props should not use .bind()'}],
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'const foo = {',
-        '  render: function() {',
-        '    const click = this.onTap.bind(this);',
-        '    return <div onClick={onClick}>Hello</div>;',
-        '  }',
-        '};'
-      ].join('\n'),
+      code: `
+        const foo = {
+          render: function() {
+            const click = this.onTap.bind(this);
+            return <div onClick={onClick}>Hello</div>;
+          }
+        };
+      `,
       errors: [{message: 'JSX props should not use .bind()'}],
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'const foo = {',
-        '  render: ({onClick}) => (',
-        '    <div onClick={onClick.bind(this)}>Hello</div>',
-        '  )',
-        '};'
-      ].join('\n'),
+      code: `
+        const foo = {
+          render: ({onClick}) => (
+            <div onClick={onClick.bind(this)}>Hello</div>
+          )
+        };
+      `,
       errors: [{message: 'JSX props should not use .bind()'}],
       parser: 'babel-eslint'
     },
     {
-      code: [
-        'const foo = {',
-        '  render() {',
-        '    const click = this.onTap.bind(this);',
-        '    return <div onClick={onClick}>Hello</div>;',
-        '  }',
-        '};'
-      ].join('\n'),
+      code: `
+        const foo = {
+          render() {
+            const click = this.onTap.bind(this);
+            return <div onClick={onClick}>Hello</div>;
+          }
+        };
+      `,
       errors: [{message: 'JSX props should not use .bind()'}],
       parser: 'babel-eslint'
     },

--- a/tests/lib/rules/jsx-no-comment-textnodes.js
+++ b/tests/lib/rules/jsx-no-comment-textnodes.js
@@ -29,176 +29,176 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
 
   valid: [
     {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        {/* valid */}',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (
+            <div>
+              {/* valid */}
+            </div>
+          );
+        }
+      }
+    `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (<div>{/* valid */}</div>);',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (<div>{/* valid */}</div>);
+        }
+      }
+    `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    const bar = (<div>{/* valid */}</div>);',
-        '    return bar;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          const bar = (<div>{/* valid */}</div>);
+          return bar;
+        }
+      }
+    `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  foo: (<div>{/* valid */}</div>),',
-        '  render() {',
-        '    return this.foo;',
-        '  },',
-        '});'
-      ].join('\n'),
+      code: `
+      var Hello = createReactClass({
+        foo: (<div>{/* valid */}</div>),
+        render() {
+          return this.foo;
+        },
+      });
+    `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        {/* valid */}',
-        '        {/* valid 2 */}',
-        '        {/* valid 3 */}',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (
+            <div>
+              {/* valid */}
+              {/* valid 2 */}
+              {/* valid 3 */}
+            </div>
+          );
+        }
+      }
+    `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (
+            <div>
+            </div>
+          );
+        }
+      }
+    `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'var foo = require(\'foo\');'
-      ].join('\n'),
+      code: `
+      var foo = require('foo');
+    `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        '<Foo bar=\'test\'>',
-        '  {/* valid */}',
-        '</Foo>'
-      ].join('\n'),
+      code: `
+      <Foo bar='test'>
+        {/* valid */}
+      </Foo>
+    `,
       parser: 'babel-eslint'
     },
     {
-      code: [
-        '<strong>',
-        '  &nbsp;https://www.example.com/attachment/download/1',
-        '</strong>'
-      ].join('\n'),
+      code: `
+      <strong>
+        &nbsp;https://www.example.com/attachment/download/1
+      </strong>
+    `,
       parser: 'babel-eslint'
     },
 
     // inside element declarations
     {
-      code: [
-        '<Foo /* valid */ placeholder={\'foo\'}/>'
-      ].join('\n'),
+      code: `
+      <Foo /* valid */ placeholder={'foo'}/>
+    `,
       parser: 'babel-eslint'
     },
     {
-      code: [
-        '<Foo title={\'foo\' /* valid */}/>'
-      ].join('\n'),
+      code: `
+      <Foo title={'foo' /* valid */}/>
+    `,
       parser: 'babel-eslint'
     }
   ],
 
   invalid: [
     {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (<div>// invalid</div>);',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (<div>// invalid</div>);
+        }
+      }
+    `,
       parser: 'babel-eslint',
       errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (<div>/* invalid */</div>);',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (<div>/* invalid */</div>);
+        }
+      }
+    `,
       parser: 'babel-eslint',
       errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        // invalid',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (
+            <div>
+              // invalid
+            </div>
+          );
+        }
+      }
+    `,
       parser: 'babel-eslint',
       errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        asdjfl',
-        '        /* invalid */',
-        '        foo',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (
+            <div>
+              asdjfl
+              /* invalid */
+              foo
+            </div>
+          );
+        }
+      }
+    `,
       parser: 'babel-eslint',
       errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        {\'asdjfl\'}',
-        '        // invalid',
-        '        {\'foo\'}',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+      class Comp1 extends Component {
+        render() {
+          return (
+            <div>
+              {'asdjfl'}
+              // invalid
+              {'foo'}
+            </div>
+          );
+        }
+      }
+    `,
       parser: 'babel-eslint',
       errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
     }

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -30,85 +30,85 @@ ruleTester.run('jsx-no-literals', rule, {
 
   valid: [
     {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        {\'asdjfl\'}',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                {'asdjfl'}
+              </div>
+            );
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (<div>{\'test\'}</div>);',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (<div>{'test'}</div>);
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    const bar = (<div>{\'hello\'}</div>);',
-        '    return bar;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            const bar = (<div>{'hello'}</div>);
+            return bar;
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  foo: (<div>{\'hello\'}</div>),',
-        '  render() {',
-        '    return this.foo;',
-        '  },',
-        '});'
-      ].join('\n'),
+      code: `
+        var Hello = createReactClass({
+          foo: (<div>{'hello'}</div>),
+          render() {
+            return this.foo;
+          },
+        });
+      `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        {\'asdjfl\'}',
-        '        {\'test\'}',
-        '        {\'foo\'}',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                {'asdjfl'}
+                {'test'}
+                {'foo'}
+              </div>
+            );
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+              </div>
+            );
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        'var foo = require(\'foo\');'
-      ].join('\n'),
+      code: `
+        var foo = require('foo');
+      `,
       parser: 'babel-eslint'
     }, {
-      code: [
-        '<Foo bar=\'test\'>',
-        '  {\'blarg\'}',
-        '</Foo>'
-      ].join('\n'),
+      code: `
+        <Foo bar='test'>
+          {'blarg'}
+        </Foo>
+      `,
       parser: 'babel-eslint'
     }, {
       code: `
@@ -156,24 +156,24 @@ ruleTester.run('jsx-no-literals', rule, {
       code: '<Foo bar={{}} />',
       options: [{noStrings: true}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  asdf() {}',
-        '  render() {',
-        '    return <Foo bar={this.asdf} />;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          asdf() {}
+          render() {
+            return <Foo bar={this.asdf} />;
+          }
+        }
+      `,
       options: [{noStrings: true}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    let foo = `bar`;',
-        '    return <div />;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            let foo = \`bar\`;
+            return <div />;
+          }
+        }
+      `,
       options: [{noStrings: true}]
     }
 
@@ -181,92 +181,92 @@ ruleTester.run('jsx-no-literals', rule, {
 
   invalid: [
     {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (<div>test</div>);',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (<div>test</div>);
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{message: 'Missing JSX expression container around literal string'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    const foo = (<div>test</div>);',
-        '    return foo;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            const foo = (<div>test</div>);
+            return foo;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{message: 'Missing JSX expression container around literal string'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    const varObjectTest = { testKey : (<div>test</div>) };',
-        '    return varObjectTest.testKey;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            const varObjectTest = { testKey : (<div>test</div>) };
+            return varObjectTest.testKey;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{message: 'Missing JSX expression container around literal string'}]
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  foo: (<div>hello</div>),',
-        '  render() {',
-        '    return this.foo;',
-        '  },',
-        '});'
-      ].join('\n'),
+      code: `
+        var Hello = createReactClass({
+          foo: (<div>hello</div>),
+          render() {
+            return this.foo;
+          },
+        });
+      `,
       parser: 'babel-eslint',
       errors: [{message: 'Missing JSX expression container around literal string'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        asdjfl',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                asdjfl
+              </div>
+            );
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{message: 'Missing JSX expression container around literal string'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        asdjfl',
-        '        test',
-        '        foo',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                asdjfl
+                test
+                foo
+              </div>
+            );
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{message: 'Missing JSX expression container around literal string'}]
     }, {
-      code: [
-        'class Comp1 extends Component {',
-        '  render() {',
-        '    return (',
-        '      <div>',
-        '        {\'asdjfl\'}',
-        '        test',
-        '        {\'foo\'}',
-        '      </div>',
-        '    );',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                {'asdjfl'}
+                test
+                {'foo'}
+              </div>
+            );
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{message: 'Missing JSX expression container around literal string'}]
     }, {
@@ -304,11 +304,11 @@ ruleTester.run('jsx-no-literals', rule, {
       options: [{noStrings: true}],
       errors: [{message: 'Strings not allowed in JSX files'}]
     }, {
-      code: [
-        '<Foo>',
-        '  {`Test`}',
-        '</Foo>'
-      ].join('\n'),
+      code: `
+        <Foo>
+          {\`Test\`}
+        </Foo>
+      `,
       options: [{noStrings: true}],
       errors: [{message: 'Strings not allowed in JSX files'}]
     }, {

--- a/tests/lib/rules/jsx-no-undef.js
+++ b/tests/lib/rules/jsx-no-undef.js
@@ -42,29 +42,29 @@ ruleTester.run('jsx-no-undef', rule, {
   }, {
     code: '/*eslint no-undef:1*/ var React, app; React.render(<app.foo.Bar />);'
   }, {
-    code: [
-      '/*eslint no-undef:1*/',
-      'var React;',
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <this.props.tag />',
-      '  }',
-      '}'
-    ].join('\n')
+    code: `
+      /*eslint no-undef:1*/
+      var React;
+      class Hello extends React.Component {
+        render() {
+          return <this.props.tag />
+        }
+      }
+    `
   }, {
     code: 'var React; React.render(<Text />);',
     globals: {
       Text: true
     }
   }, {
-    code: [
-      'import Text from "cool-module";',
-      'const TextWrapper = function (props) {',
-      '  return (',
-      '    <Text />',
-      '  );',
-      '};'
-    ].join('\n'),
+    code: `
+      import Text from "cool-module";
+      const TextWrapper = function (props) {
+        return (
+          <Text />
+        );
+      };
+    `,
     parserOptions: Object.assign({sourceType: 'module'}, parserOptions),
     options: [{
       allowGlobals: false
@@ -97,14 +97,14 @@ ruleTester.run('jsx-no-undef', rule, {
       message: '\'appp\' is not defined.'
     }]
   }, {
-    code: [
-      'const TextWrapper = function (props) {',
-      '  return (',
-      '    <Text />',
-      '  );',
-      '};',
-      'export default TextWrapper;'
-    ].join('\n'),
+    code: `
+      const TextWrapper = function (props) {
+        return (
+          <Text />
+        );
+      };
+      export default TextWrapper;
+    `,
     parserOptions: Object.assign({sourceType: 'module'}, parserOptions),
     errors: [{
       message: '\'Text\' is not defined.'

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -201,32 +201,34 @@ ruleTester.run('jsx-sort-props', rule, {
       errors: 2
     },
     {
-      code: [
-        '<App',
-        'a={true}',
-        'z',
-        'r',
-        '_onClick={function(){}}',
-        'onHandle={function(){}}',
-        '{...this.props}',
-        'b={false}',
-        '{...otherProps}>',
-        '  {test}',
-        '</App>'
-      ].join('\n'),
-      output: [
-        '<App',
-        '_onClick={function(){}}',
-        'a={true}',
-        'onHandle={function(){}}',
-        'r',
-        'z',
-        '{...this.props}',
-        'b={false}',
-        '{...otherProps}>',
-        '  {test}',
-        '</App>'
-      ].join('\n'),
+      code: `
+      <App
+        a={true}
+        z
+        r
+        _onClick={function(){}}
+        onHandle={function(){}}
+        {...this.props}
+        b={false}
+        {...otherProps}
+      >
+        {test}
+      </App>
+    `,
+      output: `
+      <App
+        _onClick={function(){}}
+        a={true}
+        onHandle={function(){}}
+        r
+        z
+        {...this.props}
+        b={false}
+        {...otherProps}
+      >
+        {test}
+      </App>
+    `,
       errors: 3
     },
     {

--- a/tests/lib/rules/jsx-space-before-closing.js
+++ b/tests/lib/rules/jsx-space-before-closing.js
@@ -37,11 +37,11 @@ ruleTester.run('jsx-space-before-closing', rule, {
   }, {
     code: '<App></App>'
   }, {
-    code: [
-      '<App',
-      '  foo={bar}',
-      '/>'
-    ].join('\n')
+    code: `
+      <App
+        foo={bar}
+      />
+    `
   }, {
     code: '<App/>',
     options: ['never']
@@ -58,11 +58,11 @@ ruleTester.run('jsx-space-before-closing', rule, {
     code: '<App></App>',
     options: ['never']
   }, {
-    code: [
-      '<App',
-      '  foo={bar}',
-      '/>'
-    ].join('\n'),
+    code: `
+      <App
+        foo={bar}
+      />
+    `,
     options: ['never']
   }],
 

--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -209,18 +209,18 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
 ruleTester.run('prefer-const', rulePreferConst, {
   valid: [],
   invalid: [{
-    code: [
-      '/* eslint jsx-uses-vars:1 */',
-      'let App = <div />;',
-      '<App />;'
-    ].join('\n'),
+    code: `
+      /* eslint jsx-uses-vars:1 */
+      let App = <div />;
+      <App />;
+    `,
     errors: [{message: '\'App\' is never reassigned. Use \'const\' instead.'}]
   }, {
-    code: [
-      '/* eslint jsx-uses-vars:1 */',
-      'let filters = \'foo\';',
-      '<div>{filters}</div>;'
-    ].join('\n'),
+    code: `
+      /* eslint jsx-uses-vars:1 */
+      let filters = 'foo';
+      <div>{filters}</div>;
+    `,
     errors: [{message: '\'filters\' is never reassigned. Use \'const\' instead.'}]
   }]
 });

--- a/tests/lib/rules/no-array-index-key.js
+++ b/tests/lib/rules/no-array-index-key.js
@@ -63,13 +63,13 @@ ruleTester.run('no-array-index-key', rule, {
     },
 
     {
-      code: [
-        'foo.map((item, i) => {',
-        '  return React.cloneElement(someChild, {',
-        '    key: item.id',
-        '  })',
-        '})'
-      ].join('\n')
+      code: `
+        foo.map((item, i) => {
+          return React.cloneElement(someChild, {
+            key: item.id
+          })
+        })
+      `
     },
 
     {
@@ -130,13 +130,13 @@ ruleTester.run('no-array-index-key', rule, {
     },
 
     {
-      code: [
-        'foo.map((item, i) => {',
-        '  return React.cloneElement(someChild, {',
-        '    key: i',
-        '  })',
-        '})'
-      ].join('\n'),
+      code: `
+        foo.map((item, i) => {
+          return React.cloneElement(someChild, {
+            key: i
+          })
+        })
+      `,
       errors: [{message: 'Do not use Array index in keys'}]
     },
 

--- a/tests/lib/rules/no-danger-with-children.js
+++ b/tests/lib/rules/no-danger-with-children.js
@@ -43,24 +43,24 @@ ruleTester.run('no-danger-with-children', rule, {
       code: '<div children="Children" />'
     },
     {
-      code: [
-        'const props = { dangerouslySetInnerHTML: { __html: "HTML" } };',
-        '<div {...props} />'
-      ].join('\n')
+      code: `
+        const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+        <div {...props} />
+      `
     },
     {
-      code: [
-        'const moreProps = { className: "eslint" };',
-        'const props = { children: "Children", ...moreProps };',
-        '<div {...props} />'
-      ].join('\n')
+      code: `
+        const moreProps = { className: "eslint" };
+        const props = { children: "Children", ...moreProps };
+        <div {...props} />
+      `
     },
     {
-      code: [
-        'const otherProps = { children: "Children" };',
-        'const { a, b, ...props } = otherProps;',
-        '<div {...props} />'
-      ].join('\n')
+      code: `
+        const otherProps = { children: "Children" };
+        const { a, b, ...props } = otherProps;
+        <div {...props} />
+      `
     },
     {
       code: '<Hello>Children</Hello>'
@@ -95,11 +95,11 @@ ruleTester.run('no-danger-with-children', rule, {
   ],
   invalid: [
     {
-      code: [
-        '<div dangerouslySetInnerHTML={{ __html: "HTML" }}>',
-        '  Children',
-        '</div>'
-      ].join('\n'),
+      code: `
+        <div dangerouslySetInnerHTML={{ __html: "HTML" }}>
+          Children
+        </div>
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
@@ -107,25 +107,25 @@ ruleTester.run('no-danger-with-children', rule, {
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'const props = { dangerouslySetInnerHTML: { __html: "HTML" } };',
-        '<div {...props}>Children</div>'
-      ].join('\n'),
+      code: `
+        const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+        <div {...props}>Children</div>
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };',
-        '<div {...props} />'
-      ].join('\n'),
+      code: `
+        const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
+        <div {...props} />
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        '<Hello dangerouslySetInnerHTML={{ __html: "HTML" }}>',
-        '  Children',
-        '</Hello>'
-      ].join('\n'),
+      code: `
+        <Hello dangerouslySetInnerHTML={{ __html: "HTML" }}>
+          Children
+        </Hello>
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
@@ -137,70 +137,70 @@ ruleTester.run('no-danger-with-children', rule, {
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'React.createElement(',
-        '  "div",',
-        '  { dangerouslySetInnerHTML: { __html: "HTML" } },',
-        '  "Children"',
-        ');'
-      ].join('\n'),
+      code: `
+        React.createElement(
+          "div",
+          { dangerouslySetInnerHTML: { __html: "HTML" } },
+          "Children"
+        );
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'React.createElement(',
-        '  "div",',
-        '  {',
-        '    dangerouslySetInnerHTML: { __html: "HTML" },',
-        '    children: "Children",',
-        '  }',
-        ');'
-      ].join('\n'),
+      code: `
+        React.createElement(
+          "div",
+          {
+            dangerouslySetInnerHTML: { __html: "HTML" },
+            children: "Children",
+          }
+        );
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'React.createElement(',
-        '  "Hello",',
-        '  { dangerouslySetInnerHTML: { __html: "HTML" } },',
-        '  "Children"',
-        ');'
-      ].join('\n'),
+      code: `
+        React.createElement(
+          "Hello",
+          { dangerouslySetInnerHTML: { __html: "HTML" } },
+          "Children"
+        );
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'React.createElement(',
-        '  "Hello",',
-        '  {',
-        '    dangerouslySetInnerHTML: { __html: "HTML" },',
-        '    children: "Children",',
-        '  }',
-        ');'
-      ].join('\n'),
+      code: `
+        React.createElement(
+          "Hello",
+          {
+            dangerouslySetInnerHTML: { __html: "HTML" },
+            children: "Children",
+          }
+        );
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'const props = { dangerouslySetInnerHTML: { __html: "HTML" } };',
-        'React.createElement("div", props, "Children");'
-      ].join('\n'),
+      code: `
+        const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
+        React.createElement("div", props, "Children");
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };',
-        'React.createElement("div", props);'
-      ].join('\n'),
+      code: `
+        const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
+        React.createElement("div", props);
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     },
     {
-      code: [
-        'const moreProps = { children: "Children" };',
-        'const otherProps = { ...moreProps };',
-        'const props = { ...otherProps, dangerouslySetInnerHTML: { __html: "HTML" } };',
-        'React.createElement("div", props);'
-      ].join('\n'),
+      code: `
+        const moreProps = { children: "Children" };
+        const otherProps = { ...moreProps };
+        const props = { ...otherProps, dangerouslySetInnerHTML: { __html: "HTML" } };
+        React.createElement("div", props);
+      `,
       errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
     }
   ]

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -149,10 +149,10 @@ ruleTester.run('no-deprecated', rule, {
       message: 'React.PropTypes is deprecated since React 15.5.0, use the npm module prop-types instead'
     }]
   }, {
-    code: [
-      'import React from \'react\';',
-      'const {createClass, PropTypes} = React;'
-    ].join('\n'),
+    code: `
+      import React from 'react';
+      const {createClass, PropTypes} = React;
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'React.createClass is deprecated since React 15.5.0, use the npm module create-react-class instead'
@@ -166,10 +166,10 @@ ruleTester.run('no-deprecated', rule, {
       message: 'ReactPerf.printDOM is deprecated since React 15.0.0, use ReactPerf.printOperations instead'
     }]
   }, {
-    code: [
-      'import ReactPerf from \'react-addons-perf\';',
-      'const {printDOM} = ReactPerf;'
-    ].join('\n'),
+    code: `
+      import ReactPerf from 'react-addons-perf';
+      const {printDOM} = ReactPerf;
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'ReactPerf.printDOM is deprecated since React 15.0.0, use ReactPerf.printOperations instead'

--- a/tests/lib/rules/no-did-mount-set-state.js
+++ b/tests/lib/rules/no-did-mount-set-state.js
@@ -30,197 +30,197 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('no-did-mount-set-state', rule, {
 
   valid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {}',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {}
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    someNonMemberFunction(arg);',
-      '    this.someHandler = this.setState;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          someNonMemberFunction(arg);
+          this.someHandler = this.setState;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    function handleEvent(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '    someClass.onSomeEvent(handleEvent)',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          function handleEvent(data) {
+            this.setState({
+              data: data
+            });
+          }
+          someClass.onSomeEvent(handleEvent)
+        }
+      });
+    `,
     parser: 'babel-eslint'
   }],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          this.setState({
+            data: data
+          });
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use setState in componentDidMount'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidMount() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentDidMount() {
+          this.setState({
+            data: data
+          });
+        }
+      }
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Do not use setState in componentDidMount'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          this.setState({
+            data: data
+          });
+        }
+      });
+    `,
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentDidMount'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidMount() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '}'
-    ].join('\n'),
-    parser: 'babel-eslint',
-    options: ['disallow-in-func'],
-    errors: [{
-      message: 'Do not use setState in componentDidMount'
-    }]
-  }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '});'
-    ].join('\n'),
-    options: ['disallow-in-func'],
-    errors: [{
-      message: 'Do not use setState in componentDidMount'
-    }]
-  }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidMount() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentDidMount() {
+          this.setState({
+            data: data
+          });
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentDidMount'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    if (true) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      });
+    `,
+    options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentDidMount'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidMount() {',
-      '    if (true) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '  }',
-      '}'
-    ].join('\n'),
-    parser: 'babel-eslint',
-    errors: [{
-      message: 'Do not use setState in componentDidMount'
-    }]
-  }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    someClass.onSomeEvent((data) => this.setState({data: data}));',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentDidMount() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentDidMount'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidMount() {',
-      '    someClass.onSomeEvent((data) => this.setState({data: data}));',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          if (true) {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      });
+    `,
+    errors: [{
+      message: 'Do not use setState in componentDidMount'
+    }]
+  }, {
+    code: `
+      class Hello extends React.Component {
+        componentDidMount() {
+          if (true) {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      }
+    `,
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Do not use setState in componentDidMount'
+    }]
+  }, {
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          someClass.onSomeEvent((data) => this.setState({data: data}));
+        }
+      });
+    `,
+    parser: 'babel-eslint',
+    options: ['disallow-in-func'],
+    errors: [{
+      message: 'Do not use setState in componentDidMount'
+    }]
+  }, {
+    code: `
+      class Hello extends React.Component {
+        componentDidMount() {
+          someClass.onSomeEvent((data) => this.setState({data: data}));
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{

--- a/tests/lib/rules/no-did-update-set-state.js
+++ b/tests/lib/rules/no-did-update-set-state.js
@@ -30,197 +30,197 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('no-did-update-set-state', rule, {
 
   valid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {}',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {}
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    someNonMemberFunction(arg);',
-      '    this.someHandler = this.setState;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          someNonMemberFunction(arg);
+          this.someHandler = this.setState;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    function handleEvent(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '    someClass.onSomeEvent(handleEvent)',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          function handleEvent(data) {
+            this.setState({
+              data: data
+            });
+          }
+          someClass.onSomeEvent(handleEvent)
+        }
+      });
+    `,
     parser: 'babel-eslint'
   }],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          this.setState({
+            data: data
+          });
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use setState in componentDidUpdate'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidUpdate() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentDidUpdate() {
+          this.setState({
+            data: data
+          });
+        }
+      }
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Do not use setState in componentDidUpdate'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          this.setState({
+            data: data
+          });
+        }
+      });
+    `,
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentDidUpdate'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidUpdate() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '}'
-    ].join('\n'),
-    parser: 'babel-eslint',
-    options: ['disallow-in-func'],
-    errors: [{
-      message: 'Do not use setState in componentDidUpdate'
-    }]
-  }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '});'
-    ].join('\n'),
-    options: ['disallow-in-func'],
-    errors: [{
-      message: 'Do not use setState in componentDidUpdate'
-    }]
-  }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidUpdate() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentDidUpdate() {
+          this.setState({
+            data: data
+          });
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentDidUpdate'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    if (true) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      });
+    `,
+    options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentDidUpdate'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidUpdate() {',
-      '    if (true) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '  }',
-      '}'
-    ].join('\n'),
-    parser: 'babel-eslint',
-    errors: [{
-      message: 'Do not use setState in componentDidUpdate'
-    }]
-  }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    someClass.onSomeEvent((data) => this.setState({data: data}));',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentDidUpdate() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentDidUpdate'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentDidUpdate() {',
-      '    someClass.onSomeEvent((data) => this.setState({data: data}));',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          if (true) {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      });
+    `,
+    errors: [{
+      message: 'Do not use setState in componentDidUpdate'
+    }]
+  }, {
+    code: `
+      class Hello extends React.Component {
+        componentDidUpdate() {
+          if (true) {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      }
+    `,
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Do not use setState in componentDidUpdate'
+    }]
+  }, {
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          someClass.onSomeEvent((data) => this.setState({data: data}));
+        }
+      });
+    `,
+    parser: 'babel-eslint',
+    options: ['disallow-in-func'],
+    errors: [{
+      message: 'Do not use setState in componentDidUpdate'
+    }]
+  }, {
+    code: `
+      class Hello extends React.Component {
+        componentDidUpdate() {
+          someClass.onSomeEvent((data) => this.setState({data: data}));
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{

--- a/tests/lib/rules/no-find-dom-node.js
+++ b/tests/lib/rules/no-find-dom-node.js
@@ -28,95 +28,95 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('no-find-dom-node', rule, {
 
   valid: [{
-    code: [
-      'var Hello = function() {};'
-    ].join('\n')
+    code: `
+      var Hello = function() {};
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    someNonMemberFunction(arg);',
-      '    this.someFunc = React.findDOMNode;',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          someNonMemberFunction(arg);
+          this.someFunc = React.findDOMNode;
+        },
+        render: function() {
+          return <div>Hello</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    React.someFunc(this);',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          React.someFunc(this);
+        },
+        render: function() {
+          return <div>Hello</div>;
+        }
+      });
+    `
   }],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    React.findDOMNode(this).scrollIntoView();',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          React.findDOMNode(this).scrollIntoView();
+        },
+        render: function() {
+          return <div>Hello</div>;
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use findDOMNode'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '    ReactDOM.findDOMNode(this).scrollIntoView();',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+          ReactDOM.findDOMNode(this).scrollIntoView();
+        },
+        render: function() {
+          return <div>Hello</div>;
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use findDOMNode'
     }]
   }, {
-    code: [
-      'class Hello extends Component {',
-      '  componentDidMount() {',
-      '    findDOMNode(this).scrollIntoView();',
-      '  }',
-      '  render() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      class Hello extends Component {
+        componentDidMount() {
+          findDOMNode(this).scrollIntoView();
+        }
+        render() {
+          return <div>Hello</div>;
+        }
+      };
+    `,
     errors: [{
       message: 'Do not use findDOMNode'
     }]
   }, {
-    code: [
-      'class Hello extends Component {',
-      '  componentDidMount() {',
-      '    this.node = findDOMNode(this);',
-      '  }',
-      '  render() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      class Hello extends Component {
+        componentDidMount() {
+          this.node = findDOMNode(this);
+        }
+        render() {
+          return <div>Hello</div>;
+        }
+      };
+    `,
     errors: [{
       message: 'Do not use findDOMNode'
     }]

--- a/tests/lib/rules/no-is-mounted.js
+++ b/tests/lib/rules/no-is-mounted.js
@@ -28,77 +28,77 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('no-is-mounted', rule, {
 
   valid: [{
-    code: [
-      'var Hello = function() {',
-      '};'
-    ].join('\n')
+    code: `
+      var Hello = function() {
+      };
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    someNonMemberFunction(arg);',
-      '    this.someFunc = this.isMounted;',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          someNonMemberFunction(arg);
+          this.someFunc = this.isMounted;
+        },
+        render: function() {
+          return <div>Hello</div>;
+        }
+      });
+    `
   }],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    if (!this.isMounted()) {',
-      '      return;',
-      '    }',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          if (!this.isMounted()) {
+            return;
+          }
+        },
+        render: function() {
+          return <div>Hello</div>;
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use isMounted'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  someMethod: function() {',
-      '    if (!this.isMounted()) {',
-      '      return;',
-      '    }',
-      '  },',
-      '  render: function() {',
-      '    return <div onClick={this.someMethod.bind(this)}>Hello</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        someMethod: function() {
+          if (!this.isMounted()) {
+            return;
+          }
+        },
+        render: function() {
+          return <div onClick={this.someMethod.bind(this)}>Hello</div>;
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use isMounted'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  someMethod() {',
-      '    if (!this.isMounted()) {',
-      '      return;',
-      '    }',
-      '  }',
-      '  render() {',
-      '    return <div onClick={this.someMethod.bind(this)}>Hello</div>;',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        someMethod() {
+          if (!this.isMounted()) {
+            return;
+          }
+        }
+        render() {
+          return <div onClick={this.someMethod.bind(this)}>Hello</div>;
+        }
+      };
+    `,
     errors: [{
       message: 'Do not use isMounted'
     }]

--- a/tests/lib/rules/no-redundant-should-component-update.js
+++ b/tests/lib/rules/no-redundant-should-component-update.js
@@ -31,118 +31,119 @@ const ruleTester = new RuleTester();
 ruleTester.run('no-redundant-should-component-update', rule, {
   valid: [
     {
-      code: [
-        'class Foo extends React.Component {',
-        '  shouldComponentUpdate() {',
-        '    return true;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
       parserOptions: parserOptions
     },
     {
-      code: [
-        'class Foo extends React.Component {',
-        '  shouldComponentUpdate = () => {',
-        '    return true;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate = () => {
+            return true;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       parserOptions: parserOptions
     },
     {
-      code: [
-        'class Foo extends React.Component {',
-        '  shouldComponentUpdate() {',
-        '    return true;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
       parserOptions: parserOptions
     },
     {
-      code: [
-        'function Foo() {',
-        '  return class Bar extends React.Component {',
-        '    shouldComponentUpdate() {',
-        '      return true;',
-        '    }',
-        '  };',
-        '}'
-      ].join('\n'),
+      code: `
+        function Foo() {
+          return class Bar extends React.Component {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `,
       parserOptions: parserOptions
     }
   ],
+
   invalid: [
     {
-      code: [
-        'class Foo extends React.PureComponent {',
-        '  shouldComponentUpdate() {',
-        '    return true;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
       errors: [{message: errorMessage('Foo')}],
       parserOptions: parserOptions
     },
     {
-      code: [
-        'class Foo extends PureComponent {',
-        '  shouldComponentUpdate() {',
-        '    return true;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
       errors: [{message: errorMessage('Foo')}],
       parserOptions: parserOptions
     },
     {
-      code: [
-        'class Foo extends React.PureComponent {',
-        '  shouldComponentUpdate = () => {',
-        '    return true;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.PureComponent {
+          shouldComponentUpdate = () => {
+            return true;
+          }
+        }
+      `,
       errors: [{message: errorMessage('Foo')}],
       parser: 'babel-eslint',
       parserOptions: parserOptions
     },
     {
-      code: [
-        'function Foo() {',
-        '  return class Bar extends React.PureComponent {',
-        '    shouldComponentUpdate() {',
-        '      return true;',
-        '    }',
-        '  };',
-        '}'
-      ].join('\n'),
+      code: `
+        function Foo() {
+          return class Bar extends React.PureComponent {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `,
       errors: [{message: errorMessage('Bar')}],
       parserOptions: parserOptions
     },
     {
-      code: [
-        'function Foo() {',
-        '  return class Bar extends PureComponent {',
-        '    shouldComponentUpdate() {',
-        '      return true;',
-        '    }',
-        '  };',
-        '}'
-      ].join('\n'),
+      code: `
+        function Foo() {
+          return class Bar extends PureComponent {
+            shouldComponentUpdate() {
+              return true;
+            }
+          };
+        }
+      `,
       errors: [{message: errorMessage('Bar')}],
       parserOptions: parserOptions
     },
     {
-      code: [
-        'var Foo = class extends PureComponent {',
-        '  shouldComponentUpdate() {',
-        '    return true;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        var Foo = class extends PureComponent {
+          shouldComponentUpdate() {
+            return true;
+          }
+        }
+      `,
       errors: [{message: errorMessage('Foo')}],
       parserOptions: parserOptions
     }

--- a/tests/lib/rules/no-render-return-value.js
+++ b/tests/lib/rules/no-render-return-value.js
@@ -28,14 +28,12 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('no-render-return-value', rule, {
 
   valid: [{
-    code: [
-      'ReactDOM.render(<div />, document.body);'
-    ].join('\n')
+    code: 'ReactDOM.render(<div />, document.body);'
   }, {
-    code: [
-      'let node;',
-      'ReactDOM.render(<div ref={ref => node = ref}/>, document.body);'
-    ].join('\n')
+    code: `
+      let node;
+      ReactDOM.render(<div ref={ref => node = ref}/>, document.body);
+    `
   }, {
     code: 'ReactDOM.render(<div ref={ref => this.node = ref}/>, document.body);',
     settings: {
@@ -57,31 +55,28 @@ ruleTester.run('no-render-return-value', rule, {
         version: '0.13.0'
       }
     }
-  }
-  ],
+  }],
 
   invalid: [{
-    code: [
-      'var Hello = ReactDOM.render(<div />, document.body);'
-    ].join('\n'),
+    code: 'var Hello = ReactDOM.render(<div />, document.body);',
     errors: [{
       message: 'Do not depend on the return value from ReactDOM.render'
     }]
   }, {
-    code: [
-      'var o = {',
-      '  inst: ReactDOM.render(<div />, document.body)',
-      '};'
-    ].join('\n'),
+    code: `
+      var o = {
+        inst: ReactDOM.render(<div />, document.body)
+      };
+    `,
     errors: [{
       message: 'Do not depend on the return value from ReactDOM.render'
     }]
   }, {
-    code: [
-      'function render () {',
-      '  return ReactDOM.render(<div />, document.body)',
-      '}'
-    ].join('\n'),
+    code: `
+      function render () {
+        return ReactDOM.render(<div />, document.body)
+      }
+    `,
     errors: [{
       message: 'Do not depend on the return value from ReactDOM.render'
     }]

--- a/tests/lib/rules/no-set-state.js
+++ b/tests/lib/rules/no-set-state.js
@@ -28,106 +28,106 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('no-set-state', rule, {
 
   valid: [{
-    code: [
-      'var Hello = function() {',
-      '  this.setState({})',
-      '};'
-    ].join('\n')
+    code: `
+      var Hello = function() {
+        this.setState({})
+      };
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    someNonMemberFunction(arg);',
-      '    this.someHandler = this.setState;',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          someNonMemberFunction(arg);
+          this.someHandler = this.setState;
+        },
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `
   }],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidUpdate: function() {',
-      '    this.setState({',
-      '      name: this.props.name.toUpperCase()',
-      '    });',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello {this.state.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidUpdate: function() {
+          this.setState({
+            name: this.props.name.toUpperCase()
+          });
+        },
+        render: function() {
+          return <div>Hello {this.state.name}</div>;
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use setState'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  someMethod: function() {',
-      '    this.setState({',
-      '      name: this.props.name.toUpperCase()',
-      '    });',
-      '  },',
-      '  render: function() {',
-      '    return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        someMethod: function() {
+          this.setState({
+            name: this.props.name.toUpperCase()
+          });
+        },
+        render: function() {
+          return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use setState'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  someMethod() {',
-      '    this.setState({',
-      '      name: this.props.name.toUpperCase()',
-      '    });',
-      '  }',
-      '  render() {',
-      '    return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        someMethod() {
+          this.setState({
+            name: this.props.name.toUpperCase()
+          });
+        }
+        render() {
+          return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+        }
+      };
+    `,
     errors: [{
       message: 'Do not use setState'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  someMethod = () => {',
-      '    this.setState({',
-      '      name: this.props.name.toUpperCase()',
-      '    });',
-      '  }',
-      '  render() {',
-      '    return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        someMethod = () => {
+          this.setState({
+            name: this.props.name.toUpperCase()
+          });
+        }
+        render() {
+          return <div onClick={this.someMethod.bind(this)}>Hello {this.state.name}</div>;
+        }
+      };
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Do not use setState'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div onMouseEnter={() => this.setState({dropdownIndex: index})} />;',
-      '  }',
-      '};'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render() {
+          return <div onMouseEnter={() => this.setState({dropdownIndex: index})} />;
+        }
+      };
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Do not use setState'

--- a/tests/lib/rules/no-string-refs.js
+++ b/tests/lib/rules/no-string-refs.js
@@ -30,70 +30,70 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('no-refs', rule, {
 
   valid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '     var component = this.hello;',
-      '  },',
-      '  render: function() {',
-      '    return <div ref={c => this.hello = c}>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+           var component = this.hello;
+        },
+        render: function() {
+          return <div ref={c => this.hello = c}>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     parser: 'babel-eslint'
   }
   ],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '     var component = this.refs.hello;',
-      '  },',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+           var component = this.refs.hello;
+        },
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Using this.refs is deprecated.'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div ref="hello">Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div ref="hello">Hello {this.props.name}</div>;
+        }
+      });
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Using string literals in ref attributes is deprecated.'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div ref={\'hello\'}>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div ref={'hello'}>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Using string literals in ref attributes is deprecated.'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentDidMount: function() {',
-      '     var component = this.refs.hello;',
-      '  },',
-      '  render: function() {',
-      '    return <div ref="hello">Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: function() {
+           var component = this.refs.hello;
+        },
+        render: function() {
+          return <div ref="hello">Hello {this.props.name}</div>;
+        }
+      });
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Using this.refs is deprecated.'

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -149,6 +149,7 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions: parserOptions
   }, {
+    // This case is currently not supported
     code: `
       class First extends React.Component {}
       First["prop" + "Types"] = {};
@@ -158,6 +159,7 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions: parserOptions
   }, {
+    // This case is currently not supported
     code: `
       class First extends React.Component {}
       First["PROP" + "TYPES"] = {};

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -27,216 +27,216 @@ const ERROR_MESSAGE_LIFECYCLE_METHOD = 'Typo in component lifecycle method decla
 const ruleTester = new RuleTester();
 ruleTester.run('no-typos', rule, {
   valid: [{
-    code: [
-      'class First {',
-      '  static PropTypes = {key: "myValue"};',
-      '  static ContextTypes = {key: "myValue"};',
-      '  static ChildContextTypes = {key: "myValue"};',
-      '  static DefaultProps = {key: "myValue"};',
-      '}'
-    ].join('\n'),
+    code: `
+      class First {
+        static PropTypes = {key: "myValue"};
+        static ContextTypes = {key: "myValue"};
+        static ChildContextTypes = {key: "myValue"};
+        static DefaultProps = {key: "myValue"};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: [
-      'class First {}',
-      'First.PropTypes = {key: "myValue"};',
-      'First.ContextTypes = {key: "myValue"};',
-      'First.ChildContextTypes = {key: "myValue"};',
-      'First.DefaultProps = {key: "myValue"};'
-    ].join('\n'),
+    code: `
+      class First {}
+      First.PropTypes = {key: "myValue"};
+      First.ContextTypes = {key: "myValue"};
+      First.ChildContextTypes = {key: "myValue"};
+      First.DefaultProps = {key: "myValue"};
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'class First extends React.Component {',
-      '  static propTypes = {key: "myValue"};',
-      '  static contextTypes = {key: "myValue"};',
-      '  static childContextTypes = {key: "myValue"};',
-      '  static defaultProps = {key: "myValue"};',
-      '}'
-    ].join('\n'),
+    code: `
+      class First extends React.Component {
+        static propTypes = {key: "myValue"};
+        static contextTypes = {key: "myValue"};
+        static childContextTypes = {key: "myValue"};
+        static defaultProps = {key: "myValue"};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: [
-      'class First extends React.Component {}',
-      'First.propTypes = {key: "myValue"};',
-      'First.contextTypes = {key: "myValue"};',
-      'First.childContextTypes = {key: "myValue"};',
-      'First.defaultProps = {key: "myValue"};'
-    ].join('\n'),
+    code: `
+      class First extends React.Component {}
+      First.propTypes = {key: "myValue"};
+      First.contextTypes = {key: "myValue"};
+      First.childContextTypes = {key: "myValue"};
+      First.defaultProps = {key: "myValue"};
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {',
-      '  propTypes = {key: "myValue"};',
-      '  contextTypes = {key: "myValue"};',
-      '  childContextTypes = {key: "myValue"};',
-      '  defaultProps = {key: "myValue"};',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyClass {
+        propTypes = {key: "myValue"};
+        contextTypes = {key: "myValue"};
+        childContextTypes = {key: "myValue"};
+        defaultProps = {key: "myValue"};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {',
-      '  PropTypes = {key: "myValue"};',
-      '  ContextTypes = {key: "myValue"};',
-      '  ChildContextTypes = {key: "myValue"};',
-      '  DefaultProps = {key: "myValue"};',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyClass {
+        PropTypes = {key: "myValue"};
+        ContextTypes = {key: "myValue"};
+        ChildContextTypes = {key: "myValue"};
+        DefaultProps = {key: "myValue"};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {',
-      '  proptypes = {key: "myValue"};',
-      '  contexttypes = {key: "myValue"};',
-      '  childcontextypes = {key: "myValue"};',
-      '  defaultprops = {key: "myValue"};',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyClass {
+        proptypes = {key: "myValue"};
+        contexttypes = {key: "myValue"};
+        childcontextypes = {key: "myValue"};
+        defaultprops = {key: "myValue"};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {',
-      '  static PropTypes() {};',
-      '  static ContextTypes() {};',
-      '  static ChildContextTypes() {};',
-      '  static DefaultProps() {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyClass {
+        static PropTypes() {};
+        static ContextTypes() {};
+        static ChildContextTypes() {};
+        static DefaultProps() {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {',
-      '  static proptypes() {};',
-      '  static contexttypes() {};',
-      '  static childcontexttypes() {};',
-      '  static defaultprops() {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyClass {
+        static proptypes() {};
+        static contexttypes() {};
+        static childcontexttypes() {};
+        static defaultprops() {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {}',
-      'MyClass.prototype.PropTypes = function() {};',
-      'MyClass.prototype.ContextTypes = function() {};',
-      'MyClass.prototype.ChildContextTypes = function() {};',
-      'MyClass.prototype.DefaultProps = function() {};'
-    ].join('\n'),
+    code: `
+      class MyClass {}
+      MyClass.prototype.PropTypes = function() {};
+      MyClass.prototype.ContextTypes = function() {};
+      MyClass.prototype.ChildContextTypes = function() {};
+      MyClass.prototype.DefaultProps = function() {};
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {}',
-      'MyClass.PropTypes = function() {};',
-      'MyClass.ContextTypes = function() {};',
-      'MyClass.ChildContextTypes = function() {};',
-      'MyClass.DefaultProps = function() {};'
-    ].join('\n'),
+    code: `
+      class MyClass {}
+      MyClass.PropTypes = function() {};
+      MyClass.ContextTypes = function() {};
+      MyClass.ChildContextTypes = function() {};
+      MyClass.DefaultProps = function() {};
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'function MyRandomFunction() {}',
-      'MyRandomFunction.PropTypes = {};',
-      'MyRandomFunction.ContextTypes = {};',
-      'MyRandomFunction.ChildContextTypes = {};',
-      'MyRandomFunction.DefaultProps = {};'
-    ].join('\n'),
+    code: `
+      function MyRandomFunction() {}
+      MyRandomFunction.PropTypes = {};
+      MyRandomFunction.ContextTypes = {};
+      MyRandomFunction.ChildContextTypes = {};
+      MyRandomFunction.DefaultProps = {};
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'class First extends React.Component {}',
-      'First["prop" + "Types"] = {};',
-      'First["context" + "Types"] = {};',
-      'First["childContext" + "Types"] = {};',
-      'First["default" + "Props"] = {};'
-    ].join('\n'),
+    code: `
+      class First extends React.Component {}
+      First["prop" + "Types"] = {};
+      First["context" + "Types"] = {};
+      First["childContext" + "Types"] = {};
+      First["default" + "Props"] = {};
+    `,
     parserOptions: parserOptions
   }, {
-    code: [ // This case is currently not supported
-      'class First extends React.Component {}',
-      'First["PROP" + "TYPES"] = {};',
-      'First["CONTEXT" + "TYPES"] = {};',
-      'First["CHILDCONTEXT" + "TYPES"] = {};',
-      'First["DEFAULT" + "PROPS"] = {};'
-    ].join('\n'),
+    code: `
+      class First extends React.Component {}
+      First["PROP" + "TYPES"] = {};
+      First["CONTEXT" + "TYPES"] = {};
+      First["CHILDCONTEXT" + "TYPES"] = {};
+      First["DEFAULT" + "PROPS"] = {};
+    `,
     parserOptions: parserOptions
   }, {
-    code: [ // This case is currently not supported
-      'const propTypes = "PROPTYPES"',
-      'const contextTypes = "CONTEXTTYPES"',
-      'const childContextTypes = "CHILDCONTEXTTYPES"',
-      'const defautProps = "DEFAULTPROPS"',
-      '',
-      'class First extends React.Component {}',
-      'First[propTypes] = {};',
-      'First[contextTypes] = {};',
-      'First[childContextTypes] = {};',
-      'First[defautProps] = {};'
-    ].join('\n'),
+    code: `
+      const propTypes = "PROPTYPES"
+      const contextTypes = "CONTEXTTYPES"
+      const childContextTypes = "CHILDCONTEXTTYPES"
+      const defautProps = "DEFAULTPROPS"
+      
+      class First extends React.Component {}
+      First[propTypes] = {};
+      First[contextTypes] = {};
+      First[childContextTypes] = {};
+      First[defautProps] = {};
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentWillMount() { }',
-      '  componentDidMount() { }',
-      '  componentWillReceiveProps() { }',
-      '  shouldComponentUpdate() { }',
-      '  componentWillUpdate() { }',
-      '  componentDidUpdate() { }',
-      '  componentWillUnmount() { }',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentWillMount() { }
+        componentDidMount() { }
+        componentWillReceiveProps() { }
+        shouldComponentUpdate() { }
+        componentWillUpdate() { }
+        componentDidUpdate() { }
+        componentWillUnmount() { }
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {',
-      '  componentWillMount() { }',
-      '  componentDidMount() { }',
-      '  componentWillReceiveProps() { }',
-      '  shouldComponentUpdate() { }',
-      '  componentWillUpdate() { }',
-      '  componentDidUpdate() { }',
-      '  componentWillUnmount() { }',
-      '  render() { }',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyClass {
+        componentWillMount() { }
+        componentDidMount() { }
+        componentWillReceiveProps() { }
+        shouldComponentUpdate() { }
+        componentWillUpdate() { }
+        componentDidUpdate() { }
+        componentWillUnmount() { }
+        render() { }
+      }
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {',
-      '  componentwillmount() { }',
-      '  componentdidmount() { }',
-      '  componentwillreceiveprops() { }',
-      '  shouldcomponentupdate() { }',
-      '  componentwillupdate() { }',
-      '  componentdidupdate() { }',
-      '  componentwillUnmount() { }',
-      '  render() { }',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyClass {
+        componentwillmount() { }
+        componentdidmount() { }
+        componentwillreceiveprops() { }
+        shouldcomponentupdate() { }
+        componentwillupdate() { }
+        componentdidupdate() { }
+        componentwillUnmount() { }
+        render() { }
+      }
+    `,
     parserOptions: parserOptions
   }, {
-    code: [
-      'class MyClass {',
-      '  Componentwillmount() { }',
-      '  Componentdidmount() { }',
-      '  Componentwillreceiveprops() { }',
-      '  Shouldcomponentupdate() { }',
-      '  Componentwillupdate() { }',
-      '  Componentdidupdate() { }',
-      '  ComponentwillUnmount() { }',
-      '  Render() { }',
-      '}'
-    ].join('\n'),
+    code: `
+      class MyClass {
+        Componentwillmount() { }
+        Componentdidmount() { }
+        Componentwillreceiveprops() { }
+        Shouldcomponentupdate() { }
+        Componentwillupdate() { }
+        Componentdidupdate() { }
+        ComponentwillUnmount() { }
+        Render() { }
+      }
+    `,
     parserOptions: parserOptions
   }, {
     // PropTypes declared on a component that is detected through JSDoc comments and is
@@ -347,194 +347,194 @@ ruleTester.run('no-typos', rule, {
   }],
 
   invalid: [{
-    code: [
-      'class Component extends React.Component {',
-      '  static PropTypes = {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {
+        static PropTypes = {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {}',
-      'Component.PropTypes = {}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {}
+      Component.PropTypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
-      'MyComponent.PropTypes = {}'
-    ].join('\n'),
+    code: `
+      function MyComponent() { return (<div>{this.props.myProp}</div>) }
+      MyComponent.PropTypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {',
-      '  static proptypes = {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {
+        static proptypes = {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {}',
-      'Component.proptypes = {}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {}
+      Component.proptypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
-      'MyComponent.proptypes = {}'
-    ].join('\n'),
+    code: `
+      function MyComponent() { return (<div>{this.props.myProp}</div>) }
+      MyComponent.proptypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {',
-      '  static ContextTypes = {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {
+        static ContextTypes = {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {}',
-      'Component.ContextTypes = {}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {}
+      Component.ContextTypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
-      'MyComponent.ContextTypes = {}'
-    ].join('\n'),
+    code: `
+      function MyComponent() { return (<div>{this.props.myProp}</div>) }
+      MyComponent.ContextTypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {',
-      '  static contexttypes = {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {
+        static contexttypes = {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {}',
-      'Component.contexttypes = {}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {}
+      Component.contexttypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
-      'MyComponent.contexttypes = {}'
-    ].join('\n'),
+    code: `
+      function MyComponent() { return (<div>{this.props.myProp}</div>) }
+      MyComponent.contexttypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {',
-      '  static ChildContextTypes = {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {
+        static ChildContextTypes = {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {}',
-      'Component.ChildContextTypes = {}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {}
+      Component.ChildContextTypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
-      'MyComponent.ChildContextTypes = {}'
-    ].join('\n'),
+    code: `
+      function MyComponent() { return (<div>{this.props.myProp}</div>) }
+      MyComponent.ChildContextTypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {',
-      '  static childcontexttypes = {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {
+        static childcontexttypes = {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {}',
-      'Component.childcontexttypes = {}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {}
+      Component.childcontexttypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
-      'MyComponent.childcontexttypes = {}'
-    ].join('\n'),
+    code: `
+      function MyComponent() { return (<div>{this.props.myProp}</div>) }
+      MyComponent.childcontexttypes = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {',
-      '  static DefaultProps = {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {
+        static DefaultProps = {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {}',
-      'Component.DefaultProps = {}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {}
+      Component.DefaultProps = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
-      'MyComponent.DefaultProps = {}'
-    ].join('\n'),
+    code: `
+      function MyComponent() { return (<div>{this.props.myProp}</div>) }
+      MyComponent.DefaultProps = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {',
-      '  static defaultprops = {};',
-      '}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {
+        static defaultprops = {};
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Component extends React.Component {}',
-      'Component.defaultprops = {}'
-    ].join('\n'),
+    code: `
+      class Component extends React.Component {}
+      Component.defaultprops = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'function MyComponent() { return (<div>{this.props.myProp}</div>) }',
-      'MyComponent.defaultprops = {}'
-    ].join('\n'),
+    code: `
+      function MyComponent() { return (<div>{this.props.myProp}</div>) }
+      MyComponent.defaultprops = {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'Component.defaultprops = {}',
-      'class Component extends React.Component {}'
-    ].join('\n'),
+    code: `
+      Component.defaultprops = {}
+      class Component extends React.Component {}
+    `,
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
@@ -546,20 +546,20 @@ ruleTester.run('no-typos', rule, {
     parserOptions: parserOptions,
     errors: [{message: ERROR_MESSAGE}]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  ComponentWillMount() { }',
-      '  ComponentDidMount() { }',
-      '  ComponentWillReceiveProps() { }',
-      '  ShouldComponentUpdate() { }',
-      '  ComponentWillUpdate() { }',
-      '  ComponentDidUpdate() { }',
-      '  ComponentWillUnmount() { }',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        ComponentWillMount() { }
+        ComponentDidMount() { }
+        ComponentWillReceiveProps() { }
+        ShouldComponentUpdate() { }
+        ComponentWillUpdate() { }
+        ComponentDidUpdate() { }
+        ComponentWillUnmount() { }
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     parserOptions: parserOptions,
     errors: [{
       message: ERROR_MESSAGE_LIFECYCLE_METHOD,
@@ -584,20 +584,20 @@ ruleTester.run('no-typos', rule, {
       type: 'MethodDefinition'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  Componentwillmount() { }',
-      '  Componentdidmount() { }',
-      '  Componentwillreceiveprops() { }',
-      '  Shouldcomponentupdate() { }',
-      '  Componentwillupdate() { }',
-      '  Componentdidupdate() { }',
-      '  Componentwillunmount() { }',
-      '  Render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        Componentwillmount() { }
+        Componentdidmount() { }
+        Componentwillreceiveprops() { }
+        Shouldcomponentupdate() { }
+        Componentwillupdate() { }
+        Componentdidupdate() { }
+        Componentwillunmount() { }
+        Render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     parserOptions: parserOptions,
     errors: [{
       message: ERROR_MESSAGE_LIFECYCLE_METHOD,
@@ -625,20 +625,20 @@ ruleTester.run('no-typos', rule, {
       type: 'MethodDefinition'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentwillmount() { }',
-      '  componentdidmount() { }',
-      '  componentwillreceiveprops() { }',
-      '  shouldcomponentupdate() { }',
-      '  componentwillupdate() { }',
-      '  componentdidupdate() { }',
-      '  componentwillunmount() { }',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentwillmount() { }
+        componentdidmount() { }
+        componentwillreceiveprops() { }
+        shouldcomponentupdate() { }
+        componentwillupdate() { }
+        componentdidupdate() { }
+        componentwillunmount() { }
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     parserOptions: parserOptions,
     errors: [{
       message: ERROR_MESSAGE_LIFECYCLE_METHOD,
@@ -663,68 +663,74 @@ ruleTester.run('no-typos', rule, {
       type: 'MethodDefinition'
     }]
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-        a: PropTypes.Number.isRequired
-     }
-   `,
+    code: `
+      class Component extends React.Component {};
+      Component.propTypes = {
+          a: PropTypes.Number.isRequired
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{
       message: 'Typo in declared prop type: Number'
     }]
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-        a: PropTypes.number.isrequired
-     }
-   `,
+    code: `
+      class Component extends React.Component {};
+      Component.propTypes = {
+          a: PropTypes.number.isrequired
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{
       message: 'Typo in prop type chain qualifier: isrequired'
     }]
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-        a: PropTypes.Number
-     }
-   `,
+    code: `
+      class Component extends React.Component {};
+      Component.propTypes = {
+          a: PropTypes.Number
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{
       message: 'Typo in declared prop type: Number'
     }]
   }, {
-    code: `class Component extends React.Component {};
-    Component.propTypes = {
-       a: PropTypes.shape({
-         b: PropTypes.String,
-         c: PropTypes.number.isRequired,
-       })
-    }
-   `,
+    code: `
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.shape({
+          b: PropTypes.String,
+          c: PropTypes.number.isRequired,
+        })
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{
       message: 'Typo in declared prop type: String'
     }]
   }, {
-    code: `class Component extends React.Component {};
-    Component.propTypes = {
-       a: PropTypes.oneOfType([
-         PropTypes.bools,
-         PropTypes.number,
-       ])
-     }
-   `,
+    code: `
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.oneOfType([
+          PropTypes.bools,
+          PropTypes.number,
+        ])
+      }
+    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{
       message: 'Typo in declared prop type: bools'
     }]
   }, {
-    code: `class Component extends React.Component {};
+    code: `
+      class Component extends React.Component {};
       Component.propTypes = {
         a: PropTypes.bools,
         b: PropTypes.Array,
@@ -744,7 +750,8 @@ ruleTester.run('no-typos', rule, {
       message: 'Typo in declared prop type: objectof'
     }]
   }, {
-    code: `class Component extends React.Component {};
+    code: `
+      class Component extends React.Component {};
       Component.childContextTypes = {
         a: PropTypes.bools,
         b: PropTypes.Array,

--- a/tests/lib/rules/no-unescaped-entities.js
+++ b/tests/lib/rules/no-unescaped-entities.js
@@ -29,103 +29,103 @@ ruleTester.run('no-unescaped-entities', rule, {
 
   valid: [
     {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return (',
-        '      <div/>',
-        '    );',
-        '  }',
-        '});'
-      ].join('\n')
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return (
+              <div/>
+            );
+          }
+        });
+      `
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>Here is some text!</div>;',
-        '  }',
-        '});'
-      ].join('\n')
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Here is some text!</div>;
+          }
+        });
+      `
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>I&rsquo;ve escaped some entities: &gt; &lt; &amp;</div>;',
-        '  }',
-        '});'
-      ].join('\n')
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>I&rsquo;ve escaped some entities: &gt; &lt; &amp;</div>;
+          }
+        });
+      `
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>first line is ok',
-        '    so is second',
-        '    and here are some escaped entities: &gt; &lt; &amp;</div>;',
-        '  }',
-        '});'
-      ].join('\n')
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>first line is ok
+            so is second
+            and here are some escaped entities: &gt; &lt; &amp;</div>;
+          }
+        });
+      `
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>{">" + "<" + "&" + \'"\'}</div>;',
-        '  },',
-        '});'
-      ].join('\n')
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>{">" + "<" + "&" + '"'}</div>;
+          },
+        });
+      `
     }
   ],
 
   invalid: [
     {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>></div>;',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>></div>;
+          }
+        });
+      `,
       errors: [{message: 'HTML entities must be escaped.'}]
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>first line is ok',
-        '    so is second',
-        '    and here are some bad entities: ></div>',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>first line is ok
+            so is second
+            and here are some bad entities: ></div>
+          }
+        });
+      `,
       errors: [{message: 'HTML entities must be escaped.'}]
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>\'</div>;',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>'</div>;
+          }
+        });
+      `,
       errors: [{message: 'HTML entities must be escaped.'}]
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>Multiple errors: \'>></div>;',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>Multiple errors: '>></div>;
+          }
+        });
+      `,
       errors: [
         {message: 'HTML entities must be escaped.'},
         {message: 'HTML entities must be escaped.'},
         {message: 'HTML entities must be escaped.'}
       ]
     }, {
-      code: [
-        'var Hello = createReactClass({',
-        '  render: function() {',
-        '    return <div>{"Unbalanced braces"}}</div>;',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var Hello = createReactClass({
+          render: function() {
+            return <div>{"Unbalanced braces"}}</div>;
+          }
+        });
+      `,
       errors: [{message: 'HTML entities must be escaped.'}]
     }
   ]

--- a/tests/lib/rules/no-will-update-set-state.js
+++ b/tests/lib/rules/no-will-update-set-state.js
@@ -30,197 +30,197 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('no-will-update-set-state', rule, {
 
   valid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {}',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {}
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {',
-      '    someNonMemberFunction(arg);',
-      '    this.someHandler = this.setState;',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {
+          someNonMemberFunction(arg);
+          this.someHandler = this.setState;
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      });
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {',
-      '    function handleEvent(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '    someClass.onSomeEvent(handleEvent)',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {
+          function handleEvent(data) {
+            this.setState({
+              data: data
+            });
+          }
+          someClass.onSomeEvent(handleEvent)
+        }
+      });
+    `,
     parser: 'babel-eslint'
   }],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {
+          this.setState({
+            data: data
+          });
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use setState in componentWillUpdate'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentWillUpdate() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentWillUpdate() {
+          this.setState({
+            data: data
+          });
+        }
+      }
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Do not use setState in componentWillUpdate'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {
+          this.setState({
+            data: data
+          });
+        }
+      });
+    `,
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentWillUpdate'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentWillUpdate() {',
-      '    this.setState({',
-      '      data: data',
-      '    });',
-      '  }',
-      '}'
-    ].join('\n'),
-    parser: 'babel-eslint',
-    options: ['disallow-in-func'],
-    errors: [{
-      message: 'Do not use setState in componentWillUpdate'
-    }]
-  }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '});'
-    ].join('\n'),
-    options: ['disallow-in-func'],
-    errors: [{
-      message: 'Do not use setState in componentWillUpdate'
-    }]
-  }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentWillUpdate() {',
-      '    someClass.onSomeEvent(function(data) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    })',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentWillUpdate() {
+          this.setState({
+            data: data
+          });
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentWillUpdate'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {',
-      '    if (true) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      });
+    `,
+    options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentWillUpdate'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentWillUpdate() {',
-      '    if (true) {',
-      '      this.setState({',
-      '        data: data',
-      '      });',
-      '    }',
-      '  }',
-      '}'
-    ].join('\n'),
-    parser: 'babel-eslint',
-    errors: [{
-      message: 'Do not use setState in componentWillUpdate'
-    }]
-  }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  componentWillUpdate: function() {',
-      '    someClass.onSomeEvent((data) => this.setState({data: data}));',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        componentWillUpdate() {
+          someClass.onSomeEvent(function(data) {
+            this.setState({
+              data: data
+            });
+          })
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{
       message: 'Do not use setState in componentWillUpdate'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  componentWillUpdate() {',
-      '    someClass.onSomeEvent((data) => this.setState({data: data}));',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {
+          if (true) {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      });
+    `,
+    errors: [{
+      message: 'Do not use setState in componentWillUpdate'
+    }]
+  }, {
+    code: `
+      class Hello extends React.Component {
+        componentWillUpdate() {
+          if (true) {
+            this.setState({
+              data: data
+            });
+          }
+        }
+      }
+    `,
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Do not use setState in componentWillUpdate'
+    }]
+  }, {
+    code: `
+      var Hello = createReactClass({
+        componentWillUpdate: function() {
+          someClass.onSomeEvent((data) => this.setState({data: data}));
+        }
+      });
+    `,
+    parser: 'babel-eslint',
+    options: ['disallow-in-func'],
+    errors: [{
+      message: 'Do not use setState in componentWillUpdate'
+    }]
+  }, {
+    code: `
+      class Hello extends React.Component {
+        componentWillUpdate() {
+          someClass.onSomeEvent((data) => this.setState({data: data}));
+        }
+      }
+    `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
     errors: [{

--- a/tests/lib/rules/prefer-es6-class.js
+++ b/tests/lib/rules/prefer-es6-class.js
@@ -30,80 +30,80 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('prefer-es6-class', rule, {
 
   valid: [{
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}',
-      'Hello.displayName = \'Hello\''
-    ].join('\n')
+    code: `
+      class Hello extends React.Component {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+      Hello.displayName = 'Hello'
+    `
   }, {
-    code: [
-      'export default class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}',
-      'Hello.displayName = \'Hello\''
-    ].join('\n')
+    code: `
+      export default class Hello extends React.Component {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+      Hello.displayName = 'Hello'
+    `
   }, {
-    code: [
-      'var Hello = "foo";',
-      'module.exports = {};'
-    ].join('\n')
+    code: `
+      var Hello = "foo";
+      module.exports = {};
+    `
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     options: ['never']
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     options: ['always']
   }],
 
   invalid: [{
-    code: [
-      'var Hello = createReactClass({',
-      '  displayName: \'Hello\',',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        displayName: 'Hello',
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     errors: [{
       message: 'Component should use es6 class instead of createClass'
     }]
   }, {
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      });
+    `,
     options: ['always'],
     errors: [{
       message: 'Component should use es6 class instead of createClass'
     }]
   }, {
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     options: ['never'],
     errors: [{
       message: 'Component should use createClass instead of es6 class'

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -29,6 +29,7 @@ ruleTester.run('prefer-stateless-function', rule, {
 
   valid: [
     {
+      // Already a stateless function
       code: `
         const Foo = function(props) {
           return <div>{props.foo}</div>;
@@ -38,6 +39,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       // Already a stateless (arrow) function
       code: 'const Foo = ({foo}) => <div>{foo}</div>;'
     }, {
+      // Extends from PureComponent and uses props
       code: `
         class Foo extends React.PureComponent {
           render() {
@@ -49,6 +51,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         ignorePureComponents: true
       }]
     }, {
+      // Extends from PureComponent and uses context
       code: `
         class Foo extends React.PureComponent {
           render() {
@@ -60,6 +63,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         ignorePureComponents: true
       }]
     }, {
+      // Extends from PureComponent in an expression context.
       code: `
         const Foo = class extends React.PureComponent {
           render() {
@@ -72,6 +76,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         ignorePureComponents: true
       }]
     }, {
+      // Has a lifecyle method
       code: `
         class Foo extends React.Component {
           shouldComponentUpdate() {
@@ -83,6 +88,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `
     }, {
+      // Has a state
       code: `
         class Foo extends React.Component {
           changeState() {
@@ -94,6 +100,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `
     }, {
+      // Use refs      
       code: `
         class Foo extends React.Component {
           doStuff() {
@@ -105,6 +112,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `
     }, {
+      // Has an additional method
       code: `
         class Foo extends React.Component {
           doStuff() {}
@@ -114,6 +122,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `
     }, {
+      // Has an empty (no super) constructor      
       code: `
         class Foo extends React.Component {
           constructor() {}
@@ -123,6 +132,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `
     }, {
+      // Has a constructor      
       code: `
         class Foo extends React.Component {
           constructor() {
@@ -134,6 +144,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `
     }, {
+      // Has a constructor (2)      
       code: `
         class Foo extends React.Component {
           constructor() {
@@ -145,6 +156,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `
     }, {
+      // Use this.bar      
       code: `
         class Foo extends React.Component {
           render() {
@@ -154,6 +166,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: 'babel-eslint'
     }, {
+      // Use this.bar (destructuring)
       code: `
         class Foo extends React.Component {
           render() {
@@ -164,6 +177,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: 'babel-eslint'
     }, {
+      // Use this[bar]
       code: `
         class Foo extends React.Component {
           render() {
@@ -173,6 +187,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: 'babel-eslint'
     }, {
+      // Use this['bar']
       code: `
         class Foo extends React.Component {
           render() {
@@ -182,6 +197,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: 'babel-eslint'
     }, {
+      // Can return null (ES6, React 0.14.0)
       code: `
         class Foo extends React.Component {
           render() {
@@ -199,6 +215,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       }
     }, {
+      // Can return null (ES5, React 0.14.0)
       code: `
         var Foo = createReactClass({
           render: function() {
@@ -215,6 +232,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       }
     }, {
+      // Can return null (shorthand if in return, React 0.14.0)
       code: `
         class Foo extends React.Component {
           render() {
@@ -241,6 +259,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: 'babel-eslint'
     }, {
+      // Has childContextTypes
       code: `
         class Foo extends React.Component {
           render() {
@@ -253,6 +272,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: 'babel-eslint'
     }, {
+      // Uses a decorator
       code: `
         @foo
         class Foo extends React.Component {
@@ -263,6 +283,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: 'babel-eslint'
     }, {
+      // Uses a called decorator
       code: `
         @foo("bar")
         class Foo extends React.Component {
@@ -273,6 +294,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: 'babel-eslint'
     }, {
+      // Uses multiple decorators
       code: `
         @foo
         @bar()
@@ -288,6 +310,7 @@ ruleTester.run('prefer-stateless-function', rule, {
 
   invalid: [
     {
+      // Only use this.props
       code: `
         class Foo extends React.Component {
           render() {

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -29,185 +29,169 @@ ruleTester.run('prefer-stateless-function', rule, {
 
   valid: [
     {
-      // Already a stateless function
-      code: [
-        'const Foo = function(props) {',
-        '  return <div>{props.foo}</div>;',
-        '};'
-      ].join('\n')
+      code: `
+        const Foo = function(props) {
+          return <div>{props.foo}</div>;
+        };
+      `
     }, {
       // Already a stateless (arrow) function
       code: 'const Foo = ({foo}) => <div>{foo}</div>;'
     }, {
-      // Extends from PureComponent and uses props
-      code: [
-        'class Foo extends React.PureComponent {',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       options: [{
         ignorePureComponents: true
       }]
     }, {
-      // Extends from PureComponent and uses context
-      code: [
-        'class Foo extends React.PureComponent {',
-        '  render() {',
-        '    return <div>{this.context.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.context.foo}</div>;
+          }
+        }
+      `,
       options: [{
         ignorePureComponents: true
       }]
     }, {
-      // Extends from PureComponent in an expression context.
-      code: [
-        'const Foo = class extends React.PureComponent {',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '};'
-      ].join('\n'),
+      code: `
+        const Foo = class extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        };
+      `,
       parserOptions: parserOptions,
       options: [{
         ignorePureComponents: true
       }]
     }, {
-      // Has a lifecyle method
-      code: [
-        'class Foo extends React.Component {',
-        '  shouldComponentUpdate() {',
-        '    return false;',
-        '  }',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n')
+      code: `
+        class Foo extends React.Component {
+          shouldComponentUpdate() {
+            return false;
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `
     }, {
-      // Has a state
-      code: [
-        'class Foo extends React.Component {',
-        '  changeState() {',
-        '    this.setState({foo: "clicked"});',
-        '  }',
-        '  render() {',
-        '    return <div onClick={this.changeState.bind(this)}>{this.state.foo || "bar"}</div>;',
-        '  }',
-        '}'
-      ].join('\n')
+      code: `
+        class Foo extends React.Component {
+          changeState() {
+            this.setState({foo: "clicked"});
+          }
+          render() {
+            return <div onClick={this.changeState.bind(this)}>{this.state.foo || "bar"}</div>;
+          }
+        }
+      `
     }, {
-      // Use refs
-      code: [
-        'class Foo extends React.Component {',
-        '  doStuff() {',
-        '    this.refs.foo.style.backgroundColor = "red";',
-        '  }',
-        '  render() {',
-        '    return <div ref="foo" onClick={this.doStuff}>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n')
+      code: `
+        class Foo extends React.Component {
+          doStuff() {
+            this.refs.foo.style.backgroundColor = "red";
+          }
+          render() {
+            return <div ref="foo" onClick={this.doStuff}>{this.props.foo}</div>;
+          }
+        }
+      `
     }, {
-      // Has an additional method
-      code: [
-        'class Foo extends React.Component {',
-        '  doStuff() {}',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n')
+      code: `
+        class Foo extends React.Component {
+          doStuff() {}
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `
     }, {
-      // Has an empty (no super) constructor
-      code: [
-        'class Foo extends React.Component {',
-        '  constructor() {}',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n')
+      code: `
+        class Foo extends React.Component {
+          constructor() {}
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `
     }, {
-      // Has a constructor
-      code: [
-        'class Foo extends React.Component {',
-        '  constructor() {',
-        '    doSpecialStuffs();',
-        '  }',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n')
+      code: `
+        class Foo extends React.Component {
+          constructor() {
+            doSpecialStuffs();
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `
     }, {
-      // Has a constructor (2)
-      code: [
-        'class Foo extends React.Component {',
-        '  constructor() {',
-        '    foo;',
-        '  }',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n')
+      code: `
+        class Foo extends React.Component {
+          constructor() {
+            foo;
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `
     }, {
-      // Use this.bar
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this.bar}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.bar}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      // Use this.bar (destructuring)
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    let {props:{foo}, bar} = this;',
-        '    return <div>{foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            let {props:{foo}, bar} = this;
+            return <div>{foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      // Use this[bar]
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this[bar]}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this[bar]}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      // Use this['bar']
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this[\'bar\']}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this['bar']}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      // Can return null (ES6, React 0.14.0)
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    if (!this.props.foo) {',
-        '      return null;',
-        '    }',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       settings: {
         react: {
@@ -215,31 +199,29 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       }
     }, {
-      // Can return null (ES5, React 0.14.0)
-      code: [
-        'var Foo = createReactClass({',
-        '  render: function() {',
-        '    if (!this.props.foo) {',
-        '      return null;',
-        '    }',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var Foo = createReactClass({
+          render: function() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `,
       settings: {
         react: {
           version: '0.14.0'
         }
       }
     }, {
-      // Can return null (shorthand if in return, React 0.14.0)
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return true ? <div /> : null;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return true ? <div /> : null;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       settings: {
         react: {
@@ -247,101 +229,94 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       }
     }, {
-      code: [
-        'export default (Component) => (',
-        '  class Test extends React.Component {',
-        '    componentDidMount() {}',
-        '    render() {',
-        '      return <Component />;',
-        '    }',
-        '  }',
-        ');'
-      ].join('\n'),
+      code: `
+        export default (Component) => (
+          class Test extends React.Component {
+            componentDidMount() {}
+            render() {
+              return <Component />;
+            }
+          }
+        );
+      `,
       parser: 'babel-eslint'
     }, {
-      // Has childContextTypes
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this.props.children}</div>;',
-        '  }',
-        '}',
-        'Foo.childContextTypes = {',
-        '  color: PropTypes.string',
-        '};'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.children}</div>;
+          }
+        }
+        Foo.childContextTypes = {
+          color: PropTypes.string
+        };
+      `,
       parser: 'babel-eslint'
     }, {
-      // Uses a decorator
-      code: [
-        '@foo',
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        @foo
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      // Uses a called decorator
-      code: [
-        '@foo("bar")',
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        @foo("bar")
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
-      // Uses multiple decorators
-      code: [
-        '@foo',
-        '@bar()',
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        @foo
+        @bar()
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }
   ],
 
   invalid: [
     {
-      // Only use this.props
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Only use this[\'props\']
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return <div>{this[\'props\'].foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return <div>{this['props'].foo}</div>;
+          }
+        }
+      `,
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Only extend PureComponent without use of props or context
-      code: [
-        'class Foo extends React.PureComponent {',
-        '  render() {',
-        '    return <div>foo</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>foo</div>;
+          }
+        }
+      `,
       options: [{
         ignorePureComponents: true
       }],
@@ -349,166 +324,155 @@ ruleTester.run('prefer-stateless-function', rule, {
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Extends from PureComponent but no ignorePureComponents option
-      code: [
-        'class Foo extends React.PureComponent {',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.PureComponent {
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Has only displayName (method) and render
-      code: [
-        'class Foo extends React.Component {',
-        '  static get displayName() {',
-        '    return \'Foo\';',
-        '  }',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          static get displayName() {
+            return 'Foo';
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Has only displayName (property) and render
-      code: [
-        'class Foo extends React.Component {',
-        '  static displayName = \'Foo\';',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          static displayName = 'Foo';
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Has only propTypes (method) and render
-      code: [
-        'class Foo extends React.Component {',
-        '  static get propTypes() {',
-        '    return {',
-        '      name: PropTypes.string',
-        '    };',
-        '  }',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          static get propTypes() {
+            return {
+              name: PropTypes.string
+            };
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Has only propTypes (property) and render
-      code: [
-        'class Foo extends React.Component {',
-        '  static propTypes = {',
-        '    name: PropTypes.string',
-        '  };',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          static propTypes = {
+            name: PropTypes.string
+          };
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Has only props (type annotation) and render
-      code: [
-        'class Foo extends React.Component {',
-        '  props: {',
-        '    name: string;',
-        '  };',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          props: {
+            name: string;
+          };
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Has only useless constructor and render
-      code: [
-        'class Foo extends React.Component {',
-        '  constructor() {',
-        '    super();',
-        '  }',
-        '  render() {',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          constructor() {
+            super();
+          }
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Only use this.props and this.context (destructuring)
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    let {props:{foo}, context:{bar}} = this;',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            let {props:{foo}, context:{bar}} = this;
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Can return null (ES6)
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    if (!this.props.foo) {',
-        '      return null;',
-        '    }',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Can return null (ES5)
-      code: [
-        'var Foo = createReactClass({',
-        '  render: function() {',
-        '    if (!this.props.foo) {',
-        '      return null;',
-        '    }',
-        '    return <div>{this.props.foo}</div>;',
-        '  }',
-        '});'
-      ].join('\n'),
+      code: `
+        var Foo = createReactClass({
+          render: function() {
+            if (!this.props.foo) {
+              return null;
+            }
+            return <div>{this.props.foo}</div>;
+          }
+        });
+      `,
       errors: [{
         message: 'Component should be written as a pure function'
       }]
     }, {
-      // Can return null (shorthand if in return)
-      code: [
-        'class Foo extends React.Component {',
-        '  render() {',
-        '    return true ? <div /> : null;',
-        '  }',
-        '}'
-      ].join('\n'),
+      code: `
+        class Foo extends React.Component {
+          render() {
+            return true ? <div /> : null;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'

--- a/tests/lib/rules/react-in-jsx-scope.js
+++ b/tests/lib/rules/react-in-jsx-scope.js
@@ -42,17 +42,17 @@ ruleTester.run('react-in-jsx-scope', rule, {
     {code: 'var React, App; <App />;'},
     {code: '/** @jsx Foo */ var Foo, App; <App />;'},
     {code: '/** @jsx Foo.Bar */ var Foo, App; <App />;'},
-    {code: [
-      'import React from \'react/addons\';',
-      'const Button = createReactClass({',
-      '  render() {',
-      '    return (',
-      '      <button {...this.props}>{this.props.children}</button>',
-      '    )',
-      '  }',
-      '});',
-      'export default Button;'
-    ].join('\n')},
+    {code: `
+      import React from 'react/addons';
+      const Button = createReactClass({
+        render() {
+          return (
+            <button {...this.props}>{this.props.children}</button>
+          )
+        }
+      });
+      export default Button;
+    `},
     {code: 'var Foo, App; <App />;', settings: settings}
   ],
   invalid: [{

--- a/tests/lib/rules/require-optimization.js
+++ b/tests/lib/rules/require-optimization.js
@@ -21,168 +21,163 @@ const MESSAGE = 'Component is not optimized. Please add a shouldComponentUpdate 
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('react-require-optimization', rule, {
   valid: [{
-    code: [
-      'class A {}'
-    ].join('\n')
+    code: `
+      class A {}
+    `
   }, {
-    code: [
-      'import React from "react";' +
-      'class YourComponent extends React.Component {' +
-      'shouldComponentUpdate () {}' +
-      '}'
-    ].join('\n')
+    code: `
+      import React from "react";
+      class YourComponent extends React.Component {
+        shouldComponentUpdate () {}
+      }
+    `
   }, {
-    code: [
-      'import React, {Component} from "react";' +
-      'class YourComponent extends Component {' +
-      'shouldComponentUpdate () {}' +
-      '}'
-    ].join('\n')
+    code: `
+      import React, {Component} from "react";
+      class YourComponent extends Component {
+        shouldComponentUpdate () {}
+      }
+    `
   }, {
-    code: [
-      'import React, {Component} from "react";',
-      '@reactMixin.decorate(PureRenderMixin)',
-      'class YourComponent extends Component {',
-      '  componetnDidMount () {}',
-      '  render() {}',
-      '}'
-    ].join('\n'),
+    code: `
+      import React, {Component} from "react";
+      @reactMixin.decorate(PureRenderMixin)
+      class YourComponent extends Component {
+        componetnDidMount () {}
+        render() {}
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'import React from "react";' +
-      'createReactClass({' +
-      'shouldComponentUpdate: function () {}' +
-      '})'
-    ].join('\n')
+    code: `
+      import React from "react";
+      createReactClass({
+        shouldComponentUpdate: function () {}
+      })
+    `
   }, {
-    code: [
-      'import React from "react";' +
-      'createReactClass({' +
-      'mixins: [PureRenderMixin]' +
-      '})'
-    ].join('\n')
+    code: `
+      import React from "react";
+      createReactClass({
+        mixins: [PureRenderMixin]
+      })
+    `
   }, {
-    code: [
-      '@reactMixin.decorate(PureRenderMixin)',
-      'class DecoratedComponent extends Component {' +
-      '}'
-    ].join('\n'),
+    code: `
+      @reactMixin.decorate(PureRenderMixin)
+      class DecoratedComponent extends Component {}
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'const FunctionalComponent = function (props) {' +
-      'return <div />;' +
-      '}'
-    ].join('\n'),
+    code: `
+      const FunctionalComponent = function (props) {
+        return <div />;
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'function FunctionalComponent(props) {' +
-      'return <div />;' +
-      '}'
-    ].join('\n'),
+    code: `
+      function FunctionalComponent(props) {
+        return <div />;
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      'const FunctionalComponent = (props) => {' +
-      'return <div />;' +
-      '}'
-    ].join('\n'),
+    code: `
+      const FunctionalComponent = (props) => {
+        return <div />;
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    code: [
-      '@bar',
-      '@pureRender',
-      '@foo',
-      'class DecoratedComponent extends Component {' +
-      '}'
-    ].join('\n'),
+    code: `
+      @bar
+      @pureRender
+      @foo
+      class DecoratedComponent extends Component {}
+    `,
     parser: 'babel-eslint',
     options: [{allowDecorators: ['renderPure', 'pureRender']}]
   }, {
-    code: [
-      'import React from "react";' +
-      'class YourComponent extends React.PureComponent {}'
-    ].join('\n'),
+    code: `
+      import React from "react";
+      class YourComponent extends React.PureComponent {}
+    `,
     parser: 'babel-eslint',
     options: [{allowDecorators: ['renderPure', 'pureRender']}]
   }, {
-    code: [
-      'import React, {PureComponent} from "react";' +
-      'class YourComponent extends PureComponent {}'
-    ].join('\n'),
+    code: `
+      import React, {PureComponent} from "react";
+      class YourComponent extends PureComponent {}
+    `,
     parser: 'babel-eslint',
     options: [{allowDecorators: ['renderPure', 'pureRender']}]
   }],
 
   invalid: [{
-    code: [
-      'import React from "react";' +
-      'class YourComponent extends React.Component {}'
-    ].join('\n'),
+    code: `
+      import React from "react";
+      class YourComponent extends React.Component {}
+    `,
     errors: [{
       message: MESSAGE
     }]
   }, {
-    code: [
-      'import React from "react";',
-      'class YourComponent extends React.Component {',
-      '  handleClick() {}',
-      '  render() {',
-      '    return <div onClick={this.handleClick}>123</div>',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      import React from "react";
+      class YourComponent extends React.Component {
+        handleClick() {}
+        render() {
+          return <div onClick={this.handleClick}>123</div>
+        }
+      }
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: MESSAGE
     }]
   }, {
-    code: [
-      'import React, {Component} from "react";' +
-      'class YourComponent extends Component {}'
-    ].join('\n'),
+    code: `
+      import React, {Component} from "react";
+      class YourComponent extends Component {}
+    `,
     errors: [{
       message: MESSAGE
     }]
   }, {
-    code: [
-      'import React from "react";' +
-      'createReactClass({' +
-      '})'
-    ].join('\n'),
+    code: `
+      import React from "react";
+      createReactClass({})
+    `,
     errors: [{
       message: MESSAGE
     }]
   }, {
-    code: [
-      'import React from "react";' +
-      'createReactClass({' +
-      'mixins: [RandomMixin]' +
-      '})'
-    ].join('\n'),
+    code: `
+      import React from "react";
+      createReactClass({
+        mixins: [RandomMixin]
+      })
+    `,
     errors: [{
       message: MESSAGE
     }]
   }, {
-    code: [
-      '@reactMixin.decorate(SomeOtherMixin)',
-      'class DecoratedComponent extends Component {' +
-      '}'
-    ].join('\n'),
+    code: `
+      @reactMixin.decorate(SomeOtherMixin)
+      class DecoratedComponent extends Component {}
+    `,
     errors: [{
       message: MESSAGE
     }],
     parser: 'babel-eslint'
   }, {
-    code: [
-      '@bar',
-      '@pure',
-      '@foo',
-      'class DecoratedComponent extends Component {' +
-      '}'
-    ].join('\n'),
+    code: `
+      @bar
+      @pure
+      @foo
+      class DecoratedComponent extends Component {}
+    `,
     errors: [{
       message: MESSAGE
     }],

--- a/tests/lib/rules/require-render-return.js
+++ b/tests/lib/rules/require-render-return.js
@@ -30,6 +30,7 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('require-render-return', rule, {
 
   valid: [{
+    // ES6 class
     code: `
       class Hello extends React.Component {
         render() {
@@ -38,6 +39,7 @@ ruleTester.run('require-render-return', rule, {
       }
     `
   }, {
+    // ES6 class with render property
     code: `
       class Hello extends React.Component {
         render = () => {
@@ -47,6 +49,7 @@ ruleTester.run('require-render-return', rule, {
     `,
     parser: 'babel-eslint'
   }, {
+    // ES6 class with render property (implicit return)
     code: `
       class Hello extends React.Component {
         render = () => (
@@ -56,6 +59,7 @@ ruleTester.run('require-render-return', rule, {
     `,
     parser: 'babel-eslint'
   }, {
+    // ES5 class
     code: `
       var Hello = createReactClass({
         displayName: 'Hello',
@@ -65,12 +69,14 @@ ruleTester.run('require-render-return', rule, {
       });
     `
   }, {
+    // Stateless function
     code: `
       function Hello() {
         return <div></div>;
       }
     `
   }, {
+    // Stateless arrow function
     code: `
       var Hello = () => (
         <div></div>
@@ -78,6 +84,7 @@ ruleTester.run('require-render-return', rule, {
     `,
     parser: 'babel-eslint'
   }, {
+    // Return in a switch...case
     code: `
       var Hello = createReactClass({
         render: function() {
@@ -91,6 +98,7 @@ ruleTester.run('require-render-return', rule, {
       });
     `
   }, {
+    // Return in a if...else
     code: `
       var Hello = createReactClass({
         render: function() {
@@ -103,6 +111,7 @@ ruleTester.run('require-render-return', rule, {
       });
     `
   }, {
+    // Not a React component
     code: `
       class Hello {
         render() {}
@@ -115,6 +124,7 @@ ruleTester.run('require-render-return', rule, {
     // ES5 class without a render method
     code: 'var Hello = createReactClass({});'
   }, {
+    // ES5 class with an imported render method
     code: `
       var render = require('./render');
       var Hello = createReactClass({
@@ -122,6 +132,7 @@ ruleTester.run('require-render-return', rule, {
       });
     `
   }, {
+    // Invalid render method (but accepted by Babel)
     code: `
       class Foo extends Component {
         render
@@ -131,6 +142,7 @@ ruleTester.run('require-render-return', rule, {
   }],
 
   invalid: [{
+    // Missing return in ES5 class
     code: `
       var Hello = createReactClass({
         displayName: 'Hello',
@@ -141,6 +153,7 @@ ruleTester.run('require-render-return', rule, {
       message: 'Your render method should have return statement'
     }]
   }, {
+    // Missing return in ES6 class
     code: `
       class Hello extends React.Component {
         render() {} 
@@ -150,6 +163,7 @@ ruleTester.run('require-render-return', rule, {
       message: 'Your render method should have return statement'
     }]
   }, {
+    // Missing return (but one is present in a sub-function)
     code: `
       class Hello extends React.Component {
         render() {
@@ -163,6 +177,7 @@ ruleTester.run('require-render-return', rule, {
       message: 'Your render method should have return statement'
     }]
   }, {
+    // Missing return ES6 class render property
     code: `
       class Hello extends React.Component {
         render = () => {

--- a/tests/lib/rules/require-render-return.js
+++ b/tests/lib/rules/require-render-return.js
@@ -30,93 +30,84 @@ const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('require-render-return', rule, {
 
   valid: [{
-    // ES6 class
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n')
+    code: `
+      class Hello extends React.Component {
+        render() {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `
   }, {
-    // ES6 class with render property
-    code: [
-      'class Hello extends React.Component {',
-      '  render = () => {',
-      '    return <div>Hello {this.props.name}</div>;',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render = () => {
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    // ES6 class with render property (implicit return)
-    code: [
-      'class Hello extends React.Component {',
-      '  render = () => (',
-      '    <div>Hello {this.props.name}</div>',
-      '  )',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render = () => (
+          <div>Hello {this.props.name}</div>
+        )
+      }
+    `,
     parser: 'babel-eslint'
   }, {
-    // ES5 class
-    code: [
-      'var Hello = createReactClass({',
-      '  displayName: \'Hello\',',
-      '  render: function() {',
-      '    return <div></div>',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        displayName: 'Hello',
+        render: function() {
+          return <div></div>
+        }
+      });
+    `
   }, {
-    // Stateless function
-    code: [
-      'function Hello() {',
-      '  return <div></div>;',
-      '}'
-    ].join('\n')
+    code: `
+      function Hello() {
+        return <div></div>;
+      }
+    `
   }, {
-    // Stateless arrow function
-    code: [
-      'var Hello = () => (',
-      '  <div></div>',
-      ');'
-    ].join('\n'),
+    code: `
+      var Hello = () => (
+        <div></div>
+      );
+    `,
     parser: 'babel-eslint'
   }, {
-    // Return in a switch...case
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    switch (this.props.name) {',
-      '      case \'Foo\':',
-      '        return <div>Hello Foo</div>;',
-      '      default:',
-      '        return <div>Hello {this.props.name}</div>;',
-      '    }',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          switch (this.props.name) {
+            case 'Foo':
+              return <div>Hello Foo</div>;
+            default:
+              return <div>Hello {this.props.name}</div>;
+          }
+        }
+      });
+    `
   }, {
-    // Return in a if...else
-    code: [
-      'var Hello = createReactClass({',
-      '  render: function() {',
-      '    if (this.props.name === \'Foo\') {',
-      '      return <div>Hello Foo</div>;',
-      '    } else {',
-      '      return <div>Hello {this.props.name}</div>;',
-      '    }',
-      '  }',
-      '});'
-    ].join('\n')
+    code: `
+      var Hello = createReactClass({
+        render: function() {
+          if (this.props.name === 'Foo') {
+            return <div>Hello Foo</div>;
+          } else {
+            return <div>Hello {this.props.name}</div>;
+          }
+        }
+      });
+    `
   }, {
-    // Not a React component
-    code: [
-      'class Hello {',
-      '  render() {}',
-      '}'
-    ].join('\n')
+    code: `
+      class Hello {
+        render() {}
+      }
+    `
   }, {
     // ES6 class without a render method
     code: 'class Hello extends React.Component {}'
@@ -124,67 +115,61 @@ ruleTester.run('require-render-return', rule, {
     // ES5 class without a render method
     code: 'var Hello = createReactClass({});'
   }, {
-    // ES5 class with an imported render method
-    code: [
-      'var render = require(\'./render\');',
-      'var Hello = createReactClass({',
-      '  render',
-      '});'
-    ].join('\n')
+    code: `
+      var render = require('./render');
+      var Hello = createReactClass({
+        render
+      });
+    `
   }, {
-    // Invalid render method (but accepted by Babel)
-    code: [
-      'class Foo extends Component {',
-      '  render',
-      '}'
-    ].join('\n'),
+    code: `
+      class Foo extends Component {
+        render
+      }
+    `,
     parser: 'babel-eslint'
   }],
 
   invalid: [{
-    // Missing return in ES5 class
-    code: [
-      'var Hello = createReactClass({',
-      '  displayName: \'Hello\',',
-      '  render: function() {}',
-      '});'
-    ].join('\n'),
+    code: `
+      var Hello = createReactClass({
+        displayName: 'Hello',
+        render: function() {}
+      });
+    `,
     errors: [{
       message: 'Your render method should have return statement'
     }]
   }, {
-    // Missing return in ES6 class
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {} ',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render() {} 
+      }
+    `,
     errors: [{
       message: 'Your render method should have return statement'
     }]
   }, {
-    // Missing return (but one is present in a sub-function)
-    code: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    const names = this.props.names.map(function(name) {',
-      '      return <div>{name}</div>',
-      '    });',
-      '  } ',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render() {
+          const names = this.props.names.map(function(name) {
+            return <div>{name}</div>
+          });
+        } 
+      }
+    `,
     errors: [{
       message: 'Your render method should have return statement'
     }]
   }, {
-    // Missing return ES6 class render property
-    code: [
-      'class Hello extends React.Component {',
-      '  render = () => {',
-      '    <div>Hello {this.props.name}</div>',
-      '  }',
-      '}'
-    ].join('\n'),
+    code: `
+      class Hello extends React.Component {
+        render = () => {
+          <div>Hello {this.props.name}</div>
+        }
+      }
+    `,
     parser: 'babel-eslint',
     errors: [{
       message: 'Your render method should have return statement'


### PR DESCRIPTION
I wanted to experiment writing a code mod and decided to write one to transform the `code: [].join('\n');` syntax to use template literals instead.

I ran it on a file by file basis. I could not transform all the files yet because template literals introduce the following issues:

* Error lines / columns are different. Since my syntax adds 1 extra line + a lot of indentation, those numbers change
* Output often also doesn't work because of the added indentation in the code through the template literal sting

But a lot of files didn't rely on this so at least we could start with transforming those 😄 

Here's the codemod code: https://astexplorer.net/#/gist/000b6e8110a245ca6384c260b954e452/1687ee893085fdae7119c809294e5ed43a3fe428