### PR TITLE
Check parentheses with new lines for multiline JSX

### DIFF
--- a/docs/rules/jsx-wrap-multilines.md
+++ b/docs/rules/jsx-wrap-multilines.md
@@ -6,19 +6,23 @@ Wrapping multiline JSX in parentheses can improve readability and/or convenience
 
 ## Rule Details
 
-This rule optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, all the syntax listed below will be checked except the conditions out of declaration or assignment, logical expressions and JSX attributes, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior (become enabled).
+This rule optionally takes a second parameter in the form of an object, containing places to apply the rule. By default, all the syntax listed below will be checked except the conditions out of declaration or assignment, logical expressions and JSX attributes, but these can be explicitly disabled. Any syntax type missing in the object will follow the default behavior displayed below.
 
-There are the possible syntax available:
+```json
+{
+  "declaration": "parens",
+  "assignment": "parens",
+  "return": "parens",
+  "arrow": "parens",
+  "condition": "ignore",
+  "logical": "ignore",
+  "prop": "ignore"
+}
+```
 
-* `declaration`
-* `assignment`
-* `return`
-* `arrow`
-* `condition` (not enabed by default, by default only conditions in declaraiton or assignment)
-* `logical` (not enabled by default)
-* `prop` (not enabled by default)
+Note: conditions are checked by default in declarations or assignments.
 
-The following patterns are considered warnings:
+The following patterns are considered warnings when using `parens` or `parens-new-line`:
 
 ```jsx
 var Hello = createReactClass({
@@ -26,6 +30,18 @@ var Hello = createReactClass({
     return <div>
       <p>Hello {this.props.name}</p>
     </div>;
+  }
+});
+```
+
+The following patterns are considered warnings when using `parens-new-line`:
+
+```jsx
+var Hello = createReactClass({
+  render: function() {
+    return (<div>
+      <p>Hello {this.props.name}</p>
+    </div>);
   }
 });
 ```
@@ -46,7 +62,9 @@ var Hello = createReactClass({
 });
 ```
 
-The following patterns are considered warnings when configured `{declaration: true}`.
+### `declaration`
+
+The following patterns are considered warnings when configured `{declaration: "parens"}`.
 
 ```jsx
 var hello = <div>
