### PR TITLE
Remove `super` being used as variable in a test

### DIFF
--- a/tests/lib/rules/jsx-indent.js
+++ b/tests/lib/rules/jsx-indent.js
@@ -409,7 +409,7 @@ ruleTester.run('jsx-indent', rule, {
       '  <span>',
       '    {condition ?',
       '      <Thing',
-      '        foo={super}',
+      '        foo={superFoo}',
       '      /> :',
       '      <Thing/>',
       '    }',


### PR DESCRIPTION
I think an update to acorn picked up through eslint->espree caused this test to fail very recently.