### PR TITLE
forbid-prop-types: forbid contextTypes, childContextTypes

### DIFF
--- a/docs/rules/forbid-prop-types.md
+++ b/docs/rules/forbid-prop-types.md
@@ -44,13 +44,17 @@ class Component extends React.Component {
 
 ```js
 ...
-"react/forbid-prop-types": [<enabled>, { "forbid": [<string>] }]
+"react/forbid-prop-types": [<enabled>, { "forbid": [<string>], checkContextTypes: <boolean> }]
 ...
 ```
 
 ### `forbid`
 
 An array of strings, with the names of `PropTypes` keys that are forbidden. The default value for this option is `['any', 'array', 'object']`.
+
+### `checkContextTypes`
+
+Whether or not to check `contextTypes` for forbidden prop types. The default value is false.
 
 ## When not to use
 

--- a/docs/rules/forbid-prop-types.md
+++ b/docs/rules/forbid-prop-types.md
@@ -44,7 +44,7 @@ class Component extends React.Component {
 
 ```js
 ...
-"react/forbid-prop-types": [<enabled>, { "forbid": [<string>], checkContextTypes: <boolean> }]
+"react/forbid-prop-types": [<enabled>, { "forbid": [<string>], checkContextTypes: <boolean>, checkChildContextTypes: <boolean> }]
 ...
 ```
 
@@ -55,6 +55,10 @@ An array of strings, with the names of `PropTypes` keys that are forbidden. The 
 ### `checkContextTypes`
 
 Whether or not to check `contextTypes` for forbidden prop types. The default value is false.
+
+### `checkChildContextTypes`
+
+Whether or not to check `childContextTypes` for forbidden prop types. The default value is false.
 
 ## When not to use
 

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -35,6 +35,9 @@ module.exports = {
         },
         checkContextTypes: {
           type: 'boolean'
+        },
+        checkChildContextTypes: {
+          type: 'boolean'
         }
       },
       additionalProperties: true
@@ -45,6 +48,7 @@ module.exports = {
     const propWrapperFunctions = new Set(context.settings.propWrapperFunctions || []);
     const configuration = context.options[0] || {};
     const checkContextTypes = configuration.checkContextTypes || false;
+    const checkChildContextTypes = configuration.checkChildContextTypes || false;
 
     function isForbidden(type) {
       const forbid = configuration.forbid || DEFAULTS;
@@ -53,6 +57,13 @@ module.exports = {
 
     function shouldCheckContextTypes(node) {
       if (checkContextTypes && propsUtil.isContextTypesDeclaration(node)) {
+        return true;
+      }
+      return false;
+    }
+
+    function shouldCheckChildContextTypes(node) {
+      if (checkChildContextTypes && propsUtil.isChildContextTypesDeclaration(node)) {
         return true;
       }
       return false;
@@ -142,14 +153,22 @@ module.exports = {
 
     return {
       ClassProperty: function(node) {
-        if (!propsUtil.isPropTypesDeclaration(node) && !shouldCheckContextTypes(node)) {
+        if (
+          !propsUtil.isPropTypesDeclaration(node) &&
+          !shouldCheckContextTypes(node) &&
+          !shouldCheckChildContextTypes(node)
+        ) {
           return;
         }
         checkNode(node.value);
       },
 
       MemberExpression: function(node) {
-        if (!propsUtil.isPropTypesDeclaration(node) && !shouldCheckContextTypes(node)) {
+        if (
+          !propsUtil.isPropTypesDeclaration(node) &&
+          !shouldCheckContextTypes(node) &&
+          !shouldCheckChildContextTypes(node)
+        ) {
           return;
         }
 
@@ -162,7 +181,11 @@ module.exports = {
             return;
           }
 
-          if (!propsUtil.isPropTypesDeclaration(property) && !shouldCheckContextTypes(property)) {
+          if (
+            !propsUtil.isPropTypesDeclaration(property) &&
+            !shouldCheckContextTypes(property) &&
+            !shouldCheckChildContextTypes(property)
+          ) {
             return;
           }
           if (property.value.type === 'ObjectExpression') {

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -5,6 +5,7 @@
 
 const variableUtil = require('../util/variable');
 const propsUtil = require('../util/props');
+const astUtil = require('../util/ast');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -173,6 +174,22 @@ module.exports = {
         }
 
         checkNode(node.parent.right);
+      },
+
+      MethodDefinition: function(node) {
+        if (
+          !propsUtil.isPropTypesDeclaration(node) &&
+          !shouldCheckContextTypes(node) &&
+          !shouldCheckChildContextTypes(node)
+        ) {
+          return;
+        }
+
+        const returnStatement = astUtil.findReturnStatement(node);
+
+        if (returnStatement && returnStatement.argument) {
+          checkNode(returnStatement.argument);
+        }
       },
 
       ObjectExpression: function(node) {

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -32,6 +32,9 @@ module.exports = {
           items: {
             type: 'string'
           }
+        },
+        checkContextTypes: {
+          type: 'boolean'
         }
       },
       additionalProperties: true
@@ -40,12 +43,19 @@ module.exports = {
 
   create: function(context) {
     const propWrapperFunctions = new Set(context.settings.propWrapperFunctions || []);
+    const configuration = context.options[0] || {};
+    const checkContextTypes = configuration.checkContextTypes || false;
 
     function isForbidden(type) {
-      const configuration = context.options[0] || {};
-
       const forbid = configuration.forbid || DEFAULTS;
       return forbid.indexOf(type) >= 0;
+    }
+
+    function shouldCheckContextTypes(node) {
+      if (checkContextTypes && propsUtil.isContextTypesDeclaration(node)) {
+        return true;
+      }
+      return false;
     }
 
     /**
@@ -132,14 +142,14 @@ module.exports = {
 
     return {
       ClassProperty: function(node) {
-        if (!propsUtil.isPropTypesDeclaration(node)) {
+        if (!propsUtil.isPropTypesDeclaration(node) && !shouldCheckContextTypes(node)) {
           return;
         }
         checkNode(node.value);
       },
 
       MemberExpression: function(node) {
-        if (!propsUtil.isPropTypesDeclaration(node)) {
+        if (!propsUtil.isPropTypesDeclaration(node) && !shouldCheckContextTypes(node)) {
           return;
         }
 
@@ -152,7 +162,7 @@ module.exports = {
             return;
           }
 
-          if (!propsUtil.isPropTypesDeclaration(property)) {
+          if (!propsUtil.isPropTypesDeclaration(property) && !shouldCheckContextTypes(property)) {
             return;
           }
           if (property.value.type === 'ObjectExpression') {

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -9,6 +9,7 @@ const util = require('util');
 const doctrine = require('doctrine');
 const variableUtil = require('./variable');
 const pragmaUtil = require('./pragma');
+const astUtil = require('./ast');
 
 const usedPropTypesAreEquivalent = (propA, propB) => {
   if (propA.name === propB.name) {
@@ -356,24 +357,7 @@ function componentRule(rule, context) {
      *
      * @param {ASTNode} ASTnode The AST node being checked
      */
-    findReturnStatement: function(node) {
-      if (
-        (!node.value || !node.value.body || !node.value.body.body) &&
-        (!node.body || !node.body.body)
-      ) {
-        return false;
-      }
-
-      const bodyNodes = (node.value ? node.value.body.body : node.body.body);
-
-      let i = bodyNodes.length - 1;
-      for (; i >= 0; i--) {
-        if (bodyNodes[i].type === 'ReturnStatement') {
-          return bodyNodes[i];
-        }
-      }
-      return false;
-    },
+    findReturnStatement: astUtil.findReturnStatement,
 
     /**
      * Get the parent component node from the current scope

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -35,7 +35,32 @@ function getComponentProperties(node) {
   }
 }
 
+/**
+ * Find a return statment in the current node
+ *
+ * @param {ASTNode} ASTnode The AST node being checked
+ */
+function findReturnStatement(node) {
+  if (
+    (!node.value || !node.value.body || !node.value.body.body) &&
+    (!node.body || !node.body.body)
+  ) {
+    return false;
+  }
+
+  const bodyNodes = (node.value ? node.value.body.body : node.body.body);
+
+  let i = bodyNodes.length - 1;
+  for (; i >= 0; i--) {
+    if (bodyNodes[i].type === 'ReturnStatement') {
+      return bodyNodes[i];
+    }
+  }
+  return false;
+}
+
 module.exports = {
   getPropertyName: getPropertyName,
-  getComponentProperties: getComponentProperties
+  getComponentProperties: getComponentProperties,
+  findReturnStatement: findReturnStatement
 };

--- a/lib/util/props.js
+++ b/lib/util/props.js
@@ -36,6 +36,15 @@ function isContextTypesDeclaration(node) {
 }
 
 /**
+ * Checks if the node passed in looks like a childContextTypes declaration.
+ * @param {ASTNode} node The node to check.
+ * @returns {Boolean} `true` if the node is a childContextTypes declaration, `false` if not
+ */
+function isChildContextTypesDeclaration(node) {
+  return astUtil.getPropertyName(node) === 'childContextTypes';
+}
+
+/**
  * Checks if the Identifier node passed in looks like a defaultProps declaration.
  * @param {ASTNode} node The node to check. Must be an Identifier node.
  * @returns {Boolean} `true` if the node is a defaultProps declaration, `false` if not
@@ -57,6 +66,7 @@ function isRequiredPropType(propTypeExpression) {
 module.exports = {
   isPropTypesDeclaration: isPropTypesDeclaration,
   isContextTypesDeclaration: isContextTypesDeclaration,
+  isChildContextTypesDeclaration: isChildContextTypesDeclaration,
   isDefaultPropsDeclaration: isDefaultPropsDeclaration,
   isRequiredPropType: isRequiredPropType
 };

--- a/lib/util/props.js
+++ b/lib/util/props.js
@@ -21,6 +21,21 @@ function isPropTypesDeclaration(node) {
 }
 
 /**
+ * Checks if the node passed in looks like a contextTypes declaration.
+ * @param {ASTNode} node The node to check.
+ * @returns {Boolean} `true` if the node is a contextTypes declaration, `false` if not
+ */
+function isContextTypesDeclaration(node) {
+  if (node && node.type === 'ClassProperty') {
+    // Flow support
+    if (node.typeAnnotation && node.key.name === 'context') {
+      return true;
+    }
+  }
+  return astUtil.getPropertyName(node) === 'contextTypes';
+}
+
+/**
  * Checks if the Identifier node passed in looks like a defaultProps declaration.
  * @param {ASTNode} node The node to check. Must be an Identifier node.
  * @returns {Boolean} `true` if the node is a defaultProps declaration, `false` if not
@@ -41,6 +56,7 @@ function isRequiredPropType(propTypeExpression) {
 
 module.exports = {
   isPropTypesDeclaration: isPropTypesDeclaration,
+  isContextTypesDeclaration: isContextTypesDeclaration,
   isDefaultPropsDeclaration: isDefaultPropsDeclaration,
   isRequiredPropType: isRequiredPropType
 };

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -190,6 +190,167 @@ ruleTester.run('forbid-prop-types', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint'
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  contextTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkContextTypes: true}]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  contextTypes: {',
+      '    s: PropTypes.string,',
+      '    n: PropTypes.number,',
+      '    i: PropTypes.instanceOf,',
+      '    b: PropTypes.bool',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkContextTypes: true}]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  contextTypes: {',
+      '    a: PropTypes.array',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['any', 'object'],
+      checkContextTypes: true
+    }]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  contextTypes: {',
+      '    o: PropTypes.object',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['any', 'array'],
+      checkContextTypes: true
+    }]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  contextTypes: {',
+      '    o: PropTypes.object,',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['any', 'array'],
+      checkContextTypes: true
+    }]
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.contextTypes = {',
+      '  a: PropTypes.string,',
+      '  b: PropTypes.string',
+      '};',
+      'First.contextTypes.justforcheck = PropTypes.string;'
+    ].join('\n'),
+    options: [{checkContextTypes: true}]
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.contextTypes = {',
+      '  elem: PropTypes.instanceOf(HTMLElement)',
+      '};'
+    ].join('\n'),
+    options: [{checkContextTypes: true}]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  render() {',
+      '    return <div>Hello</div>;',
+      '  }',
+      '}',
+      'Hello.contextTypes = {',
+      '  "aria-controls": PropTypes.string',
+      '};'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{checkContextTypes: true}]
+  }, {
+    // Invalid code, should not be validated
+    code: [
+      'class Component extends React.Component {',
+      '  contextTypes: {',
+      '    a: PropTypes.any,',
+      '    c: PropTypes.any,',
+      '    b: PropTypes.any',
+      '  };',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{checkContextTypes: true}]
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  render: function() {',
+      '    let { a, ...b } = obj;',
+      '    let c = { ...d };',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkContextTypes: true}]
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  contextTypes: {',
+      '    retailer: PropTypes.instanceOf(Map).isRequired,',
+      '    requestRetailer: PropTypes.func.isRequired',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkContextTypes: true}]
+  }, {
+    // Proptypes declared with a spread property
+    code: [
+      'class Test extends react.component {',
+      '  static contextTypes = {',
+      '    intl: React.contextTypes.number,',
+      '    ...contextTypes',
+      '  };',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{checkContextTypes: true}]
   }],
 
   invalid: [{
@@ -478,6 +639,240 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{
       forbid: ['object']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  contextTypes: {',
+      '    a: PropTypes.any',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 3,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Foo extends Component {',
+      '  static contextTypes = {',
+      '    a: PropTypes.any',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{checkContextTypes: true}],
+    parser: 'babel-eslint',
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 3,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Foo extends Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'Foo.contextTypes = {',
+      '  a: PropTypes.any',
+      '};'
+    ].join('\n'),
+    options: [{checkContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 7,
+      column: 3,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'function Foo(props) {',
+      '  return <div />;',
+      '}',
+      'Foo.contextTypes = {',
+      '  a: PropTypes.any',
+      '};'
+    ].join('\n'),
+    options: [{checkContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 5,
+      column: 3,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'const Foo = (props) => {',
+      '  return <div />;',
+      '};',
+      'Foo.contextTypes = {',
+      '  a: PropTypes.any',
+      '};'
+    ].join('\n'),
+    options: [{checkContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 5,
+      column: 3,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static contextTypes = forbidExtraProps({',
+      '    a: PropTypes.array,',
+      '    o: PropTypes.object',
+      '  });',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    errors: 2,
+    options: [{checkContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'Component.contextTypes = forbidExtraProps({',
+      '  a: PropTypes.array,',
+      '  o: PropTypes.object',
+      '});'
+    ].join('\n'),
+    errors: 2,
+    options: [{checkContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'function Component(props) {',
+      '  return <div />;',
+      '}',
+      'Component.contextTypes = forbidExtraProps({',
+      '  a: PropTypes.array,',
+      '  o: PropTypes.object',
+      '});'
+    ].join('\n'),
+    errors: 2,
+    options: [{checkContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'const Component = (props) => {',
+      '  return <div />;',
+      '};',
+      'Component.contextTypes = forbidExtraProps({',
+      '  a: PropTypes.array,',
+      '  o: PropTypes.object',
+      '});'
+    ].join('\n'),
+    errors: 2,
+    options: [{checkContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  contextTypes: {',
+      '    retailer: PropTypes.instanceOf(Map).isRequired,',
+      '    requestRetailer: PropTypes.func.isRequired',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['instanceOf'],
+      checkContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static contextTypes = {',
+      '    retailer: PropTypes.instanceOf(Map).isRequired,',
+      '    requestRetailer: PropTypes.func.isRequired',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{
+      forbid: ['instanceOf'],
+      checkContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'Component.contextTypes = {',
+      '  retailer: PropTypes.instanceOf(Map).isRequired,',
+      '  requestRetailer: PropTypes.func.isRequired',
+      '}'
+    ].join('\n'),
+    options: [{
+      forbid: ['instanceOf'],
+      checkContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'function Component(props) {',
+      '  return <div />;',
+      '}',
+      'Component.contextTypes = {',
+      '  retailer: PropTypes.instanceOf(Map).isRequired,',
+      '  requestRetailer: PropTypes.func.isRequired',
+      '}'
+    ].join('\n'),
+    options: [{
+      forbid: ['instanceOf'],
+      checkContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'const Component = (props) => {',
+      '  return <div />;',
+      '};',
+      'Component.contextTypes = {',
+      '  retailer: PropTypes.instanceOf(Map).isRequired,',
+      '  requestRetailer: PropTypes.func.isRequired',
+      '}'
+    ].join('\n'),
+    options: [{
+      forbid: ['instanceOf'],
+      checkContextTypes: true
     }],
     errors: 1
   }]

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -19,8 +19,6 @@ const parserOptions = {
   }
 };
 
-require('babel-eslint');
-
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -191,6 +189,18 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     parser: 'babel-eslint'
   }, {
+    // Proptypes declared with a spread property
+    code: [
+      'class Test extends react.component {',
+      '  static get propTypes() {',
+      '    return {',
+      '      intl: React.propTypes.number,',
+      '      ...propTypes',
+      '    };',
+      '  };',
+      '}'
+    ].join('\n')
+  }, {
     code: [
       'var First = createReactClass({',
       '  childContextTypes: externalPropTypes,',
@@ -352,6 +362,19 @@ ruleTester.run('forbid-prop-types', rule, {
     parser: 'babel-eslint',
     options: [{checkContextTypes: true}]
   }, {
+    // Proptypes declared with a spread property
+    code: [
+      'class Test extends react.component {',
+      '  static get childContextTypes() {',
+      '    return {',
+      '      intl: React.childContextTypes.number,',
+      '      ...childContextTypes',
+      '    };',
+      '  };',
+      '}'
+    ].join('\n'),
+    options: [{checkContextTypes: true}]
+  }, {
     code: [
       'var First = createReactClass({',
       '  childContextTypes: externalPropTypes,',
@@ -511,6 +534,19 @@ ruleTester.run('forbid-prop-types', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
+    options: [{checkChildContextTypes: true}]
+  }, {
+    // Proptypes declared with a spread property
+    code: [
+      'class Test extends react.component {',
+      '  static get childContextTypes() {',
+      '    return {',
+      '      intl: React.childContextTypes.number,',
+      '      ...childContextTypes',
+      '    };',
+      '  };',
+      '}'
+    ].join('\n'),
     options: [{checkChildContextTypes: true}]
   }],
 
@@ -756,6 +792,21 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'class Component extends React.Component {',
+      '  static get propTypes() {',
+      '    return {',
+      '      a: PropTypes.array,',
+      '      o: PropTypes.object',
+      '    };',
+      '  };',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    errors: 2
+  }, {
+    code: [
+      'class Component extends React.Component {',
       '  static propTypes = forbidExtraProps({',
       '    a: PropTypes.array,',
       '    o: PropTypes.object',
@@ -766,6 +817,24 @@ ruleTester.run('forbid-prop-types', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
+    errors: 2,
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static get propTypes() {',
+      '    return forbidExtraProps({',
+      '      a: PropTypes.array,',
+      '      o: PropTypes.object',
+      '    });',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
     errors: 2,
     settings: {
       propWrapperFunctions: ['forbidExtraProps']
@@ -842,6 +911,26 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'class Foo extends Component {',
+      '  static get contextTypes() {',
+      '    return {',
+      '      a: PropTypes.any',
+      '    };',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{checkContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 4,
+      column: 7,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Foo extends Component {',
       '  render() {',
       '    return <div />;',
       '  }',
@@ -902,6 +991,25 @@ ruleTester.run('forbid-prop-types', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
+    errors: 2,
+    options: [{checkContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static get contextTypes() {',
+      '    return forbidExtraProps({',
+      '      a: PropTypes.array,',
+      '      o: PropTypes.object',
+      '    });',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
     errors: 2,
     options: [{checkContextTypes: true}],
     settings: {
@@ -984,6 +1092,25 @@ ruleTester.run('forbid-prop-types', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
+    options: [{
+      forbid: ['instanceOf'],
+      checkContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static get contextTypes() {',
+      '    return {',
+      '      retailer: PropTypes.instanceOf(Map).isRequired,',
+      '      requestRetailer: PropTypes.func.isRequired',
+      '    };',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
     options: [{
       forbid: ['instanceOf'],
       checkContextTypes: true
@@ -1076,6 +1203,26 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'class Foo extends Component {',
+      '  static get childContextTypes() {',
+      '    return {',
+      '      a: PropTypes.any',
+      '    };',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 4,
+      column: 7,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Foo extends Component {',
       '  render() {',
       '    return <div />;',
       '  }',
@@ -1136,6 +1283,25 @@ ruleTester.run('forbid-prop-types', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
+    errors: 2,
+    options: [{checkChildContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static get childContextTypes() {',
+      '    return forbidExtraProps({',
+      '      a: PropTypes.array,',
+      '      o: PropTypes.object',
+      '    });',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
     errors: 2,
     options: [{checkChildContextTypes: true}],
     settings: {

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -193,7 +193,7 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'var First = createReactClass({',
-      '  contextTypes: externalPropTypes,',
+      '  childContextTypes: externalPropTypes,',
       '  render: function() {',
       '    return <div />;',
       '  }',
@@ -203,7 +203,7 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'var First = createReactClass({',
-      '  contextTypes: {',
+      '  childContextTypes: {',
       '    s: PropTypes.string,',
       '    n: PropTypes.number,',
       '    i: PropTypes.instanceOf,',
@@ -218,7 +218,7 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'var First = createReactClass({',
-      '  contextTypes: {',
+      '  childContextTypes: {',
       '    a: PropTypes.array',
       '  },',
       '  render: function() {',
@@ -233,7 +233,7 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'var First = createReactClass({',
-      '  contextTypes: {',
+      '  childContextTypes: {',
       '    o: PropTypes.object',
       '  },',
       '  render: function() {',
@@ -248,7 +248,7 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'var First = createReactClass({',
-      '  contextTypes: {',
+      '  childContextTypes: {',
       '    o: PropTypes.object,',
       '  },',
       '  render: function() {',
@@ -267,11 +267,11 @@ ruleTester.run('forbid-prop-types', rule, {
       '    return <div />;',
       '  }',
       '}',
-      'First.contextTypes = {',
+      'First.childContextTypes = {',
       '  a: PropTypes.string,',
       '  b: PropTypes.string',
       '};',
-      'First.contextTypes.justforcheck = PropTypes.string;'
+      'First.childContextTypes.justforcheck = PropTypes.string;'
     ].join('\n'),
     options: [{checkContextTypes: true}]
   }, {
@@ -281,7 +281,7 @@ ruleTester.run('forbid-prop-types', rule, {
       '    return <div />;',
       '  }',
       '}',
-      'First.contextTypes = {',
+      'First.childContextTypes = {',
       '  elem: PropTypes.instanceOf(HTMLElement)',
       '};'
     ].join('\n'),
@@ -293,7 +293,7 @@ ruleTester.run('forbid-prop-types', rule, {
       '    return <div>Hello</div>;',
       '  }',
       '}',
-      'Hello.contextTypes = {',
+      'Hello.childContextTypes = {',
       '  "aria-controls": PropTypes.string',
       '};'
     ].join('\n'),
@@ -303,7 +303,7 @@ ruleTester.run('forbid-prop-types', rule, {
     // Invalid code, should not be validated
     code: [
       'class Component extends React.Component {',
-      '  contextTypes: {',
+      '  childContextTypes: {',
       '    a: PropTypes.any,',
       '    c: PropTypes.any,',
       '    b: PropTypes.any',
@@ -329,7 +329,7 @@ ruleTester.run('forbid-prop-types', rule, {
   }, {
     code: [
       'var Hello = createReactClass({',
-      '  contextTypes: {',
+      '  childContextTypes: {',
       '    retailer: PropTypes.instanceOf(Map).isRequired,',
       '    requestRetailer: PropTypes.func.isRequired',
       '  },',
@@ -343,14 +343,175 @@ ruleTester.run('forbid-prop-types', rule, {
     // Proptypes declared with a spread property
     code: [
       'class Test extends react.component {',
-      '  static contextTypes = {',
-      '    intl: React.contextTypes.number,',
-      '    ...contextTypes',
+      '  static childContextTypes = {',
+      '    intl: React.childContextTypes.number,',
+      '    ...childContextTypes',
       '  };',
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
     options: [{checkContextTypes: true}]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  childContextTypes: externalPropTypes,',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  childContextTypes: {',
+      '    s: PropTypes.string,',
+      '    n: PropTypes.number,',
+      '    i: PropTypes.instanceOf,',
+      '    b: PropTypes.bool',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  childContextTypes: {',
+      '    a: PropTypes.array',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['any', 'object'],
+      checkChildContextTypes: true
+    }]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  childContextTypes: {',
+      '    o: PropTypes.object',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['any', 'array'],
+      checkChildContextTypes: true
+    }]
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  childContextTypes: {',
+      '    o: PropTypes.object,',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['any', 'array'],
+      checkChildContextTypes: true
+    }]
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.childContextTypes = {',
+      '  a: PropTypes.string,',
+      '  b: PropTypes.string',
+      '};',
+      'First.childContextTypes.justforcheck = PropTypes.string;'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}]
+  }, {
+    code: [
+      'class First extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'First.childContextTypes = {',
+      '  elem: PropTypes.instanceOf(HTMLElement)',
+      '};'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}]
+  }, {
+    code: [
+      'class Hello extends React.Component {',
+      '  render() {',
+      '    return <div>Hello</div>;',
+      '  }',
+      '}',
+      'Hello.childContextTypes = {',
+      '  "aria-controls": PropTypes.string',
+      '};'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{checkChildContextTypes: true}]
+  }, {
+    // Invalid code, should not be validated
+    code: [
+      'class Component extends React.Component {',
+      '  childContextTypes: {',
+      '    a: PropTypes.any,',
+      '    c: PropTypes.any,',
+      '    b: PropTypes.any',
+      '  };',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{checkChildContextTypes: true}]
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  render: function() {',
+      '    let { a, ...b } = obj;',
+      '    let c = { ...d };',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}]
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  childContextTypes: {',
+      '    retailer: PropTypes.instanceOf(Map).isRequired,',
+      '    requestRetailer: PropTypes.func.isRequired',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}]
+  }, {
+    // Proptypes declared with a spread property
+    code: [
+      'class Test extends react.component {',
+      '  static childContextTypes = {',
+      '    intl: React.childContextTypes.number,',
+      '    ...childContextTypes',
+      '  };',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{checkChildContextTypes: true}]
   }],
 
   invalid: [{
@@ -873,6 +1034,240 @@ ruleTester.run('forbid-prop-types', rule, {
     options: [{
       forbid: ['instanceOf'],
       checkContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  childContextTypes: {',
+      '    a: PropTypes.any',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 3,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Foo extends Component {',
+      '  static childContextTypes = {',
+      '    a: PropTypes.any',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}],
+    parser: 'babel-eslint',
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 3,
+      column: 5,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Foo extends Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'Foo.childContextTypes = {',
+      '  a: PropTypes.any',
+      '};'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 7,
+      column: 3,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'function Foo(props) {',
+      '  return <div />;',
+      '}',
+      'Foo.childContextTypes = {',
+      '  a: PropTypes.any',
+      '};'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 5,
+      column: 3,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'const Foo = (props) => {',
+      '  return <div />;',
+      '};',
+      'Foo.childContextTypes = {',
+      '  a: PropTypes.any',
+      '};'
+    ].join('\n'),
+    options: [{checkChildContextTypes: true}],
+    errors: [{
+      message: ANY_ERROR_MESSAGE,
+      line: 5,
+      column: 3,
+      type: 'Property'
+    }]
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static childContextTypes = forbidExtraProps({',
+      '    a: PropTypes.array,',
+      '    o: PropTypes.object',
+      '  });',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    errors: 2,
+    options: [{checkChildContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'Component.childContextTypes = forbidExtraProps({',
+      '  a: PropTypes.array,',
+      '  o: PropTypes.object',
+      '});'
+    ].join('\n'),
+    errors: 2,
+    options: [{checkChildContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'function Component(props) {',
+      '  return <div />;',
+      '}',
+      'Component.childContextTypes = forbidExtraProps({',
+      '  a: PropTypes.array,',
+      '  o: PropTypes.object',
+      '});'
+    ].join('\n'),
+    errors: 2,
+    options: [{checkChildContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'const Component = (props) => {',
+      '  return <div />;',
+      '};',
+      'Component.childContextTypes = forbidExtraProps({',
+      '  a: PropTypes.array,',
+      '  o: PropTypes.object',
+      '});'
+    ].join('\n'),
+    errors: 2,
+    options: [{checkChildContextTypes: true}],
+    settings: {
+      propWrapperFunctions: ['forbidExtraProps']
+    }
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  childContextTypes: {',
+      '    retailer: PropTypes.instanceOf(Map).isRequired,',
+      '    requestRetailer: PropTypes.func.isRequired',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['instanceOf'],
+      checkChildContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  static childContextTypes = {',
+      '    retailer: PropTypes.instanceOf(Map).isRequired,',
+      '    requestRetailer: PropTypes.func.isRequired',
+      '  }',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    options: [{
+      forbid: ['instanceOf'],
+      checkChildContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'class Component extends React.Component {',
+      '  render() {',
+      '    return <div />;',
+      '  }',
+      '}',
+      'Component.childContextTypes = {',
+      '  retailer: PropTypes.instanceOf(Map).isRequired,',
+      '  requestRetailer: PropTypes.func.isRequired',
+      '}'
+    ].join('\n'),
+    options: [{
+      forbid: ['instanceOf'],
+      checkChildContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'function Component(props) {',
+      '  return <div />;',
+      '}',
+      'Component.childContextTypes = {',
+      '  retailer: PropTypes.instanceOf(Map).isRequired,',
+      '  requestRetailer: PropTypes.func.isRequired',
+      '}'
+    ].join('\n'),
+    options: [{
+      forbid: ['instanceOf'],
+      checkChildContextTypes: true
+    }],
+    errors: 1
+  }, {
+    code: [
+      'const Component = (props) => {',
+      '  return <div />;',
+      '};',
+      'Component.childContextTypes = {',
+      '  retailer: PropTypes.instanceOf(Map).isRequired,',
+      '  requestRetailer: PropTypes.func.isRequired',
+      '}'
+    ].join('\n'),
+    options: [{
+      forbid: ['instanceOf'],
+      checkChildContextTypes: true
     }],
     errors: 1
   }]


### PR DESCRIPTION
This PR adds support for checking `contextTypes` and `childContextTypes` for forbidden prop types. I also added support for checking getters, too, since I have seen them supported elsewhere.

Closes #1513 