@@ -54,7 +72,8 @@ var hello = <div>
 </div>;
 ```
 
-The following patterns are **not** considered warnings when configured `{declaration: true}`.
+
+The following patterns are **not** considered warnings when configured `{declaration: "parens"}`.
 
 ```jsx
 var hello = (
@@ -64,7 +83,39 @@ var hello = (
 );
 ```
 
-The following patterns are considered warnings when configured `{assignment: true}`.
+```jsx
+var hello = (<div>
+  <p>Hello</p>
+</div>);
+```
+
+The following patterns are considered warnings when configured `{declaration: "parens-new-line"}`.
+
+```jsx
+var hello = <div>
+  <p>Hello</p>
+</div>;
+```
+
+```jsx
+var hello = (<div>
+  <p>Hello</p>
+</div>);
+```
+
+The following patterns are **not** considered warnings when configured `{declaration: "parens-new-line"}`.
+
+```jsx
+var hello = (
+  <div>
+    <p>Hello</p>
+  </div>
+);
+```
+
+### `assignment`
+
+The following patterns are considered warnings when configured `{assignment: "parens"}`.
 
 ```jsx
 var hello;
@@ -73,7 +124,8 @@ hello = <div>
 </div>;
 ```
 
-The following patterns are **not** considered warnings when configured `{assignment: true}`.
+
+The following patterns are **not** considered warnings when configured `{assignment: "parens"}`.
 
 ```jsx
 var hello;
@@ -83,7 +135,44 @@ hello = (
   </div>
 );
 ```
-The following patterns are considered warnings when configured `{return: true}`.
+
+```jsx
+var hello;
+hello = (<div>
+  <p>Hello</p>
+</div>);
+```
+
+The following patterns are considered warnings when configured `{assignment: "parens-new-line"}`.
+
+```jsx
+var hello;
+hello = <div>
+  <p>Hello</p>
+</div>;
+```
+
+```jsx
+var hello;
+hello = (<div>
+  <p>Hello</p>
+</div>);
+```
+
+The following patterns are **not** considered warnings when configured `{assignment: "parens-new-line"}`.
+
+```jsx
+var hello;
+hello = (
+  <div>
+    <p>Hello</p>
+  </div>
+);
+```
+
+### `return`
+
+The following patterns are considered warnings when configured `{return: "parens"}`.
 
 ```jsx
 function hello() {
@@ -93,7 +182,7 @@ function hello() {
 }
 ```
 
-The following patterns are **not** considered warnings when configured `{return: true}`.
+The following patterns are **not** considered warnings when configured `{return: "parens"}`.
 
 ```jsx
 function hello() {
@@ -104,7 +193,48 @@ function hello() {
   );
 }
 ```
-The following patterns are considered warnings when configured `{arrow: true}`.
+
+```jsx
+function hello() {
+  return (<div>
+    <p>Hello</p>
+  </div>);
+}
+```
+
+The following patterns are considered warnings when configured `{return: "parens-new-line"}`.
+
+```jsx
+function hello() {
+  return <div>
+    <p>Hello</p>
+  </div>;
+}
+```
+
+```jsx
+function hello() {
+  return (<div>
+    <p>Hello</p>
+  </div>);
+}
+```
+
+The following patterns are **not** considered warnings when configured `{return: "parens-new-line"}`.
+
+```jsx
+function hello() {
+  return (
+    <div>
+      <p>Hello</p>
+    </div>
+  );
+}
+```
+
+### `arrow`
+
+The following patterns are considered warnings when configured `{arrow: "parens"}`.
 
 ```jsx
 var hello = () => <div>
@@ -112,7 +242,8 @@ var hello = () => <div>
 </div>;
 ```
 
-The following patterns are **not** considered warnings when configured `{arrow: true}`.
+
+The following patterns are **not** considered warnings when configured `{arrow: "parens"}`.
 
 ```jsx
 var hello = () => (
@@ -122,7 +253,39 @@ var hello = () => (
 );
 ```
 
-The following patterns are considered warnings when configured `{condition: true}`.
+```jsx
+var hello = () => (<div>
+  <p>World</p>
+</div>);
+```
+
+The following patterns are considered warnings when configured `{arrow: "parens-new-line"}`.
+
+```jsx
+var hello = () => <div>
+  <p>World</p>
+</div>;
+```
+
+```jsx
+var hello = () => (<div>
+  <p>World</p>
+</div>);
+```
+
+The following patterns are **not** considered warnings when configured `{arrow: "parens-new-line"}`.
+
+```jsx
+var hello = () => (
+  <div>
+    <p>World</p>
+  </div>
+);
+```
+
+### `condition`
+
+The following patterns are considered warnings when configured `{condition: "parens"}`.
 
 ```jsx
 <div>
@@ -132,7 +295,8 @@ The following patterns are considered warnings when configured `{condition: true
 </div>
 ```
 
-The following patterns are not considered warnings when configured `{condition: true}`.
+
+The following patterns are **not** considered warnings when configured `{condition: "parens"}`.
 
 ```jsx
 <div>
@@ -142,8 +306,49 @@ The following patterns are not considered warnings when configured `{condition: 
 </div>
 ```
 
+```jsx
+<div>
+  {foo ? (
+    <div>
+      <p>Hello</p>
+    </div>
+  ): null}
+</div>
+```
 
-The following patterns are considered warnings when configured `{logical: true}`.
+The following patterns are considered warnings when configured `{condition: "parens-new-line"}`.
+
+```jsx
+<div>
+  {foo ? <div>
+      <p>Hello</p>
+    </div> : null}
+</div>
+```
+
+```jsx
+<div>
+  {foo ? (<div>
+      <p>Hello</p>
+  </div>) : null}
+</div>
+```
+
+The following patterns are **not** considered warnings when configured `{condition: "parens-new-line"}`.
+
+```jsx
+<div>
+  {foo ? (
+    <div>
+      <p>Hello</p>
+    </div>
+  ): null}
+</div>
+```
+
+### `logical`
+
+The following patterns are considered warnings when configured `{logical: "parens"}`.
 
 ```jsx
 <div>
@@ -155,7 +360,7 @@ The following patterns are considered warnings when configured `{logical: true}`
 </div>
 ```
 
-The following patterns are not considered warnings when configured `{logical: true}`.
+The following patterns are **not** considered warnings when configured `{logical: "parens"}`.
 
 ```jsx
 <div>
@@ -167,22 +372,108 @@ The following patterns are not considered warnings when configured `{logical: tr
 </div>
 ```
 
-The following patterns are considered warnings when configured `{attr: true}`.
+```jsx
+<div>
+  {foo && (
+    <div>
+      <p>Hello World</p>
+    </div>
+  )}
+</div>
+```
+
+The following patterns are considered warnings when configured `{logical: "parens-new-line"}`.
 
 ```jsx
-<div attr={<div>
+<div>
+  {foo &&
+    <div>
+      <p>Hello World</p>
+    </div>
+  }
+</div>
+```
+
+```jsx
+<div>
+  {foo &&
+    (<div>
+      <p>Hello World</p>
+    </div>)
+  }
+</div>
+```
+
+The following patterns are **not** considered warnings when configured `{logical: "parens-new-line"}`.
+
+```jsx
+<div>
+  {foo && (
+    <div>
+      <p>Hello World</p>
+    </div>
+  )}
+</div>
+```
+
+### `prop`
+
+The following patterns are considered warnings when configured `{prop: "parens"}`.
+
+```jsx
+<div foo={<div>
     <p>Hello</p>
   </div>}>
   <p>Hello</p>
 </div>;
 ```
 
-The following patterns are not considered warnings when configured `{attr: true}`.
+The following patterns are **not** considered warnings when configured `{prop: "parens"}`.
 
 ```jsx
-<div attr={(<div>
+<div foo={(<div>
     <p>Hello</p>
   </div>)}>
+  <p>Hello</p>
+</div>;
+```
+
+```jsx
+<div foo={(
+  <div>
+    <p>Hello</p>
+  </div>
+)}>
+  <p>Hello</p>
+</div>;
+```
+
+The following patterns are considered warnings when configured `{prop: "parens-new-line"}`.
+
+```jsx
+<div foo={<div>
+    <p>Hello</p>
+  </div>}>
+  <p>Hello</p>
+</div>;
+```
+
+```jsx
+<div foo={(<div>
+    <p>Hello</p>
+  </div>)}>
+  <p>Hello</p>
+</div>;
+```
+
+The following patterns are **not** considered warnings when configured `{prop: "parens-new-line"}`.
+
+```jsx
+<div foo={(
+  <div>
+    <p>Hello</p>
+  </div>
+)}>
   <p>Hello</p>
 </div>;
 ```

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -11,14 +11,17 @@ const has = require('has');
 // ------------------------------------------------------------------------------
 
 const DEFAULTS = {
-  declaration: true,
-  assignment: true,
-  return: true,
-  arrow: true,
-  condition: false,
-  logical: false,
-  prop: false
+  declaration: 'parens',
+  assignment: 'parens',
+  return: 'parens',
+  arrow: 'parens',
+  condition: 'ignore',
+  logical: 'ignore',
+  prop: 'ignore'
 };
+
+const MISSING_PARENS = 'Missing parentheses around multilines JSX';
+const PARENS_NEW_LINES = 'Parentheses around JSX should be on separate lines';
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -35,27 +38,28 @@ module.exports = {
 
     schema: [{
       type: 'object',
+      // true/false are for backwards compatibility
       properties: {
         declaration: {
-          type: 'boolean'
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line']
         },
         assignment: {
-          type: 'boolean'
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line']
         },
         return: {
-          type: 'boolean'
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line']
         },
         arrow: {
-          type: 'boolean'
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line']
         },
         condition: {
-          type: 'boolean'
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line']
         },
         logical: {
-          type: 'boolean'
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line']
         },
         prop: {
-          type: 'boolean'
+          enum: [true, false, 'ignore', 'parens', 'parens-new-line']
         }
       },
       additionalProperties: false
@@ -64,6 +68,19 @@ module.exports = {
 
   create: function(context) {
     const sourceCode = context.getSourceCode();
+
+    function getOption(type) {
+      const userOptions = context.options[0] || {};
+      if (has(userOptions, type)) {
+        return userOptions[type];
+      }
+      return DEFAULTS[type];
+    }
+
+    function isEnabled(type) {
+      const option = getOption(type);
+      return option && option !== 'ignore';
+    }
 
     function isParenthesised(node) {
       const previousToken = sourceCode.getTokenBefore(node);
@@ -74,32 +91,45 @@ module.exports = {
         nextToken.value === ')' && nextToken.range[0] >= node.range[1];
     }
 
+    function needsNewLines(node) {
+      const previousToken = sourceCode.getTokenBefore(node);
+      const nextToken = sourceCode.getTokenAfter(node);
+
+      return isParenthesised(node) &&
+        previousToken.loc.end.line === node.loc.start.line &&
+        node.loc.end.line === nextToken.loc.end.line;
+    }
+
     function isMultilines(node) {
       return node.loc.start.line !== node.loc.end.line;
     }
 
-    function check(node) {
+    function report(node, message, fixerFn) {
+      context.report({
+        node: node,
+        message: message,
+        fix: fixerFn
+      });
+    }
+
+    function check(node, type) {
       if (!node || node.type !== 'JSXElement') {
         return;
       }
 
-      if (!isParenthesised(node) && isMultilines(node)) {
-        context.report({
-          node: node,
-          message: 'Missing parentheses around multilines JSX',
-          fix: function(fixer) {
-            return fixer.replaceText(node, `(${sourceCode.getText(node)})`);
-          }
-        });
-      }
-    }
+      const option = getOption(type);
 
-    function isEnabled(type) {
-      const userOptions = context.options[0] || {};
-      if (has(userOptions, type)) {
-        return userOptions[type];
+      if ((option === true || option === 'parens') && !isParenthesised(node) && isMultilines(node)) {
+        report(node, MISSING_PARENS, fixer => fixer.replaceText(node, `(${sourceCode.getText(node)})`));
       }
-      return DEFAULTS[type];
+
+      if (option === 'parens-new-line' && isMultilines(node)) {
+        if (!isParenthesised(node)) {
+          report(node, MISSING_PARENS, fixer => fixer.replaceText(node, `(\n${sourceCode.getText(node)}\n)`));
+        } else if (needsNewLines(node)) {
+          report(node, PARENS_NEW_LINES, fixer => fixer.replaceText(node, `\n${sourceCode.getText(node)}\n`));
+        }
+      }
     }
 
     // --------------------------------------------------------------------------
@@ -109,59 +139,66 @@ module.exports = {
     return {
 
       VariableDeclarator: function(node) {
-        if (!isEnabled('declaration')) {
+        const type = 'declaration';
+        if (!isEnabled(type)) {
           return;
         }
         if (!isEnabled('condition') && node.init && node.init.type === 'ConditionalExpression') {
-          check(node.init.consequent);
-          check(node.init.alternate);
+          check(node.init.consequent, type);
+          check(node.init.alternate, type);
           return;
         }
-        check(node.init);
+        check(node.init, type);
       },
 
       AssignmentExpression: function(node) {
-        if (!isEnabled('assignment')) {
+        const type = 'assignment';
+        if (!isEnabled(type)) {
           return;
         }
         if (!isEnabled('condition') && node.right.type === 'ConditionalExpression') {
-          check(node.right.consequent);
-          check(node.right.alternate);
+          check(node.right.consequent, type);
+          check(node.right.alternate, type);
           return;
         }
-        check(node.right);
+        check(node.right, type);
       },
 
       ReturnStatement: function(node) {
-        if (isEnabled('return')) {
-          check(node.argument);
+        const type = 'return';
+        if (isEnabled(type)) {
+          check(node.argument, type);
         }
       },
 
       'ArrowFunctionExpression:exit': function (node) {
         const arrowBody = node.body;
+        const type = 'arrow';
 
-        if (isEnabled('arrow') && arrowBody.type !== 'BlockStatement') {
-          check(arrowBody);
+        if (isEnabled(type) && arrowBody.type !== 'BlockStatement') {
+          check(arrowBody, type);
         }
       },
 
       ConditionalExpression: function(node) {
-        if (isEnabled('condition')) {
-          check(node.consequent);
-          check(node.alternate);
+        const type = 'condition';
+        if (isEnabled(type)) {
+          check(node.consequent, type);
+          check(node.alternate, type);
         }
       },
 
       LogicalExpression: function(node) {
-        if (isEnabled('logical')) {
-          check(node.right);
+        const type = 'logical';
+        if (isEnabled(type)) {
+          check(node.right, type);
         }
       },
 
       JSXAttribute: function (node) {
-        if (isEnabled('prop') && node.value && node.value.type === 'JSXExpressionContainer') {
-          check(node.value.expression);
+        const type = 'prop';
+        if (isEnabled(type) && node.value && node.value.type === 'JSXExpressionContainer') {
+          check(node.value.expression, type);
         }
       }
     };

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -21,8 +21,11 @@ const parserOptions = {
 };
 
 // ------------------------------------------------------------------------------
-// Code Snippets
+// Constants/Code Snippets
 // ------------------------------------------------------------------------------
+
+const MISSING_PARENS = 'Missing parentheses around multilines JSX';
+const PARENS_NEW_LINES = 'Parentheses around JSX should be on separate lines';
 
 const RETURN_SINGLE_LINE = `
   var Hello = createReactClass({
@@ -52,6 +55,18 @@ const RETURN_NO_PAREN = `
   });
 `;
 
+const RETURN_PAREN_NEW_LINE = `
+  var Hello = createReactClass({
+    render: function() {
+      return (
+        <div>
+          <p>Hello {this.props.name}</p>
+        </div>
+      );
+    }
+  });
+`;
+
 const DECLARATION_TERNARY_SINGLE_LINE = 'var hello = foo ? <p>Hello</p> : <p>Hi</p>;';
 
 const DECLARATION_TERNARY_PAREN = `
@@ -68,6 +83,18 @@ const DECLARATION_TERNARY_NO_PAREN = `
   </div> : <div>
     <p>Hi</p>
   </div>;
+`;
+
+const DECLARATION_TERNARY_PAREN_NEW_LINE = `
+  var hello = foo ? (
+    <div>
+    <p>Hello</p>
+    </div>
+  ) : (
+    <div>
+      <p>Hi</p>
+    </div>
+  );
 `;
 
 const ASSIGNMENT_TERNARY_SINGLE_LINE = 'var hello; hello = foo ? <p>Hello</p> : <p>Hi</p>;';
@@ -90,6 +117,19 @@ const ASSIGNMENT_TERNARY_NO_PAREN = `
   </div>;
 `;
 
+const ASSIGNMENT_TERNARY_PAREN_NEW_LINE = `
+  var hello;
+  hello = foo ? (
+    <div>
+      <p>Hello</p>
+    </div>
+  ) : (
+    <div>
+      <p>Hi</p>
+    </div>
+  );
+`;
+
 const DECLARATION_SINGLE_LINE = 'var hello = <p>Hello</p>;';
 
 const DECLARATION_PAREN = `
@@ -102,6 +142,14 @@ const DECLARATION_NO_PAREN = `
   var hello = <div>
     <p>Hello</p>
   </div>;
+`;
+
+const DECLARATION_PAREN_NEW_LINE = `
+  var hello = (
+    <div>
+      <p>Hello</p>
+    </div>
+  );
 `;
 
 const ASSIGNMENT_SINGLE_LINE = 'var hello; hello = <p>Hello</p>;';
@@ -120,6 +168,15 @@ const ASSIGNMENT_NO_PAREN = `
   </div>;
 `;
 
+const ASSIGNMENT_PAREN_NEW_LINE = `
+  var hello;
+  hello = (
+    <div>
+      <p>Hello</p>
+    </div>
+  );
+`;
+
 const ARROW_SINGLE_LINE = 'var hello = () => <p>Hello</p>;';
 
 const ARROW_PAREN = `
@@ -132,6 +189,14 @@ const ARROW_NO_PAREN = `
   var hello = () => <div>
     <p>Hello</p>
   </div>;
+`;
+
+const ARROW_PAREN_NEW_LINE = `
+  var hello = () => (
+    <div>
+      <p>Hello</p>
+    </div>
+  );
 `;
 
 const CONDITION_SINGLE_LINE = 'foo ? <p>Hello</p> : null;';
@@ -149,6 +214,16 @@ const CONDITION_NO_PAREN = `
     {foo ? <div>
         <p>Hello</p>
       </div> : null}
+  </div>
+`;
+
+const CONDITION_PAREN_NEW_LINE = `
+  <div>
+    {foo ? (
+      <div>
+        <p>Hello</p>
+      </div>
+    ) : null}
   </div>
 `;
 
@@ -174,6 +249,16 @@ const LOGICAL_NO_PAREN = `
   </div>
 `;
 
+const LOGICAL_PAREN_NEW_LINE = `
+  <div>
+    {foo && (
+      <div>
+        <p>Hello World</p>
+      </div>
+    )}
+  </div>
+`;
+
 const ATTR_SINGLE_LINE = '<div prop={<p>Hello</p>}></div>';
 
 const ATTR_PAREN = `
@@ -196,6 +281,20 @@ const ATTR_NO_PAREN = `
   </div>
 `;
 
+const ATTR_PAREN_NEW_LINE = `
+  <div prop={(
+    <div>
+      <p>Hello</p>
+    </div>
+  )}>
+    <p>Hello</p>
+  </div>
+`;
+
+function addNewLineSymbols(code) {
+  return code.replace(/\(</g, '(\n<').replace(/>\)/g, '>\n)');
+}
+
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -209,12 +308,30 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     }, {
       code: RETURN_PAREN
     }, {
+      code: RETURN_SINGLE_LINE,
+      options: [{return: true}]
+    }, {
+      code: RETURN_PAREN,
+      options: [{return: true}]
+    }, {
+      code: RETURN_NO_PAREN,
+      options: [{return: 'ignore'}]
+    }, {
       code: RETURN_NO_PAREN,
       options: [{return: false}]
     }, {
       code: DECLARATION_TERNARY_SINGLE_LINE
     }, {
       code: DECLARATION_TERNARY_PAREN
+    }, {
+      code: DECLARATION_TERNARY_SINGLE_LINE,
+      options: [{declaration: true}]
+    }, {
+      code: DECLARATION_TERNARY_PAREN,
+      options: [{declaration: true}]
+    }, {
+      code: DECLARATION_TERNARY_NO_PAREN,
+      options: [{declaration: 'ignore'}]
     }, {
       code: DECLARATION_TERNARY_NO_PAREN,
       options: [{declaration: false}]
@@ -223,6 +340,15 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     }, {
       code: ASSIGNMENT_TERNARY_PAREN
     }, {
+      code: ASSIGNMENT_TERNARY_SINGLE_LINE,
+      options: [{assignment: true}]
+    }, {
+      code: ASSIGNMENT_TERNARY_PAREN,
+      options: [{assignment: true}]
+    }, {
+      code: ASSIGNMENT_TERNARY_NO_PAREN,
+      options: [{assignment: 'ignore'}]
+    }, {
       code: ASSIGNMENT_TERNARY_NO_PAREN,
       options: [{assignment: false}]
     }, {
@@ -230,22 +356,47 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     }, {
       code: DECLARATION_PAREN
     }, {
+      code: DECLARATION_SINGLE_LINE,
+      options: [{declaration: true}]
+    }, {
+      code: DECLARATION_PAREN,
+      options: [{declaration: true}]
+    }, {
+      code: DECLARATION_NO_PAREN,
+      options: [{declaration: 'ignore'}]
+    }, {
       code: DECLARATION_NO_PAREN,
       options: [{declaration: false}]
+    }, {
+      code: ASSIGNMENT_SINGLE_LINE,
+      options: [{declaration: 'ignore'}]
     }, {
       code: ASSIGNMENT_SINGLE_LINE,
       options: [{declaration: false}]
     }, {
       code: ASSIGNMENT_PAREN
     }, {
+      code: ASSIGNMENT_PAREN,
+      options: [{assignment: true}]
+    }, {
+      code: ASSIGNMENT_NO_PAREN,
+      options: [{assignment: 'ignore'}]
+    }, {
       code: ASSIGNMENT_NO_PAREN,
       options: [{assignment: false}]
     }, {
+      code: ARROW_PAREN
+    }, {
+      code: ARROW_SINGLE_LINE
+    }, {
       code: ARROW_PAREN,
-      options: []
+      options: [{arrow: true}]
     }, {
       code: ARROW_SINGLE_LINE,
-      options: []
+      options: [{arrow: true}]
+    }, {
+      code: ARROW_NO_PAREN,
+      options: [{arrow: 'ignore'}]
     }, {
       code: ARROW_NO_PAREN,
       options: [{arrow: false}]
@@ -273,6 +424,33 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     }, {
       code: ATTR_PAREN,
       options: [{prop: true}]
+    }, {
+      code: RETURN_PAREN_NEW_LINE,
+      options: [{return: 'parens-new-line'}]
+    }, {
+      code: DECLARATION_TERNARY_PAREN_NEW_LINE,
+      options: [{declaration: 'parens-new-line'}]
+    }, {
+      code: ASSIGNMENT_TERNARY_PAREN_NEW_LINE,
+      options: [{assignment: 'parens-new-line'}]
+    }, {
+      code: DECLARATION_PAREN_NEW_LINE,
+      options: [{declaration: 'parens-new-line'}]
+    }, {
+      code: ASSIGNMENT_PAREN_NEW_LINE,
+      options: [{assignment: 'parens-new-line'}]
+    }, {
+      code: ARROW_PAREN_NEW_LINE,
+      options: [{arrow: 'parens-new-line'}]
+    }, {
+      code: CONDITION_PAREN_NEW_LINE,
+      options: [{condition: 'parens-new-line'}]
+    }, {
+      code: LOGICAL_PAREN_NEW_LINE,
+      options: [{logical: 'parens-new-line'}]
+    }, {
+      code: ATTR_PAREN_NEW_LINE,
+      options: [{prop: 'parens-new-line'}]
     }
   ],
 
@@ -280,64 +458,201 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     {
       code: RETURN_NO_PAREN,
       output: RETURN_PAREN,
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: RETURN_NO_PAREN,
       output: RETURN_PAREN,
       options: [{return: true}],
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: DECLARATION_TERNARY_NO_PAREN,
       output: DECLARATION_TERNARY_PAREN,
       errors: [
-        {message: 'Missing parentheses around multilines JSX'},
-        {message: 'Missing parentheses around multilines JSX'}
+        {message: MISSING_PARENS},
+        {message: MISSING_PARENS}
+      ]
+    }, {
+      code: DECLARATION_TERNARY_NO_PAREN,
+      output: DECLARATION_TERNARY_PAREN,
+      options: [{declaration: true}],
+      errors: [
+        {message: MISSING_PARENS},
+        {message: MISSING_PARENS}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_NO_PAREN,
       output: ASSIGNMENT_TERNARY_PAREN,
       errors: [
-        {message: 'Missing parentheses around multilines JSX'},
-        {message: 'Missing parentheses around multilines JSX'}
+        {message: MISSING_PARENS},
+        {message: MISSING_PARENS}
+      ]
+    }, {
+      code: ASSIGNMENT_TERNARY_NO_PAREN,
+      output: ASSIGNMENT_TERNARY_PAREN,
+      options: [{assignment: true}],
+      errors: [
+        {message: MISSING_PARENS},
+        {message: MISSING_PARENS}
       ]
     }, {
       code: DECLARATION_NO_PAREN,
       output: DECLARATION_PAREN,
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: DECLARATION_NO_PAREN,
       output: DECLARATION_PAREN,
       options: [{declaration: true}],
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: ASSIGNMENT_NO_PAREN,
       output: ASSIGNMENT_PAREN,
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: ASSIGNMENT_NO_PAREN,
       output: ASSIGNMENT_PAREN,
       options: [{assignment: true}],
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: ARROW_NO_PAREN,
+      output: ARROW_PAREN,
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: ARROW_NO_PAREN,
       output: ARROW_PAREN,
       options: [{arrow: true}],
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: CONDITION_NO_PAREN,
+      output: CONDITION_PAREN,
+      options: [{condition: 'parens'}],
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: CONDITION_NO_PAREN,
       output: CONDITION_PAREN,
       options: [{condition: true}],
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: LOGICAL_NO_PAREN,
+      output: LOGICAL_PAREN,
+      options: [{logical: 'parens'}],
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: LOGICAL_NO_PAREN,
       output: LOGICAL_PAREN,
       options: [{logical: true}],
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: ATTR_NO_PAREN,
+      output: ATTR_PAREN,
+      options: [{prop: 'parens'}],
+      errors: [{message: MISSING_PARENS}]
     }, {
       code: ATTR_NO_PAREN,
       output: ATTR_PAREN,
       options: [{prop: true}],
-      errors: [{message: 'Missing parentheses around multilines JSX'}]
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: RETURN_NO_PAREN,
+      output: addNewLineSymbols(RETURN_PAREN),
+      options: [{return: 'parens-new-line'}],
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: RETURN_PAREN,
+      output: addNewLineSymbols(RETURN_PAREN),
+      options: [{return: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: DECLARATION_TERNARY_NO_PAREN,
+      output: addNewLineSymbols(DECLARATION_TERNARY_PAREN),
+      options: [{declaration: 'parens-new-line'}],
+      errors: [
+        {message: MISSING_PARENS},
+        {message: MISSING_PARENS}
+      ]
+    }, {
+      code: DECLARATION_TERNARY_PAREN,
+      output: addNewLineSymbols(DECLARATION_TERNARY_PAREN),
+      options: [{declaration: 'parens-new-line'}],
+      errors: [
+        {message: PARENS_NEW_LINES},
+        {message: PARENS_NEW_LINES}
+      ]
+    }, {
+      code: ASSIGNMENT_TERNARY_NO_PAREN,
+      output: addNewLineSymbols(ASSIGNMENT_TERNARY_PAREN),
+      options: [{assignment: 'parens-new-line'}],
+      errors: [
+        {message: MISSING_PARENS},
+        {message: MISSING_PARENS}
+      ]
+    }, {
+      code: ASSIGNMENT_TERNARY_PAREN,
+      output: addNewLineSymbols(ASSIGNMENT_TERNARY_PAREN),
+      options: [{assignment: 'parens-new-line'}],
+      errors: [
+        {message: PARENS_NEW_LINES},
+        {message: PARENS_NEW_LINES}
+      ]
+    }, {
+      code: DECLARATION_NO_PAREN,
+      output: addNewLineSymbols(DECLARATION_PAREN),
+      options: [{declaration: 'parens-new-line'}],
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: DECLARATION_PAREN,
+      output: addNewLineSymbols(DECLARATION_PAREN),
+      options: [{declaration: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: ASSIGNMENT_NO_PAREN,
+      output: addNewLineSymbols(ASSIGNMENT_PAREN),
+      options: [{assignment: 'parens-new-line'}],
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: ASSIGNMENT_PAREN,
+      output: addNewLineSymbols(ASSIGNMENT_PAREN),
+      options: [{assignment: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: ARROW_PAREN,
+      output: addNewLineSymbols(ARROW_PAREN),
+      options: [{arrow: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: ARROW_NO_PAREN,
+      output: addNewLineSymbols(ARROW_PAREN),
+      options: [{arrow: 'parens-new-line'}],
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: CONDITION_PAREN,
+      output: addNewLineSymbols(CONDITION_PAREN),
+      options: [{condition: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: CONDITION_NO_PAREN,
+      output: addNewLineSymbols(CONDITION_PAREN),
+      options: [{condition: 'parens-new-line'}],
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: LOGICAL_PAREN,
+      output: addNewLineSymbols(LOGICAL_PAREN),
+      options: [{logical: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: LOGICAL_NO_PAREN,
+      output: addNewLineSymbols(LOGICAL_PAREN),
+      options: [{logical: 'parens-new-line'}],
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: ATTR_PAREN,
+      output: addNewLineSymbols(ATTR_PAREN),
+      options: [{prop: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: ATTR_NO_PAREN,
+      output: addNewLineSymbols(ATTR_PAREN),
+      options: [{prop: 'parens-new-line'}],
+      errors: [{message: MISSING_PARENS}]
     }
   ]
 });


### PR DESCRIPTION
This changes the options from a boolean to an enum with three possible
values: `ignore`, `parens`, and `parens-new-line`. Using `ignore` is like
the previous `false` while `parens` is like the previous `true`. The new
option (`parens-new-line`) will check that the parentheses around the
multiline JSX are on separate lines for better readability.

This PR attempts to address #1469.