### PR TITLE
chore: rm node_modules from eslintignore.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,1 @@
-node_modules/**
 reports/**


### PR DESCRIPTION
since it was ignored by default.