### PR TITLE
[jsx-curly-brace-presence] Bail out in warning JSX expression when some chars exist

### DIFF
--- a/docs/rules/jsx-curly-brace-presence.md
+++ b/docs/rules/jsx-curly-brace-presence.md
@@ -122,7 +122,7 @@ will be warned and fixed to:
 <App prop="Hello world">Hello world</App>;
 ```
 
-* If the rule is set to enforce curly braces and the strings have quotes, it will be fixed with double quotes for JSX children and the normal way for JSX attributes.
+* If the rule is set to enforce curly braces and the strings have quotes, it will be fixed with double quotes for JSX children and the normal way for JSX attributes. Also, double quotes will be escaped in the fix.
 
 For example:
 
@@ -137,12 +137,14 @@ will warned and fixed to:
 <App prop={"Hello \"foo\" world"}>{"Hello 'foo' \"bar\" world"}</App>;
 ```
 
-* If the rule is set to get rid of unnecessary curly braces and the strings have escaped characters, it will not warn or fix for JSX children because JSX expressions are necessary in this case. For instance:
+* If the rule is set to get rid of unnecessary curly braces(JSX expression) and there are characters that need to be escaped in its JSX form, such as quote characters, [forbidden JSX text characters](https://facebook.github.io/jsx/), escaped characters and anything that looks like HTML names, the code will not be warned because the fix may make the code less readable.
 
 The following pattern will not be given a warning even if `'never'` is passed.
 
 ```jsx
+<Color text={"\u00a0"} />
 <App>{"Hello \u00b7 world"}</App>;
+<style type="text/css">{'.main { margin-top: 0; }'}</style>;
 ```
 
 ## When Not To Use It

--- a/docs/rules/jsx-curly-brace-presence.md
+++ b/docs/rules/jsx-curly-brace-presence.md
@@ -137,7 +137,7 @@ will warned and fixed to:
 <App prop={"Hello \"foo\" world"}>{"Hello 'foo' \"bar\" world"}</App>;
 ```
 
-* If the rule is set to get rid of unnecessary curly braces(JSX expression) and there are characters that need to be escaped in its JSX form, such as quote characters, [forbidden JSX text characters](https://facebook.github.io/jsx/), escaped characters and anything that looks like HTML names, the code will not be warned because the fix may make the code less readable.
+* If the rule is set to get rid of unnecessary curly braces(JSX expression) and there are characters that need to be escaped in its JSX form, such as quote characters, [forbidden JSX text characters](https://facebook.github.io/jsx/), escaped characters and anything that looks like HTML entity names, the code will not be warned because the fix may make the code less readable.
 
 The following pattern will not be given a warning even if `'never'` is passed.
 

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -59,12 +59,37 @@ module.exports = {
       {props: ruleOptions, children: ruleOptions} :
       Object.assign({}, DEFAULT_CONFIG, ruleOptions);
 
-    function containsBackslashForEscaping(rawStringValue) {
+    function containsBackslash(rawStringValue) {
       return rawStringValue.includes('\\');
+    }
+
+    function containsHTMLEntity(rawStringValue) {
+      return rawStringValue.match(/&([A-Za-z\d]+);/g);
+    }
+
+    function containsDisallowedJSXTextChars(rawStringValue) {
+      return rawStringValue.match(/{|<|>|}/g);
+    }
+
+    function containsQuoteCharacters(value) {
+      return value.match(/'|"/g);
     }
 
     function escapeDoubleQuotes(rawStringValue) {
       return rawStringValue.replace(/\\"/g, '"').replace(/"/g, '\\"');
+    }
+
+    function escapeBackslashes(rawStringValue) {
+      return rawStringValue.replace(/\\/g, '\\\\');
+    }
+
+    function needToEscapeCharacterForJSX(raw, cooked) {
+      return (
+        containsBackslash(raw) ||
+        containsHTMLEntity(raw) ||
+        containsDisallowedJSXTextChars(raw) ||
+        containsQuoteCharacters(cooked)
+      );
     }
 
     /**
@@ -83,11 +108,10 @@ module.exports = {
 
           let textToReplace;
           if (parentType === 'JSXAttribute') {
-            textToReplace = `"${escapeDoubleQuotes(
-              expressionType === 'TemplateLiteral' ?
-                expression.quasis[0].value.raw :
-                expression.raw.substring(1, expression.raw.length - 1)
-            )}"`;
+            textToReplace = `"${expressionType === 'TemplateLiteral' ?
+              expression.quasis[0].value.raw :
+              expression.raw.substring(1, expression.raw.length - 1)
+            }"`;
           } else {
             textToReplace = expressionType === 'TemplateLiteral' ?
               expression.quasis[0].value.cooked : expression.value;
@@ -103,10 +127,16 @@ module.exports = {
         node: literalNode,
         message: 'Need to wrap this literal in a JSX expression.',
         fix: function(fixer) {
+          // Leave it to the author to fix as it can be fixed by either a
+          // real character or unicode
+          if (containsHTMLEntity(literalNode.raw)) {
+            return null;
+          }
+
           const expression = literalNode.parent.type === 'JSXAttribute' ?
-            `{"${escapeDoubleQuotes(
+            `{"${escapeDoubleQuotes(escapeBackslashes(
               literalNode.raw.substring(1, literalNode.raw.length - 1)
-            )}"}` :
+            ))}"}` :
             `{${JSON.stringify(literalNode.value)}}`;
 
           return fixer.replaceText(literalNode, expression);
