### PR TITLE
Replace node.start/node.end with node.range[0]/node.range[1], respectively

### DIFF
--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -232,7 +232,7 @@ module.exports = {
 
       'JSXOpeningElement:exit': function(node) {
         const attributeNode = lastAttributeNode[getOpeningElementId(node)];
-        const cachedLastAttributeEndPos = attributeNode ? attributeNode.end : null;
+        const cachedLastAttributeEndPos = attributeNode ? attributeNode.range[1] : null;
         let expectedNextLine;
         const tokens = getTokensLocations(node);
         const expectedLocation = getExpectedLocation(tokens);
@@ -260,18 +260,18 @@ module.exports = {
             switch (expectedLocation) {
               case 'after-tag':
                 if (cachedLastAttributeEndPos) {
-                  return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
+                  return fixer.replaceTextRange([cachedLastAttributeEndPos, node.range[1]],
                     (expectedNextLine ? '\n' : '') + closingTag);
                 }
-                return fixer.replaceTextRange([node.name.range[1], node.end],
+                return fixer.replaceTextRange([node.name.range[1], node.range[1]],
                   (expectedNextLine ? '\n' : ' ') + closingTag);
               case 'after-props':
-                return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
+                return fixer.replaceTextRange([cachedLastAttributeEndPos, node.range[1]],
                   (expectedNextLine ? '\n' : '') + closingTag);
               case 'props-aligned':
               case 'tag-aligned':
               case 'line-aligned':
-                return fixer.replaceTextRange([cachedLastAttributeEndPos, node.end],
+                return fixer.replaceTextRange([cachedLastAttributeEndPos, node.range[1]],
                   `\n${getIndentation(tokens, expectedLocation, correctColumn)}${closingTag}`);
               default:
                 return true;

--- a/lib/rules/jsx-closing-tag-location.js
+++ b/lib/rules/jsx-closing-tag-location.js
@@ -73,7 +73,7 @@ module.exports = {
             const indent = Array(opening.loc.start.column + 1).join(' ');
             if (isNodeFirstInLine(node)) {
               return fixer.replaceTextRange(
-                [node.start - node.loc.start.column, node.start],
+                [node.range[0] - node.loc.start.column, node.range[0]],
                 indent
               );
             }

--- a/lib/rules/jsx-equals-spacing.js
+++ b/lib/rules/jsx-equals-spacing.js
@@ -59,7 +59,7 @@ module.exports = {
                   loc: equalToken.loc.start,
                   message: 'There should be no space before \'=\'',
                   fix: function(fixer) {
-                    return fixer.removeRange([attrNode.name.range[1], equalToken.start]);
+                    return fixer.removeRange([attrNode.name.range[1], equalToken.range[0]]);
                   }
                 });
               }
@@ -69,7 +69,7 @@ module.exports = {
                   loc: equalToken.loc.start,
                   message: 'There should be no space after \'=\'',
                   fix: function(fixer) {
-                    return fixer.removeRange([equalToken.end, attrNode.value.range[0]]);
+                    return fixer.removeRange([equalToken.range[1], attrNode.value.range[0]]);
                   }
                 });
               }

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -42,7 +42,7 @@ module.exports = {
                 node: decl,
                 message: 'Property should be placed on a new line',
                 fix: function(fixer) {
-                  return fixer.replaceTextRange([node.name.end, decl.start], '\n');
+                  return fixer.replaceTextRange([node.name.end, decl.range[0]], '\n');
                 }
               });
             }
@@ -55,7 +55,7 @@ module.exports = {
               node: firstNode,
               message: 'Property should be placed on the same line as the component declaration',
               fix: function(fixer) {
-                return fixer.replaceTextRange([node.name.end, firstNode.start], ' ');
+                return fixer.replaceTextRange([node.name.end, firstNode.range[0]], ' ');
               }
             });
             return;

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -97,7 +97,7 @@ module.exports = {
           message: MESSAGE,
           data: msgContext,
           fix: function(fixer) {
-            return fixer.replaceTextRange([node.start - node.loc.start.column, node.start],
+            return fixer.replaceTextRange([node.range[0] - node.loc.start.column, node.range[0]],
               Array(needed + 1).join(indentType === 'space' ? ' ' : '\t'));
           }
         });

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -81,7 +81,7 @@ module.exports = {
       return function(fixer) {
         const indent = Array(needed + 1).join(indentChar);
         return fixer.replaceTextRange(
-          [node.start - node.loc.start.column, node.start],
+          [node.range[0] - node.loc.start.column, node.range[0]],
           indent
         );
       };
@@ -225,7 +225,7 @@ module.exports = {
         }
         // Use the parent in a list or an array
         if (prevToken.type === 'JSXText' || prevToken.type === 'Punctuator' && prevToken.value === ',') {
-          prevToken = sourceCode.getNodeByRangeIndex(prevToken.start);
+          prevToken = sourceCode.getNodeByRangeIndex(prevToken.range[0]);
           prevToken = prevToken.type === 'Literal' ? prevToken.parent : prevToken;
         // Use the first non-punctuator token in a conditional expression
         } else if (prevToken.type === 'Punctuator' && prevToken.value === ':') {

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -47,8 +47,8 @@ module.exports = {
 
     function generateFixFunction(line, max) {
       const output = [];
-      const front = line[0].start;
-      const back = line[line.length - 1].end;
+      const front = line[0].range[0];
+      const back = line[line.length - 1].range[1];
       for (let i = 0; i < line.length; i += max) {
         const nodes = line.slice(i, i + max);
         output.push(nodes.reduce((prev, curr) => {

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -102,7 +102,7 @@ const generateFixerFunction = (node, context) => {
         const sortedAttr = sortedAttributeGroups[ii][jj];
         const sortedAttrText = sourceCode.getText(sortedAttr);
         fixers.push(
-          fixer.replaceTextRange([attr.start, attr.end], sortedAttrText)
+          fixer.replaceTextRange([attr.range[0], attr.range[1]], sortedAttrText)
         );
       });
     });

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -77,9 +77,9 @@ module.exports = {
           message: 'Empty components are self-closing',
           fix: function(fixer) {
             // Represents the last character of the JSXOpeningElement, the '>' character
-            const openingElementEnding = node.end - 1;
+            const openingElementEnding = node.range[1] - 1;
             // Represents the last character of the JSXClosingElement, the '>' character
-            const closingElementEnding = node.parent.closingElement.end;
+            const closingElementEnding = node.parent.closingElement.range[1];
 
             // Replace />.*<\/.*>/ with '/>'
             const range = [openingElementEnding, closingElementEnding];


### PR DESCRIPTION
Usage of non-standard `.start`/`.end` properties causes failures when they aren't set by some parsers that follow the official AST (e.g. [typescript-eslint-parser](https://github.com/eslint/typescript-eslint-parser)).

See: https://github.com/eslint/eslint/issues/8956