### PR TITLE
Support propWrapperFunctions for boolean-prop-naming

### DIFF
--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -139,6 +139,13 @@ module.exports = {
       });
     }
 
+    function checkPropWrapperArguments(node, args) {
+      if (!node || !Array.isArray(args)) {
+        return;
+      }
+      args.filter(arg => arg.type === 'ObjectExpression').forEach(object => validatePropNaming(node, object.properties));
+    }
+
     // --------------------------------------------------------------------------
     // Public
     // --------------------------------------------------------------------------
@@ -147,6 +154,9 @@ module.exports = {
       ClassProperty: function(node) {
         if (!rule || !propsUtil.isPropTypesDeclaration(node)) {
           return;
+        }
+        if (node.value && node.value.type === 'CallExpression' && propWrapperFunctions.has(sourceCode.getText(node.value.callee))) {
+          checkPropWrapperArguments(node, node.value.arguments);
         }
         if (node.value && node.value.properties) {
           validatePropNaming(node, node.value.properties);
@@ -166,7 +176,7 @@ module.exports = {
         }
         const right = node.parent.right;
         if (right.type === 'CallExpression' && propWrapperFunctions.has(sourceCode.getText(right.callee))) {
-          right.arguments.filter(arg => arg.type === 'ObjectExpression').forEach(object => validatePropNaming(component.node, object.properties));
+          checkPropWrapperArguments(component.node, right.arguments);
           return;
         }
         validatePropNaming(component.node, node.parent.right.properties);

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -46,6 +46,7 @@ module.exports = {
     const config = context.options[0] || {};
     const rule = config.rule ? new RegExp(config.rule) : null;
     const propTypeNames = config.propTypeNames || ['bool'];
+    const propWrapperFunctions = new Set(context.settings.propWrapperFunctions || []);
 
     // Remembers all Flowtype object definitions
     const objectTypeAnnotations = new Map();
@@ -160,7 +161,12 @@ module.exports = {
           return;
         }
         const component = utils.getRelatedComponent(node);
-        if (!component || !node.parent.right.properties) {
+        if (!component || !node.parent.right) {
+          return;
+        }
+        const right = node.parent.right;
+        if (right.type === 'CallExpression' && propWrapperFunctions.has(sourceCode.getText(right.callee))) {
+          right.arguments.filter(arg => arg.type === 'ObjectExpression').forEach(object => validatePropNaming(component.node, object.properties));
           return;
         }
         validatePropNaming(component.node, node.parent.right.properties);

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -578,5 +578,41 @@ ruleTester.run('boolean-prop-naming', rule, {
     errors: [{
       message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
     }]
+  }, {
+    code: `
+    function Card(props) {
+      return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+    }
+    Card.propTypes = forbidExtraProps({
+        showScore: PropTypes.bool
+    });`,
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    },
+    options: [{
+      rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
+    }],
+    errors: [{
+      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+    }]
+  }, {
+    code: `
+    class Card extends React.Component {
+      render() {
+        return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+      }
+    }
+    Card.propTypes = forbidExtraProps({
+        showScore: PropTypes.bool
+    });`,
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    },
+    options: [{
+      rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
+    }],
+    errors: [{
+      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+    }]
   }]
 });

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -614,5 +614,25 @@ ruleTester.run('boolean-prop-naming', rule, {
     errors: [{
       message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
     }]
+  }, {
+    code: `
+    class Card extends React.Component {
+      static propTypes = forbidExtraProps({
+        showScore: PropTypes.bool
+      });
+      render() {
+        return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+      }
+    }`,
+    parser: 'babel-eslint',
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    },
+    options: [{
+      rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
+    }],
+    errors: [{
+      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+    }]
   }]
 });

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -295,6 +295,18 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     parser: 'babel-eslint'
+  }, {
+    // No propWrapperFunctions setting
+    code: `
+    function Card(props) {
+      return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+    }
+    Card.propTypes = merge({}, Card.propTypes, {
+        showScore: PropTypes.bool
+    });`,
+    options: [{
+      rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
+    }]
   }],
 
   invalid: [{
@@ -514,6 +526,57 @@ ruleTester.run('boolean-prop-naming', rule, {
       message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
     }, {
       message: 'Prop name (somethingElse) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+    }]
+  }, {
+    code: `
+    function Card(props) {
+      return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+    }
+    Card.propTypes = merge({}, Card.propTypes, {
+        showScore: PropTypes.bool
+    });`,
+    settings: {
+      propWrapperFunctions: ['merge']
+    },
+    options: [{
+      rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
+    }],
+    errors: [{
+      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+    }]
+  }, {
+    code: `
+    function Card(props) {
+      return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+    }
+    Card.propTypes = Object.assign({}, Card.propTypes, {
+        showScore: PropTypes.bool
+    });`,
+    settings: {
+      propWrapperFunctions: ['Object.assign']
+    },
+    options: [{
+      rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
+    }],
+    errors: [{
+      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+    }]
+  }, {
+    code: `
+    function Card(props) {
+      return <div>{props.showScore ? 'yeh' : 'no'}</div>;
+    }
+    Card.propTypes = _.assign({}, Card.propTypes, {
+        showScore: PropTypes.bool
+    });`,
+    settings: {
+      propWrapperFunctions: ['_.assign']
+    },
+    options: [{
+      rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
+    }],
+    errors: [{
+      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
     }]
   }]
 });


### PR DESCRIPTION
This adds support for checking prop types  in `boolean-prop-naming` when using the `propWrapperFunctions` setting.

Closes #1452.