### PR TITLE
Fix crash in default-props-match-prop-types

### DIFF
--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -177,6 +177,10 @@ module.exports = {
           annotation = findVariableByName(annotation.id.name);
         }
 
+        if (!annotation || !annotation.properties) {
+          return properties;
+        }
+
         return properties.concat(annotation.properties);
       }, []);
     }

--- a/tests/lib/rules/default-props-match-prop-types.js
+++ b/tests/lib/rules/default-props-match-prop-types.js
@@ -755,6 +755,19 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    },
+    // don't error when variable is not in scope with intersection
+    {
+      code: [
+        'import type ImportedProps from "fake";',
+        'type Props = ImportedProps & {',
+        '  foo: string',
+        '};',
+        'function Hello(props: Props) {',
+        '  return <div>Hello {props.name.firstname}</div>;',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
     }
   ],
 


### PR DESCRIPTION
The rule would crash when checking an intersection with a
GenericTypeAnnotation that was not defined in the scope of the file.

Closes #1499 