### PR TITLE
Fix bad report by jsx-no-comment-textnodes

### DIFF
--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -34,7 +34,10 @@ module.exports = {
 
     return {
       Literal: function(node) {
-        if (/^\s*\/(\/|\*)/m.test(node.value)) {
+        const sourceCode = context.getSourceCode();
+        // since babel-eslint has the wrong node.raw, we'll get the source text
+        const rawValue = sourceCode.getText(node);
+        if (/^\s*\/(\/|\*)/m.test(rawValue)) {
           // inside component, e.g. <div>literal</div>
           if (node.parent.type !== 'JSXAttribute' &&
               node.parent.type !== 'JSXExpressionContainer' &&

--- a/tests/lib/rules/jsx-no-comment-textnodes.js
+++ b/tests/lib/rules/jsx-no-comment-textnodes.js
@@ -131,6 +131,20 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       <Foo title={'foo' /* valid */}/>
     `,
       parser: 'babel-eslint'
+    },
+    {
+      code: '<pre>&#x2F;&#x2F; TODO: Write perfect code</pre>'
+    },
+    {
+      code: '<pre>&#x2F;&#x2F; TODO: Write perfect code</pre>',
+      parser: 'babel-eslint'
+    },
+    {
+      code: '<pre>&#x2F;&#42; TODO: Write perfect code &#42;&#x2F;</pre>'
+    },
+    {
+      code: '<pre>&#x2F;&#42; TODO: Write perfect code &#42;&#x2F;</pre>',
+      parser: 'babel-eslint'
     }
   ],
 


### PR DESCRIPTION
The rule was reporting usage of two slashes via html entities at the
beginning of a literal between JSX elements. Since that is not a valid
comment, there should be no error reported by this rule.

Closes #1517 