### PR TITLE
Add forbidDefaultForRequired option

### DIFF
--- a/docs/rules/require-default-props.md
+++ b/docs/rules/require-default-props.md
@@ -103,6 +103,19 @@ Greeting.defaultProps = {
 ```
 
 ```jsx
+type Props = {
+  foo: string,
+  bar?: string
+};
+
+function MyStatelessComponent(props: Props) {
+  return <div>Hello {props.foo} {props.bar}</div>;
+}
+```
+
+The following patterns are **not** considered warnings:
+
+```jsx
 class Greeting extends React.Component {
   render() {
     return (
@@ -120,19 +133,6 @@ class Greeting extends React.Component {
   };
 }
 ```
-
-```jsx
-type Props = {
-  foo: string,
-  bar?: string
-};
-
-function MyStatelessComponent(props: Props) {
-  return <div>Hello {props.foo} {props.bar}</div>;
-}
-```
-
-The following patterns are **not** considered warnings:
 
 ```jsx
 function MyStatelessComponent({ foo, bar }) {
@@ -180,6 +180,91 @@ function NotAComponent({ foo, bar }) {}
 
 NotAComponent.propTypes = {
   foo: PropTypes.string,
+  bar: PropTypes.string.isRequired
+};
+```
+
+## Rule Options
+
+```js
+...
+"react/require-default-props": [<enabled>, { forbidDefaultForRequired: <boolean> }]
+...
+```
+
+* `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
+* `forbidDefaultForRequired`: optional boolean to forbid prop default for a required prop. Defaults to false.
+
+### `forbidDefaultForRequired`
+
+Forbids setting a default for props that are marked as `isRequired`.
+
+The following patterns are warnings:
+
+```jsx
+class Greeting extends React.Component {
+  render() {
+    return (
+      <h1>Hello, {this.props.foo} {this.props.bar}</h1>
+    );
+  }
+
+  static propTypes = {
+    foo: PropTypes.string,
+    bar: PropTypes.string.isRequired
+  };
+
+  static defaultProps = {
+    foo: "foo",
+    bar: "bar"
+  };
+}
+```
+
+```jsx
+function MyStatelessComponent({ foo, bar }) {
+  return <div>{foo}{bar}</div>;
+}
+
+MyStatelessComponent.propTypes = {
+  foo: PropTypes.string.isRequired,
+  bar: PropTypes.string
+};
+
+MyStatelessComponent.defaultProps = {
+  foo: 'foo',
+  bar: 'bar'
+};
+```
+
+The following patterns are **not** warnings:
+
+```jsx
+class Greeting extends React.Component {
+  render() {
+    return (
+      <h1>Hello, {this.props.foo} {this.props.bar}</h1>
+    );
+  }
+
+  static propTypes = {
+    foo: PropTypes.string,
+    bar: PropTypes.string.isRequired
+  };
+
+  static defaultProps = {
+    foo: "foo"
+  };
+}
+```
+
+```jsx
+function MyStatelessComponent({ foo, bar }) {
+  return <div>{foo}{bar}</div>;
+}
+
+MyStatelessComponent.propTypes = {
+  foo: PropTypes.string.isRequired,
   bar: PropTypes.string.isRequired
 };
 ```

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -24,12 +24,22 @@ module.exports = {
       category: 'Best Practices'
     },
 
-    schema: []
+    schema: [{
+      type: 'object',
+      properties: {
+        forbidDefaultForRequired: {
+          type: 'boolean'
+        }
+      },
+      additionalProperties: false
+    }]
   },
 
   create: Components.detect((context, components, utils) => {
     const sourceCode = context.getSourceCode();
     const propWrapperFunctions = new Set(context.settings.propWrapperFunctions || []);
+    const configuration = context.options[0] || {};
+    const forbidDefaultForRequired = configuration.forbidDefaultForRequired || false;
 
     /**
      * Find a variable by name in the current scope.
@@ -285,6 +295,13 @@ module.exports = {
 
       propTypes.forEach(prop => {
         if (prop.isRequired) {
+          if (forbidDefaultForRequired && defaultProps[prop.name]) {
+            context.report(
+              prop.node,
+              'propType "{{name}}" is required and should not have a defaultProp declaration.',
+              {name: prop.name}
+            );
+          }
           return;
         }
 

--- a/tests/lib/rules/require-default-props.js
+++ b/tests/lib/rules/require-default-props.js
@@ -735,6 +735,20 @@ ruleTester.run('require-default-props', rule, {
         '};'
       ].join('\n'),
       parser: 'babel-eslint'
+    },
+    {
+      code: [
+        'class Hello extends React.Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string.isRequired',
+        '  }',
+        '  render() {',
+        '    return <div>Hello {this.props.foo}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      options: [{forbidDefaultForRequired: true}]
     }
   ],
 
@@ -1895,6 +1909,102 @@ ruleTester.run('require-default-props', rule, {
       parser: 'babel-eslint',
       errors: [{
         message: 'propType "first-name" is not required, but has no corresponding defaultProp declaration.'
+      }]
+    },
+    {
+      code: [
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    return <div>Hello {this.props.foo}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string.isRequired',
+        '};',
+        'Hello.defaultProps = {',
+        '  foo: \'bar\'',
+        '};'
+      ].join('\n'),
+      options: [{forbidDefaultForRequired: true}],
+      errors: [{
+        message: 'propType "foo" is required and should not have a defaultProp declaration.'
+      }]
+    },
+    {
+      code: [
+        'function Hello(props) {',
+        '  return <div>Hello {props.foo}</div>;',
+        '}',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string.isRequired',
+        '};',
+        'Hello.defaultProps = {',
+        '  foo: \'bar\'',
+        '};'
+      ].join('\n'),
+      options: [{forbidDefaultForRequired: true}],
+      errors: [{
+        message: 'propType "foo" is required and should not have a defaultProp declaration.'
+      }]
+    },
+    {
+      code: [
+        'const Hello = (props) => {',
+        '  return <div>Hello {props.foo}</div>;',
+        '};',
+        'Hello.propTypes = {',
+        '  foo: PropTypes.string.isRequired',
+        '};',
+        'Hello.defaultProps = {',
+        '  foo: \'bar\'',
+        '};'
+      ].join('\n'),
+      options: [{forbidDefaultForRequired: true}],
+      errors: [{
+        message: 'propType "foo" is required and should not have a defaultProp declaration.'
+      }]
+    },
+    {
+      code: [
+        'class Hello extends React.Component {',
+        '  static propTypes = {',
+        '    foo: PropTypes.string.isRequired',
+        '  }',
+        '  static defaultProps = {',
+        '    foo: \'bar\'',
+        '  }',
+        '  render() {',
+        '    return <div>Hello {this.props.foo}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      options: [{forbidDefaultForRequired: true}],
+      errors: [{
+        message: 'propType "foo" is required and should not have a defaultProp declaration.'
+      }]
+    },
+    {
+      code: [
+        'class Hello extends React.Component {',
+        '  static get propTypes () {',
+        '    return {',
+        '      foo: PropTypes.string.isRequired',
+        '    };',
+        '  }',
+        '  static get defaultProps() {',
+        '    return {',
+        '      foo: \'bar\'',
+        '    };',
+        '  }',
+        '  render() {',
+        '    return <div>Hello {this.props.foo}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      options: [{forbidDefaultForRequired: true}],
+      errors: [{
+        message: 'propType "foo" is required and should not have a defaultProp declaration.'
       }]
     }
   ]


### PR DESCRIPTION
New option for require-default-props rule that forbids defining default
props for props that are required.

This doesn't handle spread properties since the work needed should also work for the default state of the rule. If that were to happen, it could cause reports for previously valid code, and that seems more suitable for a major version bump. Therefore, I think that should be in a separate PR.

Closes #1524