@@ -114,23 +144,25 @@ module.exports = {
       });
     }
 
+    // Bail out if there is any character that needs to be escaped in JSX
+    // because escaping decreases readiblity and the original code may be more
+    // readible anyway or intentional for other specific reasons
     function lintUnnecessaryCurly(JSXExpressionNode) {
       const expression = JSXExpressionNode.expression;
       const expressionType = expression.type;
-      const parentType = JSXExpressionNode.parent.type;
 
       if (
         expressionType === 'Literal' &&
-          typeof expression.value === 'string' && (
-          parentType === 'JSXAttribute' ||
-          !containsBackslashForEscaping(expression.raw))
+          typeof expression.value === 'string' &&
+          !needToEscapeCharacterForJSX(expression.raw, expression.value)
       ) {
         reportUnnecessaryCurly(JSXExpressionNode);
       } else if (
         expressionType === 'TemplateLiteral' &&
-          expression.expressions.length === 0 && (
-          parentType === 'JSXAttribute' ||
-          !containsBackslashForEscaping(expression.quasis[0].value.raw))
+          expression.expressions.length === 0 &&
+          !needToEscapeCharacterForJSX(
+            expression.quasis[0].value.raw, expression.quasis[0].value.cooked
+          )
       ) {
         reportUnnecessaryCurly(JSXExpressionNode);
       }
@@ -170,17 +202,13 @@ module.exports = {
 
     return {
       JSXExpressionContainer: node => {
-        const parent = node.parent;
-
-        if (shouldCheckForUnnecessaryCurly(parent, userConfig)) {
+        if (shouldCheckForUnnecessaryCurly(node.parent, userConfig)) {
           lintUnnecessaryCurly(node);
         }
       },
 
       Literal: node => {
-        const parentType = node.parent.type;
-
-        if (shouldCheckForMissingCurly(parentType, userConfig)) {
+        if (shouldCheckForMissingCurly(node.parent.type, userConfig)) {
           reportMissingCurly(node);
         }
       }

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -69,7 +69,7 @@ module.exports = {
     }
 
     function containsHTMLEntity(rawStringValue) {
-      return /&([A-Za-z\d#]+);/.test(rawStringValue);
+      return /&[A-Za-z\d#]+;/.test(rawStringValue);
     }
 
     function containsDisallowedJSXTextChars(rawStringValue) {

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Enforce curly braces or disallow unnecessary curly brace in JSX
  * @author Jacky Ho
+ * @author Simon Lydell
  */
 'use strict';
 

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -60,7 +60,7 @@ module.exports = {
       Object.assign({}, DEFAULT_CONFIG, ruleOptions);
 
     function containsLineTerminators(rawStringValue) {
-      return /[\n\r\u2028\u2029]+/.test(rawStringValue);
+      return /[\n\r\u2028\u2029]/.test(rawStringValue);
     }
 
     function containsBackslash(rawStringValue) {

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -64,15 +64,15 @@ module.exports = {
     }
 
     function containsHTMLEntity(rawStringValue) {
-      return rawStringValue.match(/&([A-Za-z\d]+);/g);
+      return /&([A-Za-z\d#]+);/.test(rawStringValue);
     }
 
     function containsDisallowedJSXTextChars(rawStringValue) {
-      return rawStringValue.match(/{|<|>|}/g);
+      return /[{<>}]/.test(rawStringValue);
     }
 
     function containsQuoteCharacters(value) {
-      return value.match(/'|"/g);
+      return /['"]/.test(value);
     }
 
     function escapeDoubleQuotes(rawStringValue) {
@@ -83,19 +83,17 @@ module.exports = {
       return rawStringValue.replace(/\\/g, '\\\\');
     }
 
-    function needToEscapeCharacterForJSX(raw, cooked) {
+    function needToEscapeCharacterForJSX(raw) {
       return (
         containsBackslash(raw) ||
         containsHTMLEntity(raw) ||
-        containsDisallowedJSXTextChars(raw) ||
-        containsQuoteCharacters(cooked)
+        containsDisallowedJSXTextChars(raw)
       );
     }
 
     /**
      * Report and fix an unnecessary curly brace violation on a node
      * @param {ASTNode} node - The AST node with an unnecessary JSX expression
-     * @param {String} text - The text to replace the unnecessary JSX expression
      */
     function reportUnnecessaryCurly(JSXExpressionNode) {
       context.report({
@@ -150,19 +148,24 @@ module.exports = {
     function lintUnnecessaryCurly(JSXExpressionNode) {
       const expression = JSXExpressionNode.expression;
       const expressionType = expression.type;
+      const parentType = JSXExpressionNode.parent.type;
 
       if (
         expressionType === 'Literal' &&
           typeof expression.value === 'string' &&
-          !needToEscapeCharacterForJSX(expression.raw, expression.value)
+          !needToEscapeCharacterForJSX(expression.raw) && (
+          parentType === 'JSXElement' ||
+          !containsQuoteCharacters(expression.value)
+        )
       ) {
         reportUnnecessaryCurly(JSXExpressionNode);
       } else if (
         expressionType === 'TemplateLiteral' &&
           expression.expressions.length === 0 &&
-          !needToEscapeCharacterForJSX(
-            expression.quasis[0].value.raw, expression.quasis[0].value.cooked
-          )
+          !needToEscapeCharacterForJSX(expression.quasis[0].value.raw) && (
+          parentType === 'JSXElement' ||
+          !containsQuoteCharacters(expression.quasis[0].value.cooked)
+        )
       ) {
         reportUnnecessaryCurly(JSXExpressionNode);
       }

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -59,6 +59,10 @@ module.exports = {
       {props: ruleOptions, children: ruleOptions} :
       Object.assign({}, DEFAULT_CONFIG, ruleOptions);
 
+    function containsLineTerminators(rawStringValue) {
+      return /[\n\r\u2028\u2029]+/.test(rawStringValue);
+    }
+
     function containsBackslash(rawStringValue) {
       return rawStringValue.includes('\\');
     }
@@ -125,9 +129,13 @@ module.exports = {
         node: literalNode,
         message: 'Need to wrap this literal in a JSX expression.',
         fix: function(fixer) {
-          // Leave it to the author to fix as it can be fixed by either a
-          // real character or unicode
-          if (containsHTMLEntity(literalNode.raw)) {
+          // If a HTML entity name is found, bail out because it can be fixed
+          // by either using the real character or the unicode equivalent.
+          // If it contains any line terminator character, bail out as well.
+          if (
+            containsHTMLEntity(literalNode.raw) ||
+            containsLineTerminators(literalNode.raw)
+          ) {
             return null;
           }
 

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+/* eslint-disable quotes */ // For better readability on tests involving quotes
+
 // ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
@@ -71,7 +73,7 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       code: '<App>{"foo"}{<Component>bar</Component>}</App>'
     },
     {
-      code: '<App prop=\'bar\'>foo</App>'
+      code: `<App prop='bar'>foo</App>`
     },
     {
       code: '<App prop={true}>foo</App>'
@@ -80,14 +82,14 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       code: '<App prop>foo</App>'
     },
     {
-      code: '<App prop=\'bar\'>{\'foo \\n bar\'}</App>'
+      code: `<App prop='bar'>{'foo \\n bar'}</App>`
     },
     {
-      code: '<MyComponent prop=\'bar\'>foo</MyComponent>',
+      code: `<MyComponent prop='bar'>foo</MyComponent>`,
       options: [{props: 'never'}]
     },
     {
-      code: '<MyComponent prop=\"bar\">foo</MyComponent>',
+      code: `<MyComponent prop="bar">foo</MyComponent>`,
       options: [{props: 'never'}]
     },
     {
@@ -99,31 +101,31 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       options: [{children: 'never'}]
     },
     {
-      code: '<App>{\"foo \'bar\' \\\"foo\\\" bar\"}</App>',
+      code: `<App>{"foo 'bar' \\"foo\\" bar"}</App>`,
       options: [{children: 'never'}]
     },
     {
-      code: '<MyComponent prop={\'bar\'}>foo</MyComponent>',
+      code: `<MyComponent prop={'bar'}>foo</MyComponent>`,
       options: [{props: 'always'}]
     },
     {
-      code: '<MyComponent>{\'foo\'}</MyComponent>',
+      code: `<MyComponent>{'foo'}</MyComponent>`,
       options: [{children: 'always'}]
     },
     {
-      code: '<MyComponent prop={\"bar\"}>foo</MyComponent>',
+      code: `<MyComponent prop={"bar"}>foo</MyComponent>`,
       options: [{props: 'always'}]
     },
     {
-      code: '<MyComponent>{\"foo\"}</MyComponent>',
+      code: `<MyComponent>{"foo"}</MyComponent>`,
       options: [{children: 'always'}]
     },
     {
-      code: '<MyComponent>{\'foo\'}</MyComponent>',
+      code: `<MyComponent>{'foo'}</MyComponent>`,
       options: [{children: 'ignore'}]
     },
     {
-      code: '<MyComponent prop={\'bar\'}>foo</MyComponent>',
+      code: `<MyComponent prop={'bar'}>foo</MyComponent>`,
       options: [{props: 'ignore'}]
     },
     {
@@ -131,39 +133,39 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       options: [{children: 'ignore'}]
     },
     {
-      code: '<MyComponent prop=\'bar\'>foo</MyComponent>',
+      code: `<MyComponent prop='bar'>foo</MyComponent>`,
       options: [{props: 'ignore'}]
     },
     {
-      code: '<MyComponent prop=\"bar\">foo</MyComponent>',
+      code: `<MyComponent prop="bar">foo</MyComponent>`,
       options: [{props: 'ignore'}]
     },
     {
-      code: '<MyComponent prop=\'bar\'>{\'foo\'}</MyComponent>',
+      code: `<MyComponent prop='bar'>{'foo'}</MyComponent>`,
       options: [{children: 'always', props: 'never'}]
     },
     {
-      code: '<MyComponent prop={\'bar\'}>foo</MyComponent>',
+      code: `<MyComponent prop={'bar'}>foo</MyComponent>`,
       options: [{children: 'never', props: 'always'}]
     },
     {
-      code: '<MyComponent prop={\'bar\'}>{\'foo\'}</MyComponent>',
+      code: `<MyComponent prop={'bar'}>{'foo'}</MyComponent>`,
       options: ['always']
     },
     {
-      code: '<MyComponent prop={\"bar\"}>{\"foo\"}</MyComponent>',
+      code: `<MyComponent prop={"bar"}>{"foo"}</MyComponent>`,
       options: ['always']
     },
     {
-      code: '<MyComponent prop={\"bar\"} attr={\'foo\'} />',
+      code: `<MyComponent prop={"bar"} attr={'foo'} />`,
       options: ['always']
     },
     {
-      code: '<MyComponent prop=\"bar\" attr=\'foo\' />',
+      code: `<MyComponent prop="bar" attr='foo' />`,
       options: ['never']
     },
     {
-      code: '<MyComponent prop=\'bar\'>foo</MyComponent>',
+      code: `<MyComponent prop='bar'>foo</MyComponent>`,
       options: ['never']
     },
     {
@@ -232,148 +234,170 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       errors: [{message: unnecessaryCurlyMessage}]
     },
     {
-      code: '<MyComponent>{\'foo\'}</MyComponent>',
+      code: `<MyComponent>{'foo'}</MyComponent>`,
       output: '<MyComponent>foo</MyComponent>',
       errors: [{message: unnecessaryCurlyMessage}]
     },
     {
-      code: '<MyComponent prop={\'bar\'}>foo</MyComponent>',
-      output: '<MyComponent prop=\"bar\">foo</MyComponent>',
+      code: `<MyComponent prop={'bar'}>foo</MyComponent>`,
+      output: `<MyComponent prop="bar">foo</MyComponent>`,
       errors: [{message: unnecessaryCurlyMessage}]
     },
     {
-      code: '<MyComponent>{\'foo\'}</MyComponent>',
+      code: `<MyComponent>{'foo'}</MyComponent>`,
       output: '<MyComponent>foo</MyComponent>',
       options: [{children: 'never'}],
       errors: [{message: unnecessaryCurlyMessage}]
     },
     {
-      code: '<MyComponent prop={\'bar\'}>foo</MyComponent>',
-      output: '<MyComponent prop=\"bar\">foo</MyComponent>',
+      code: `<MyComponent prop={'bar'}>foo</MyComponent>`,
+      output: '<MyComponent prop="bar">foo</MyComponent>',
       options: [{props: 'never'}],
       errors: [{message: unnecessaryCurlyMessage}]
     },
     {
-      code: '<MyComponent prop=\'bar\'>foo</MyComponent>',
-      output: '<MyComponent prop={\"bar\"}>foo</MyComponent>',
+      code: `<MyComponent prop='bar'>foo</MyComponent>`,
+      output: '<MyComponent prop={"bar"}>foo</MyComponent>',
       options: [{props: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
-      code: '<MyComponent prop=\"foo \'bar\'\">foo</MyComponent>',
-      output: '<MyComponent prop={\"foo \'bar\'\"}>foo</MyComponent>',
+      code: `<MyComponent prop="foo 'bar'">foo</MyComponent>`,
+      output: `<MyComponent prop={"foo 'bar'"}>foo</MyComponent>`,
       options: [{props: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
-      code: '<MyComponent prop=\'foo "bar"\'>foo</MyComponent>',
-      output: '<MyComponent prop={\"foo \\\"bar\\\"\"}>foo</MyComponent>',
+      code: `<MyComponent prop='foo "bar"'>foo</MyComponent>`,
+      output: `<MyComponent prop={"foo \\"bar\\""}>foo</MyComponent>`,
       options: [{props: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
-      code: '<MyComponent prop=\"foo \'bar\'\">foo</MyComponent>',
-      output: '<MyComponent prop={\"foo \'bar\'\"}>foo</MyComponent>',
+      code: `<MyComponent prop="foo 'bar'">foo</MyComponent>`,
+      output: `<MyComponent prop={"foo 'bar'"}>foo</MyComponent>`,
       options: [{props: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
       code: '<MyComponent>foo bar </MyComponent>',
-      output: '<MyComponent>{\"foo bar \"}</MyComponent>',
+      output: `<MyComponent>{"foo bar "}</MyComponent>`,
       options: [{children: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
-      code: '<MyComponent>foo bar \'foo\'</MyComponent>',
-      output: '<MyComponent>{\"foo bar \'foo\'\"}</MyComponent>',
+      code: `<MyComponent prop="foo 'bar' \\n ">foo</MyComponent>`,
+      output: `<MyComponent prop={"foo 'bar' \\\\n "}>foo</MyComponent>`,
+      options: [{props: 'always'}],
+      errors: [{message: missingCurlyMessage}]
+    },
+    {
+      code: '<MyComponent>foo bar \\r </MyComponent>',
+      output: '<MyComponent>{"foo bar \\\\r "}</MyComponent>',
       options: [{children: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
-      code: '<MyComponent>foo bar \"foo\"</MyComponent>',
-      output: '<MyComponent>{\"foo bar \\\"foo\\\"\"}</MyComponent>',
+      code: `<MyComponent>foo bar 'foo'</MyComponent>`,
+      output: `<MyComponent>{"foo bar 'foo'"}</MyComponent>`,
+      options: [{children: 'always'}],
+      errors: [{message: missingCurlyMessage}]
+    },
+    {
+      code: '<MyComponent>foo bar "foo"</MyComponent>',
+      output: '<MyComponent>{"foo bar \\"foo\\""}</MyComponent>',
       options: [{children: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
       code: '<MyComponent>foo bar <App/></MyComponent>',
-      output: '<MyComponent>{\"foo bar \"}<App/></MyComponent>',
+      output: '<MyComponent>{"foo bar "}<App/></MyComponent>',
       options: [{children: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
       code: '<MyComponent>foo \\n bar</MyComponent>',
-      output: '<MyComponent>{\"foo \\\\n bar\"}</MyComponent>',
+      output: '<MyComponent>{"foo \\\\n bar"}</MyComponent>',
       options: [{children: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
       code: '<MyComponent>foo \\u1234 bar</MyComponent>',
-      output: '<MyComponent>{\"foo \\\\u1234 bar\"}</MyComponent>',
+      output: '<MyComponent>{"foo \\\\u1234 bar"}</MyComponent>',
       options: [{children: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
-      code: '<MyComponent prop=\'foo \\u1234 bar\' />',
+      code: `<MyComponent prop='foo \\u1234 bar' />`,
       output: '<MyComponent prop={"foo \\\\u1234 bar"} />',
       options: [{props: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
-      code: '<MyComponent prop={\'bar\'}>{\'foo\'}</MyComponent>',
-      output: '<MyComponent prop=\"bar\">foo</MyComponent>',
+      code: `<MyComponent prop={'bar'}>{'foo'}</MyComponent>`,
+      output: '<MyComponent prop="bar">foo</MyComponent>',
       options: ['never'],
       errors: [
         {message: unnecessaryCurlyMessage}, {message: unnecessaryCurlyMessage}
       ]
     },
     {
-      code: '<MyComponent prop=\'bar\'>foo</MyComponent>',
-      output: '<MyComponent prop={\"bar\"}>{\"foo\"}</MyComponent>',
+      code: `<MyComponent prop='bar'>foo</MyComponent>`,
+      output: '<MyComponent prop={"bar"}>{"foo"}</MyComponent>',
       options: ['always'],
       errors: [
         {message: missingCurlyMessage}, {message: missingCurlyMessage}
       ]
     },
     {
-      code: '<App prop={\'foo\'} attr={\" foo \"} />',
-      output: '<App prop=\"foo\" attr=\" foo \" />',
+      code: `<App prop={'foo'} attr={" foo "} />`,
+      output: '<App prop="foo" attr=" foo " />',
       errors: [
         {message: unnecessaryCurlyMessage}, {message: unnecessaryCurlyMessage}
       ],
       options: [{props: 'never'}]
     },
     {
-      code: '<App prop=\'foo\' attr=\"bar\" />',
-      output: '<App prop={\"foo\"} attr={\"bar\"} />',
+      code: `<App prop='foo' attr="bar" />`,
+      output: '<App prop={"foo"} attr={"bar"} />',
       errors: [
         {message: missingCurlyMessage}, {message: missingCurlyMessage}
       ],
       options: [{props: 'always'}]
     },
     {
-      code: '<App prop=\'foo\' attr={\"bar\"} />',
-      output: '<App prop={\"foo\"} attr={\"bar\"} />',
+      code: `<App prop='foo' attr={"bar"} />`,
+      output: `<App prop={"foo"} attr={"bar"} />`,
       errors: [{message: missingCurlyMessage}],
       options: [{props: 'always'}]
     },
     {
-      code: '<App prop={\'foo\'} attr=\'bar\' />',
-      output: '<App prop={\'foo\'} attr={\"bar\"} />',
+      code: `<App prop={'foo'} attr='bar' />`,
+      output: `<App prop={'foo'} attr={"bar"} />`,
       errors: [{message: missingCurlyMessage}],
       options: [{props: 'always'}]
     },
     {
-      code: '<App prop=\'foo &middot; bar\' />',
-      output: '<App prop=\'foo &middot; bar\' />',
+      code: `<App prop='foo &middot; bar' />`,
       errors: [{message: missingCurlyMessage}],
       options: [{props: 'always'}]
     },
     {
       code: '<App>foo &middot; bar</App>',
-      output: '<App>foo &middot; bar</App>',
       errors: [{message: missingCurlyMessage}],
       options: [{children: 'always'}]
+    },
+    {
+      code: `<App>{'foo "bar"'}</App>`,
+      output: `<App>foo "bar"</App>`,
+      errors: [{message: unnecessaryCurlyMessage}],
+      options: [{children: 'never'}]
+    },
+    {
+      code: `<App>{"foo 'bar'"}</App>`,
+      output: `<App>foo 'bar'</App>`,
+      errors: [{message: unnecessaryCurlyMessage}],
+      options: [{children: 'never'}]
     }
   ]
 });

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -169,6 +169,46 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
     {
       code: '<MyComponent prop={`bar ${word} foo`}>{`foo ${word}`}</MyComponent>',
       options: ['never']
+    },
+    {
+      code: '<MyComponent>{"div { margin-top: 0; }"}</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent>{"<Foo />"}</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent prop={"{ style: true }"}>bar</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent prop={"< style: true >"}>foo</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent prop={"Hello \\u1026 world"}>bar</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent>{"Hello \\u1026 world"}</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent prop={"Hello &middot; world"}>bar</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent>{"Hello &middot; world"}</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent>{"Hello \\n world"}</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: ['<a a={"start\\', '\\', 'end"}/>'].join('/n'),
+      options: ['never']
     }
   ],
 
@@ -176,42 +216,6 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
     {
       code: '<App prop={`foo`} />',
       output: '<App prop="foo" />',
-      options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<App prop={\'foo \\u00b7 bar\'}>foo</App>',
-      output: '<App prop=\"foo \\u00b7 bar\">foo</App>',
-      options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<App prop={`foo \\n bar`}>foo</App>',
-      output: '<App prop="foo \\n bar">foo</App>',
-      options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<App prop={`foo \\u00b7 bar`}>foo</App>',
-      output: '<App prop="foo \\u00b7 bar">foo</App>',
-      options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<App prop={`foo \\\'foo\\\' bar`}>foo</App>',
-      output: '<App prop="foo \\\'foo\\\' bar">foo</App>',
-      options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<App prop={`foo \\\"foo\\\" bar`}>foo</App>',
-      output: '<App prop="foo \\\"foo\\\" bar">foo</App>',
-      options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<App prop={`foo "foo" bar`}>foo</App>',
-      output: '<App prop="foo \\\"foo\\\" bar">foo</App>',
       options: [{props: 'never'}],
       errors: [{message: unnecessaryCurlyMessage}]
     },
@@ -228,12 +232,6 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       errors: [{message: unnecessaryCurlyMessage}]
     },
     {
-      code: '<App>{`foo "foo" bar`}</App>',
-      output: '<App>foo "foo" bar</App>',
-      options: [{children: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
       code: '<MyComponent>{\'foo\'}</MyComponent>',
       output: '<MyComponent>foo</MyComponent>',
       errors: [{message: unnecessaryCurlyMessage}]
@@ -252,18 +250,6 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
     {
       code: '<MyComponent prop={\'bar\'}>foo</MyComponent>',
       output: '<MyComponent prop=\"bar\">foo</MyComponent>',
-      options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<MyComponent prop={\"bar \'foo\' \"}>foo</MyComponent>',
-      output: '<MyComponent prop=\"bar \'foo\' \">foo</MyComponent>',
-      options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<MyComponent prop={\'bar \"foo\" \'}>foo</MyComponent>',
-      output: '<MyComponent prop=\"bar \\\"foo\\\" \">foo</MyComponent>',
       options: [{props: 'never'}],
       errors: [{message: unnecessaryCurlyMessage}]
     },
@@ -316,9 +302,21 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       errors: [{message: missingCurlyMessage}]
     },
     {
-      code: '<MyComponent>foo\\nbar</MyComponent>',
-      output: '<MyComponent>{\"foo\\\\nbar\"}</MyComponent>',
+      code: '<MyComponent>foo \\n bar</MyComponent>',
+      output: '<MyComponent>{\"foo \\\\n bar\"}</MyComponent>',
       options: [{children: 'always'}],
+      errors: [{message: missingCurlyMessage}]
+    },
+    {
+      code: '<MyComponent>foo \\u1234 bar</MyComponent>',
+      output: '<MyComponent>{\"foo \\\\u1234 bar\"}</MyComponent>',
+      options: [{children: 'always'}],
+      errors: [{message: missingCurlyMessage}]
+    },
+    {
+      code: '<MyComponent prop=\'foo \\u1234 bar\' />',
+      output: '<MyComponent prop={"foo \\\\u1234 bar"} />',
+      options: [{props: 'always'}],
       errors: [{message: missingCurlyMessage}]
     },
     {
@@ -336,30 +334,6 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       errors: [
         {message: missingCurlyMessage}, {message: missingCurlyMessage}
       ]
-    },
-    {
-      code: '<App>{\'foo "bar"\'}</App>',
-      output: '<App>foo \"bar\"</App>',
-      options: [{children: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
-    },
-    {
-      code: '<App>{\"foo \'bar\'\"}</App>',
-      output: '<App>foo \'bar\'</App>',
-      errors: [{message: unnecessaryCurlyMessage}],
-      options: [{children: 'never'}]
-    },
-    {
-      code: '<App prop={\"foo \'bar\' foo \"}>foo</App>',
-      output: '<App prop=\"foo \'bar\' foo \">foo</App>',
-      errors: [{message: unnecessaryCurlyMessage}],
-      options: [{props: 'never'}]
-    },
-    {
-      code: '<App prop={\'foo "bar"\'}>foo</App>',
-      output: '<App prop=\"foo \\\"bar\\\"\">foo</App>',
-      errors: [{message: unnecessaryCurlyMessage}],
-      options: [{props: 'never'}]
     },
     {
       code: '<App prop={\'foo\'} attr={\" foo \"} />',
@@ -388,6 +362,18 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       output: '<App prop={\'foo\'} attr={\"bar\"} />',
       errors: [{message: missingCurlyMessage}],
       options: [{props: 'always'}]
+    },
+    {
+      code: '<App prop=\'foo &middot; bar\' />',
+      output: '<App prop=\'foo &middot; bar\' />',
+      errors: [{message: missingCurlyMessage}],
+      options: [{props: 'always'}]
+    },
+    {
+      code: '<App>foo &middot; bar</App>',
+      output: '<App>foo &middot; bar</App>',
+      errors: [{message: missingCurlyMessage}],
+      options: [{children: 'always'}]
     }
   ]
 });

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -398,6 +398,54 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       output: `<App>foo 'bar'</App>`,
       errors: [{message: unnecessaryCurlyMessage}],
       options: [{children: 'never'}]
+    },
+    {
+      code: [
+        '<App prop="    ',
+        '   a     ',
+        '     b      c',
+        '        d',
+        '">',
+        '  a',
+        '      b     c   ',
+        '         d      ',
+        '</App>'
+      ].join('\n'),
+      output: [
+        '<App prop={"    ',
+        '   a     ',
+        '     b      c',
+        '        d',
+        '"}>{"\\n  a\\n      b     c   \\n         d      \\n"}</App>'
+      ].join('\n'),
+      errors: [
+        {message: missingCurlyMessage}, {message: missingCurlyMessage}
+      ],
+      options: ['always']
+    },
+    {
+      code: [
+        `<App prop='    `,
+        '   a     ',
+        '     b      c',
+        '        d',
+        `'>`,
+        '  a',
+        '      b     c   ',
+        '         d      ',
+        '</App>'
+      ].join('\n'),
+      output: [
+        '<App prop={"    ',
+        '   a     ',
+        '     b      c',
+        '        d',
+        '"}>{"\\n  a\\n      b     c   \\n         d      \\n"}</App>'
+      ].join('\n'),
+      errors: [
+        {message: missingCurlyMessage}, {message: missingCurlyMessage}
+      ],
+      options: ['always']
     }
   ]
 });

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -411,13 +411,6 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
         '         d      ',
         '</App>'
       ].join('\n'),
-      output: [
-        '<App prop={"    ',
-        '   a     ',
-        '     b      c',
-        '        d',
-        '"}>{"\\n  a\\n      b     c   \\n         d      \\n"}</App>'
-      ].join('\n'),
       errors: [
         {message: missingCurlyMessage}, {message: missingCurlyMessage}
       ],
@@ -434,13 +427,6 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
         '      b     c   ',
         '         d      ',
         '</App>'
-      ].join('\n'),
-      output: [
-        '<App prop={"    ',
-        '   a     ',
-        '     b      c',
-        '        d',
-        '"}>{"\\n  a\\n      b     c   \\n         d      \\n"}</App>'
       ].join('\n'),
       errors: [
         {message: missingCurlyMessage}, {message: missingCurlyMessage}


### PR DESCRIPTION
This is an attempt to fix https://github.com/yannickcr/eslint-plugin-react/issues/1449, so that the jsx-curly-brace-presence rule, when set to get rid of unnecessary curly braces(JSX expression), will bail out or deem a JSX expression necessary when a character that needs to be escaped in its JSX form is found in the expression. It also improves the fix in enforcing curly braces by escaping backslashes in its JSX form.

Gigantic thanks to @lydell for suggesting the implementation [plan](https://github.com/yannickcr/eslint-plugin-react/issues/1449#issuecomment-332750344) for this PR. I hope I didn't screw it up too much. 😄 

Let me know if there is any improvement you have in mind.

Fixes #1479. Fixes #1449.