### PR TITLE
Account for defaultProps in prefer-stateless rule

### DIFF
--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -6,7 +6,7 @@ Stateless functional components are simpler than class based components and will
 
 This rule will check your class based React components for
 
-* methods/properties other than `displayName`, `propTypes`, `render` and useless constructor (same detection as ESLint [no-useless-constructor rule](http://eslint.org/docs/rules/no-useless-constructor))
+* methods/properties other than `displayName`, `propTypes`, `contextTypes`, `defaultProps`, `render` and useless constructor (same detection as ESLint [no-useless-constructor rule](http://eslint.org/docs/rules/no-useless-constructor))
 * instance property other than `this.props` and `this.context`
 * extension of `React.PureComponent` (if the `ignorePureComponents` flag is true)
 * presence of `ref` attribute in JSX

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -216,12 +216,13 @@ module.exports = {
         const isDisplayName = name === 'displayName';
         const isPropTypes = name === 'propTypes' || name === 'props' && property.typeAnnotation;
         const contextTypes = name === 'contextTypes';
+        const defaultProps = name === 'defaultProps';
         const isUselessConstructor =
           property.kind === 'constructor' &&
           isRedundantSuperCall(property.value.body.body, property.value.params)
         ;
         const isRender = name === 'render';
-        return !isDisplayName && !isPropTypes && !contextTypes && !isUselessConstructor && !isRender;
+        return !isDisplayName && !isPropTypes && !contextTypes && !defaultProps && !isUselessConstructor && !isRender;
       });
     }
 

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -547,7 +547,54 @@ ruleTester.run('prefer-stateless-function', rule, {
       errors: [{
         message: 'Component should be written as a pure function'
       }]
-
+    }, {
+      code: `
+        class Foo extends React.Component {
+          static contextTypes = {
+            foo: PropTypes.boolean
+          }
+          render() {
+            const { foo } = this.context;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+      parser: 'babel-eslint',
+      errors: [{
+        message: 'Component should be written as a pure function'
+      }]
+    }, {
+      code: `
+        class Foo extends React.Component {
+          static get contextTypes() {
+            return {
+              foo: PropTypes.boolean
+            };
+          }
+          render() {
+            const { foo } = this.context;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+      errors: [{
+        message: 'Component should be written as a pure function'
+      }]
+    }, {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            const { foo } = this.context;
+            return foo ? <div /> : null;
+          }
+        }
+        Foo.contextTypes = {
+          foo: PropTypes.boolean
+        };
+      `,
+      errors: [{
+        message: 'Component should be written as a pure function'
+      }]
     }
   ]
 });

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -496,10 +496,58 @@ ruleTester.run('prefer-stateless-function', rule, {
           }
         }
       `,
+      errors: [{
+        message: 'Component should be written as a pure function'
+      }]
+    }, {
+      code: `
+        class Foo extends React.Component {
+          static defaultProps = {
+            foo: true
+          }
+          render() {
+            const { foo } = this.props;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
       parser: 'babel-eslint',
       errors: [{
         message: 'Component should be written as a pure function'
       }]
+    }, {
+      code: `
+        class Foo extends React.Component {
+          static get defaultProps() {
+            return {
+              foo: true
+            };
+          }
+          render() {
+            const { foo } = this.props;
+            return foo ? <div /> : null;
+          }
+        }
+      `,
+      errors: [{
+        message: 'Component should be written as a pure function'
+      }]
+    }, {
+      code: `
+        class Foo extends React.Component {
+          render() {
+            const { foo } = this.props;
+            return foo ? <div /> : null;
+          }
+        }
+        Foo.defaultProps = {
+          foo: true
+        };
+      `,
+      errors: [{
+        message: 'Component should be written as a pure function'
+      }]
+
     }
   ]
 });


### PR DESCRIPTION
Previously, a class component that could be converted to a stateless
functional component would not be reported as such if the component had
`defaultProps` defined as a class property.

Closes #1521