### PR TITLE
Deprecation check for React.DOM factories 

### DIFF
--- a/docs/rules/no-deprecated.md
+++ b/docs/rules/no-deprecated.md
@@ -23,6 +23,9 @@ const propTypes = {
   foo: PropTypes.bar,
 };
 
+//Any factories under React.DOM
+React.DOM.div();
+
 import React, { PropTypes } from 'react';
 ```
 

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -68,7 +68,8 @@ module.exports = {
       // 15.5.0
       deprecated[`${pragma}.createClass`] = ['15.5.0', 'the npm module create-react-class'];
       deprecated[`${pragma}.PropTypes`] = ['15.5.0', 'the npm module prop-types'];
-
+      // 15.6.0
+      deprecated[`${pragma}.DOM`] = ['15.6.0', 'the npm module react-dom-factories'];
       return deprecated;
     }
 

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -174,5 +174,11 @@ ruleTester.run('no-deprecated', rule, {
     errors: [{
       message: 'ReactPerf.printDOM is deprecated since React 15.0.0, use ReactPerf.printOperations instead'
     }]
+  },
+  {
+    code: 'React.DOM.div',
+    errors: [{
+      message: 'React.DOM is deprecated since React 15.6.0, use the npm module react-dom-factories instead'
+    }]
   }]
 });


### PR DESCRIPTION
React.DOM factories were deprecated in 15.6.0 -> https://github.com/facebook/react/pull/8356