### PR TITLE
Add `sortShapeProp` option to sort-prop-types rule

### DIFF
--- a/docs/rules/sort-prop-types.md
+++ b/docs/rules/sort-prop-types.md
@@ -80,6 +80,7 @@ class Component extends React.Component {
   "callbacksLast": <boolean>,
   "ignoreCase": <boolean>,
   "requiredFirst": <boolean>,
+  "sortShapeProp": <boolean>
 }]
 ...
 ```
@@ -115,6 +116,25 @@ var Component = createReactClass({
     fooRequired: PropTypes.any.isRequired,
     a: PropTypes.number,
     z: PropTypes.string,
+  },
+...
+});
+```
+
+### `sortShapeProp`
+
+When `true`, props defined in `PropTypes.shape` must be sorted via the same rules as the top-level props:
+
+```js
+var Component = createReactClass({
+  propTypes: {
+    a: PropTypes.number,
+    b: PropTypes.shape({
+      d: PropTypes.number,
+      e: PropTypes.func,
+      f: PropTypes.bool,
+    }),
+    c: PropTypes.string,
   },
 ...
 });

--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -28,6 +28,9 @@ module.exports = {
         },
         ignoreCase: {
           type: 'boolean'
+        },
+        sortShapeProp: {
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -40,6 +43,7 @@ module.exports = {
     const requiredFirst = configuration.requiredFirst || false;
     const callbacksLast = configuration.callbacksLast || false;
     const ignoreCase = configuration.ignoreCase || false;
+    const sortShapeProp = configuration.sortShapeProp || false;
     const propWrapperFunctions = new Set(context.settings.propWrapperFunctions || []);
 
     /**
@@ -76,6 +80,12 @@ module.exports = {
 
     function isRequiredProp(node) {
       return getValueName(node) === 'isRequired';
+    }
+
+    function isShapeProp(node) {
+      return Boolean(
+        node && node.callee && node.callee.property && node.callee.property.name === 'shape'
+      );
     }
 
     /**
@@ -185,6 +195,13 @@ module.exports = {
     }
 
     return {
+      CallExpression: function(node) {
+        if (!sortShapeProp || !isShapeProp(node) || (!node.arguments && !node.arguments[0])) {
+          return;
+        }
+        checkSorted(node.arguments[0].properties);
+      },
+
       ClassProperty: function(node) {
         if (!isPropTypesDeclaration(node)) {
           return;

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -344,6 +344,27 @@ ruleTester.run('sort-prop-types', rule, {
         }),
       };
     `
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        a: PropTypes.any,
+        b: PropTypes.any,
+        c: PropTypes.shape({
+          c: PropTypes.any,
+          ...otherPropTypes,
+          a: PropTypes.any,
+          b: PropTypes.bool,
+        }),
+      };
+    `,
+    options: [{
+      sortShapeProp: true
+    }]
   }],
 
   invalid: [{

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -26,6 +26,8 @@ require('babel-eslint');
 // -----------------------------------------------------------------------------
 
 const ERROR_MESSAGE = 'Prop types declarations should be sorted alphabetically';
+const REQUIRED_ERROR_MESSAGE = 'Required prop types must be listed before all other prop types';
+const CALLBACK_ERROR_MESSAGE = 'Callback prop types must be listed after all other prop types';
 
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('sort-prop-types', rule, {
@@ -154,7 +156,6 @@ ruleTester.run('sort-prop-types', rule, {
       '  "aria-controls": PropTypes.string',
       '};'
     ].join('\n'),
-    parser: 'babel-eslint',
     options: [{
       ignoreCase: true
     }]
@@ -325,6 +326,24 @@ ruleTester.run('sort-prop-types', rule, {
       '};',
       'First.propTypes = propTypes;'
     ].join('\n')
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        x: PropTypes.any,
+        y: PropTypes.any,
+        z: PropTypes.shape({
+          c: PropTypes.any,
+          C: PropTypes.string,
+          a: PropTypes.any,
+          b: PropTypes.bool,
+        }),
+      };
+    `
   }],
 
   invalid: [{
@@ -626,7 +645,7 @@ ruleTester.run('sort-prop-types', rule, {
       callbacksLast: true
     }],
     errors: [{
-      message: 'Callback prop types must be listed after all other prop types',
+      message: CALLBACK_ERROR_MESSAGE,
       line: 5,
       column: 5,
       type: 'Property'
@@ -670,7 +689,7 @@ ruleTester.run('sort-prop-types', rule, {
       requiredFirst: true
     }],
     errors: [{
-      message: 'Required prop types must be listed before all other prop types',
+      message: REQUIRED_ERROR_MESSAGE,
       line: 4,
       column: 5,
       type: 'Property'
@@ -688,7 +707,7 @@ ruleTester.run('sort-prop-types', rule, {
     ].join('\n'),
     parser: 'babel-eslint',
     errors: [{
-      message: 'Prop types declarations should be sorted alphabetically',
+      message: ERROR_MESSAGE,
       line: 6,
       column: 5,
       type: 'Property'
@@ -708,6 +727,255 @@ ruleTester.run('sort-prop-types', rule, {
       message: ERROR_MESSAGE,
       line: 3,
       column: 3,
+      type: 'Property'
+    }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        x: PropTypes.any,
+        y: PropTypes.any,
+        z: PropTypes.shape({
+          c: PropTypes.any,
+          a: PropTypes.any,
+          b: PropTypes.bool,
+        }),
+      };
+    `,
+    options: [{
+      sortShapeProp: true
+    }],
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 12,
+      column: 11,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 13,
+      column: 11,
+      type: 'Property'
+    }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        z: PropTypes.any,
+        y: PropTypes.any,
+        a: PropTypes.shape({
+          c: PropTypes.any,
+          C: PropTypes.string,
+          a: PropTypes.any,
+          b: PropTypes.bool,
+        }),
+      };
+    `,
+    options: [{
+      sortShapeProp: true
+    }],
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 9,
+      column: 9,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 10,
+      column: 9,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 12,
+      column: 11,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 13,
+      column: 11,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 14,
+      column: 11,
+      type: 'Property'
+    }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        x: PropTypes.any,
+        y: PropTypes.any,
+        z: PropTypes.shape({
+          c: PropTypes.any,
+          C: PropTypes.string,
+          a: PropTypes.any,
+          b: PropTypes.bool,
+        }),
+      };
+    `,
+    options: [{
+      sortShapeProp: true,
+      ignoreCase: true
+    }],
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 13,
+      column: 11,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 14,
+      column: 11,
+      type: 'Property'
+    }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        x: PropTypes.any,
+        y: PropTypes.any,
+        z: PropTypes.shape({
+          a: PropTypes.string,
+          c: PropTypes.number.isRequired,
+          b: PropTypes.any,
+          d: PropTypes.bool,
+        }),
+      };
+    `,
+    options: [{
+      sortShapeProp: true,
+      requiredFirst: true
+    }],
+    errors: [{
+      message: REQUIRED_ERROR_MESSAGE,
+      line: 12,
+      column: 11,
+      type: 'Property'
+    }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        x: PropTypes.any,
+        y: PropTypes.any,
+        z: PropTypes.shape({
+          a: PropTypes.string,
+          c: PropTypes.number.isRequired,
+          b: PropTypes.any,
+          onFoo: PropTypes.func,
+          d: PropTypes.bool,
+        }),
+      };
+    `,
+    options: [{
+      sortShapeProp: true,
+      callbacksLast: true
+    }],
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 13,
+      column: 11,
+      type: 'Property'
+    }, {
+      message: CALLBACK_ERROR_MESSAGE,
+      line: 14,
+      column: 11,
+      type: 'Property'
+    }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        x: PropTypes.any,
+        y: PropTypes.any,
+        z: PropTypes.shape({
+          a: PropTypes.string,
+          c: PropTypes.number.isRequired,
+          b: PropTypes.any,
+          ...otherPropTypes,
+          f: PropTypes.bool,
+          d: PropTypes.string,
+        }),
+      };
+    `,
+    options: [{
+      sortShapeProp: true
+    }],
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 13,
+      column: 11,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 16,
+      column: 11,
+      type: 'Property'
+    }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        static propTypes = {
+          z: PropTypes.any,
+          y: PropTypes.any,
+          a: PropTypes.shape({
+            c: PropTypes.any,
+            a: PropTypes.any,
+            b: PropTypes.bool,
+          }),
+        };
+        render() {
+          return <div />;
+        }
+      }
+    `,
+    options: [{
+      sortShapeProp: true
+    }],
+    parser: 'babel-eslint',
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 5,
+      column: 11,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 6,
+      column: 11,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 8,
+      column: 13,
+      type: 'Property'
+    }, {
+      message: ERROR_MESSAGE,
+      line: 9,
+      column: 13,
       type: 'Property'
     }]
   }]


### PR DESCRIPTION
This allows the rule to enforce the sorting rules in a shape prop object.

I think it makes more sense to happen by default, but I expect it would be better to wait until the next major version for that. This PR should allow the rule to satisfy the request in #1476.