### PR TITLE
Extract duplicate code between prop-types and no-unused-prop-types #1

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -84,7 +84,7 @@ module.exports = {
 
     /**
      * Check if we are in a lifecycle method
-     * @return {boolean} true if we are in a class constructor, false if not
+     * @return {boolean} true if we are in a lifecycle method, false if not
      **/
     function inLifeCycleMethod() {
       let scope = context.getScope();
@@ -239,40 +239,6 @@ module.exports = {
         component &&
         !component.ignorePropsValidation
       );
-    }
-
-    /**
-     * Returns true if the given node is a React Component lifecycle method
-     * @param {ASTNode} node The AST node being checked.
-     * @return {Boolean} True if the node is a lifecycle method
-     */
-    function isNodeALifeCycleMethod(node) {
-      const nodeKeyName = (node.key || {}).name;
-      return (
-        node.kind === 'constructor' ||
-        nodeKeyName === 'componentWillReceiveProps' ||
-        nodeKeyName === 'shouldComponentUpdate' ||
-        nodeKeyName === 'componentWillUpdate' ||
-        nodeKeyName === 'componentDidUpdate'
-      );
-    }
-
-    /**
-     * Returns true if the given node is inside a React Component lifecycle
-     * method.
-     * @param {ASTNode} node The AST node being checked.
-     * @return {Boolean} True if the node is inside a lifecycle method
-     */
-    function isInLifeCycleMethod(node) {
-      if (node.type === 'MethodDefinition' && isNodeALifeCycleMethod(node)) {
-        return true;
-      }
-
-      if (node.parent) {
-        return isInLifeCycleMethod(node.parent);
-      }
-
-      return false;
     }
 
     /**
@@ -670,7 +636,7 @@ module.exports = {
             // let {firstname} = props
             const genericDestructuring = isPropAttributeName(node) && (
               utils.getParentStatelessComponent() ||
-              isInLifeCycleMethod(node)
+              inLifeCycleMethod()
             );
 
             if (thisDestructuring) {
@@ -992,7 +958,7 @@ module.exports = {
         // let {firstname} = props
         const statelessDestructuring = destructuring && isPropAttributeName(node) && (
           utils.getParentStatelessComponent() ||
-          isInLifeCycleMethod(node)
+          inLifeCycleMethod()
         );
 
         if (!thisDestructuring && !statelessDestructuring) {
@@ -1058,7 +1024,7 @@ module.exports = {
       ObjectPattern: function(node) {
         // If the object pattern is a destructured props object in a lifecycle
         // method -- mark it for used props.
-        if (isNodeALifeCycleMethod(node.parent.parent)) {
+        if (inLifeCycleMethod()) {
           node.properties.forEach((property, i) => {
             if (i === 0) {
               markPropTypesAsUsed(node.parent);

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -21,7 +21,7 @@ const propsUtil = require('../util/props');
 const DIRECT_PROPS_REGEX = /^props\s*(\.|\[)/;
 const DIRECT_NEXT_PROPS_REGEX = /^nextProps\s*(\.|\[)/;
 const DIRECT_PREV_PROPS_REGEX = /^prevProps\s*(\.|\[)/;
-const LIFE_CYCLE_METHODS = ['componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
+const LIFE_CYCLE_METHODS = ['constructor', 'componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
 
 // ------------------------------------------------------------------------------
 // Rule Definition

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -13,6 +13,7 @@ const variable = require('../util/variable');
 const annotations = require('../util/annotations');
 const versionUtil = require('../util/version');
 const propsUtil = require('../util/props');
+const astUtil = require('../util/ast');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -21,7 +22,6 @@ const propsUtil = require('../util/props');
 const DIRECT_PROPS_REGEX = /^props\s*(\.|\[)/;
 const DIRECT_NEXT_PROPS_REGEX = /^nextProps\s*(\.|\[)/;
 const DIRECT_PREV_PROPS_REGEX = /^prevProps\s*(\.|\[)/;
-const LIFE_CYCLE_METHODS = ['constructor', 'componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -82,24 +82,6 @@ module.exports = {
       return value;
     }
 
-    /**
-     * Check if we are in a lifecycle method
-     * @return {boolean} true if we are in a lifecycle method, false if not
-     **/
-    function inLifeCycleMethod() {
-      let scope = context.getScope();
-      while (scope) {
-        if (
-          scope.block && scope.block.parent &&
-          scope.block.parent.key &&
-            LIFE_CYCLE_METHODS.indexOf(scope.block.parent.key.name) >= 0
-        ) {
-          return true;
-        }
-        scope = scope.upper;
-      }
-      return false;
-    }
 
     /**
      * Check if the current node is in a setState updater method
@@ -155,7 +137,7 @@ module.exports = {
         || isPropArgumentInSetStateUpdater(node))
       );
       const isStatelessFunctionUsage = node.object.name === 'props';
-      return isClassUsage || isStatelessFunctionUsage || inLifeCycleMethod();
+      return isClassUsage || isStatelessFunctionUsage || astUtil.inLifeCycleMethod(context);
     }
 
     /**
@@ -546,7 +528,7 @@ module.exports = {
       const isDirectSetStateProp = isPropArgumentInSetStateUpdater(node);
       const isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
       const isNotInConstructor = !inConstructor(node);
-      const isNotInLifeCycleMethod = !inLifeCycleMethod();
+      const isNotInLifeCycleMethod = !astUtil.inLifeCycleMethod(context);
       const isNotInSetStateUpdater = !inSetStateUpdater();
       if ((isDirectProp || isDirectNextProp || isDirectPrevProp || isDirectSetStateProp)
         && isInClassComponent
@@ -636,7 +618,7 @@ module.exports = {
             // let {firstname} = props
             const genericDestructuring = isPropAttributeName(node) && (
               utils.getParentStatelessComponent() ||
-              inLifeCycleMethod()
+              astUtil.inLifeCycleMethod(context)
             );
 
             if (thisDestructuring) {
@@ -958,7 +940,7 @@ module.exports = {
         // let {firstname} = props
         const statelessDestructuring = destructuring && isPropAttributeName(node) && (
           utils.getParentStatelessComponent() ||
-          inLifeCycleMethod()
+          astUtil.inLifeCycleMethod(context)
         );
 
         if (!thisDestructuring && !statelessDestructuring) {
@@ -1024,7 +1006,7 @@ module.exports = {
       ObjectPattern: function(node) {
         // If the object pattern is a destructured props object in a lifecycle
         // method -- mark it for used props.
-        if (inLifeCycleMethod()) {
+        if (astUtil.inLifeCycleMethod(context)) {
           node.properties.forEach((property, i) => {
             if (i === 0) {
               markPropTypesAsUsed(node.parent);

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -502,21 +502,6 @@ module.exports = {
     }
 
     /**
-     * Check if we are in a class constructor
-     * @return {boolean} true if we are in a class constructor, false if not
-     */
-    function inConstructor() {
-      let scope = context.getScope();
-      while (scope) {
-        if (scope.block && scope.block.parent && scope.block.parent.kind === 'constructor') {
-          return true;
-        }
-        scope = scope.upper;
-      }
-      return false;
-    }
-
-    /**
      * Retrieve the name of a property node
      * @param {ASTNode} node The AST node with the property.
      * @return {string} the name of the property or undefined if not found
@@ -527,12 +512,10 @@ module.exports = {
       const isDirectPrevProp = DIRECT_PREV_PROPS_REGEX.test(sourceCode.getText(node));
       const isDirectSetStateProp = isPropArgumentInSetStateUpdater(node);
       const isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
-      const isNotInConstructor = !inConstructor(node);
       const isNotInLifeCycleMethod = !astUtil.inLifeCycleMethod(context);
       const isNotInSetStateUpdater = !inSetStateUpdater();
       if ((isDirectProp || isDirectNextProp || isDirectPrevProp || isDirectSetStateProp)
         && isInClassComponent
-        && isNotInConstructor
         && isNotInLifeCycleMethod
         && isNotInSetStateUpdater
       ) {

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -513,9 +513,12 @@ module.exports = {
       const isDirectSetStateProp = isPropArgumentInSetStateUpdater(node);
       const isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
       const isNotInLifeCycleMethod = !astUtil.inLifeCycleMethod(context);
+      const isNotInConstructor = !astUtil.inConstructor(context);
       const isNotInSetStateUpdater = !inSetStateUpdater();
-      if ((isDirectProp || isDirectNextProp || isDirectPrevProp || isDirectSetStateProp)
+      if (
+        (isDirectProp || isDirectNextProp || isDirectPrevProp || isDirectSetStateProp)
         && isInClassComponent
+        && isNotInConstructor
         && isNotInLifeCycleMethod
         && isNotInSetStateUpdater
       ) {
@@ -599,10 +602,12 @@ module.exports = {
               )
             );
             // let {firstname} = props
-            const genericDestructuring = isPropAttributeName(node) && (
-              utils.getParentStatelessComponent() ||
-              astUtil.inLifeCycleMethod(context)
-            );
+            const genericDestructuring =
+              isPropAttributeName(node) && (
+                utils.getParentStatelessComponent() ||
+                astUtil.inConstructor(context) ||
+                astUtil.inLifeCycleMethod(context)
+              );
 
             if (thisDestructuring) {
               properties = node.id.properties[i].value.properties;
@@ -923,6 +928,7 @@ module.exports = {
         // let {firstname} = props
         const statelessDestructuring = destructuring && isPropAttributeName(node) && (
           utils.getParentStatelessComponent() ||
+          astUtil.inConstructor(context) ||
           astUtil.inLifeCycleMethod(context)
         );
 
@@ -989,7 +995,7 @@ module.exports = {
       ObjectPattern: function(node) {
         // If the object pattern is a destructured props object in a lifecycle
         // method -- mark it for used props.
-        if (astUtil.inLifeCycleMethod(context)) {
+        if (astUtil.inConstructor(context) || astUtil.inLifeCycleMethod(context)) {
           node.properties.forEach((property, i) => {
             if (i === 0) {
               markPropTypesAsUsed(node.parent);

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -89,7 +89,7 @@ module.exports = {
 
     /**
      * Check if we are in a lifecycle method
-     * @return {boolean} true if we are in a class constructor, false if not
+     * @return {boolean} true if we are in a lifecycle method, false if not
      **/
     function inLifeCycleMethod() {
       let scope = context.getScope();

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -13,6 +13,7 @@ const variable = require('../util/variable');
 const annotations = require('../util/annotations');
 const versionUtil = require('../util/version');
 const propsUtil = require('../util/props');
+const astUtil = require('../util/ast');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -20,7 +21,6 @@ const propsUtil = require('../util/props');
 
 const PROPS_REGEX = /^(props|nextProps)$/;
 const DIRECT_PROPS_REGEX = /^(props|nextProps)\s*(\.|\[)/;
-const LIFE_CYCLE_METHODS = ['constructor', 'componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -88,25 +88,6 @@ module.exports = {
     }
 
     /**
-     * Check if we are in a lifecycle method
-     * @return {boolean} true if we are in a lifecycle method, false if not
-     **/
-    function inLifeCycleMethod() {
-      let scope = context.getScope();
-      while (scope) {
-        if (
-          scope.block && scope.block.parent &&
-          scope.block.parent.key &&
-            LIFE_CYCLE_METHODS.indexOf(scope.block.parent.key.name) >= 0
-        ) {
-          return true;
-        }
-        scope = scope.upper;
-      }
-      return false;
-    }
-
-    /**
     * Checks if a prop is being assigned a value props.bar = 'bar'
     * @param {ASTNode} node The AST node being checked.
     * @returns {Boolean}
@@ -131,7 +112,7 @@ module.exports = {
         node.object.type === 'ThisExpression' && node.property.name === 'props'
       );
       const isStatelessFunctionUsage = node.object.name === 'props' && !isAssignmentToProp(node);
-      const isNextPropsUsage = node.object.name === 'nextProps' && inLifeCycleMethod();
+      const isNextPropsUsage = node.object.name === 'nextProps' && astUtil.inLifeCycleMethod(context);
       return isClassUsage || isStatelessFunctionUsage || isNextPropsUsage;
     }
 
@@ -521,7 +502,7 @@ module.exports = {
     function getPropertyName(node) {
       const isDirectProp = DIRECT_PROPS_REGEX.test(sourceCode.getText(node));
       const isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
-      const isNotInLifecycleMethod = !inLifeCycleMethod();
+      const isNotInLifecycleMethod = !astUtil.inLifeCycleMethod(context);
       if (isDirectProp && isInClassComponent && isNotInLifecycleMethod) {
         return void 0;
       }
@@ -601,7 +582,7 @@ module.exports = {
             // let {firstname} = props
             const directDestructuring =
               PROPS_REGEX.test(node.init.name) &&
-              (utils.getParentStatelessComponent() || inLifeCycleMethod())
+              (utils.getParentStatelessComponent() || astUtil.inLifeCycleMethod(context))
             ;
 
             if (thisDestructuring) {
@@ -635,7 +616,7 @@ module.exports = {
             name: name,
             allNames: allNames,
             node: (
-              !isDirectProp && !inLifeCycleMethod() ?
+              !isDirectProp && !astUtil.inLifeCycleMethod(context) ?
                 node.parent.property :
                 node.property
             )
@@ -953,7 +934,7 @@ module.exports = {
         const directDestructuring =
           destructuring &&
           PROPS_REGEX.test(node.init.name) &&
-          (utils.getParentStatelessComponent() || inLifeCycleMethod())
+          (utils.getParentStatelessComponent() || astUtil.inLifeCycleMethod(context))
         ;
 
         if (!thisDestructuring && !directDestructuring) {

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -20,6 +20,7 @@ const propsUtil = require('../util/props');
 
 const PROPS_REGEX = /^(props|nextProps)$/;
 const DIRECT_PROPS_REGEX = /^(props|nextProps)\s*(\.|\[)/;
+const LIFE_CYCLE_METHODS = ['constructor', 'componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -87,30 +88,16 @@ module.exports = {
     }
 
     /**
-     * Check if we are in a class constructor
+     * Check if we are in a lifecycle method
      * @return {boolean} true if we are in a class constructor, false if not
-     */
-    function inConstructor() {
-      let scope = context.getScope();
-      while (scope) {
-        if (scope.block && scope.block.parent && scope.block.parent.kind === 'constructor') {
-          return true;
-        }
-        scope = scope.upper;
-      }
-      return false;
-    }
-
-    /**
-     * Check if we are in a class constructor
-     * @return {boolean} true if we are in a class constructor, false if not
-     */
-    function inComponentWillReceiveProps() {
+     **/
+    function inLifeCycleMethod() {
       let scope = context.getScope();
       while (scope) {
         if (
           scope.block && scope.block.parent &&
-          scope.block.parent.key && scope.block.parent.key.name === 'componentWillReceiveProps'
+          scope.block.parent.key &&
+            LIFE_CYCLE_METHODS.indexOf(scope.block.parent.key.name) >= 0
         ) {
           return true;
         }
@@ -144,7 +131,7 @@ module.exports = {
         node.object.type === 'ThisExpression' && node.property.name === 'props'
       );
       const isStatelessFunctionUsage = node.object.name === 'props' && !isAssignmentToProp(node);
-      const isNextPropsUsage = node.object.name === 'nextProps' && inComponentWillReceiveProps();
+      const isNextPropsUsage = node.object.name === 'nextProps' && inLifeCycleMethod();
       return isClassUsage || isStatelessFunctionUsage || isNextPropsUsage;
     }
 
@@ -534,9 +521,8 @@ module.exports = {
     function getPropertyName(node) {
       const isDirectProp = DIRECT_PROPS_REGEX.test(sourceCode.getText(node));
       const isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
-      const isNotInConstructor = !inConstructor();
-      const isNotInComponentWillReceiveProps = !inComponentWillReceiveProps();
-      if (isDirectProp && isInClassComponent && isNotInConstructor && isNotInComponentWillReceiveProps) {
+      const isNotInLifecycleMethod = !inLifeCycleMethod();
+      if (isDirectProp && isInClassComponent && isNotInLifecycleMethod) {
         return void 0;
       }
       if (!isDirectProp) {
@@ -615,7 +601,7 @@ module.exports = {
             // let {firstname} = props
             const directDestructuring =
               PROPS_REGEX.test(node.init.name) &&
-              (utils.getParentStatelessComponent() || inConstructor() || inComponentWillReceiveProps())
+              (utils.getParentStatelessComponent() || inLifeCycleMethod())
             ;
 
             if (thisDestructuring) {
@@ -649,7 +635,7 @@ module.exports = {
             name: name,
             allNames: allNames,
             node: (
-              !isDirectProp && !inConstructor() && !inComponentWillReceiveProps() ?
+              !isDirectProp && !inLifeCycleMethod() ?
                 node.parent.property :
                 node.property
             )
@@ -967,7 +953,7 @@ module.exports = {
         const directDestructuring =
           destructuring &&
           PROPS_REGEX.test(node.init.name) &&
-          (utils.getParentStatelessComponent() || inConstructor() || inComponentWillReceiveProps())
+          (utils.getParentStatelessComponent() || inLifeCycleMethod())
         ;
 
         if (!thisDestructuring && !directDestructuring) {

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -502,8 +502,14 @@ module.exports = {
     function getPropertyName(node) {
       const isDirectProp = DIRECT_PROPS_REGEX.test(sourceCode.getText(node));
       const isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
+      const isNotInConstructor = !astUtil.inConstructor(context);
       const isNotInLifecycleMethod = !astUtil.inLifeCycleMethod(context);
-      if (isDirectProp && isInClassComponent && isNotInLifecycleMethod) {
+      if (
+        isDirectProp &&
+        isInClassComponent &&
+        isNotInConstructor &&
+        isNotInLifecycleMethod
+      ) {
         return void 0;
       }
       if (!isDirectProp) {
@@ -581,9 +587,11 @@ module.exports = {
             );
             // let {firstname} = props
             const directDestructuring =
-              PROPS_REGEX.test(node.init.name) &&
-              (utils.getParentStatelessComponent() || astUtil.inLifeCycleMethod(context))
-            ;
+              PROPS_REGEX.test(node.init.name) && (
+                utils.getParentStatelessComponent() ||
+                astUtil.inConstructor(context) ||
+                astUtil.inLifeCycleMethod(context)
+              );
 
             if (thisDestructuring) {
               properties = node.id.properties[i].value.properties;
@@ -616,7 +624,7 @@ module.exports = {
             name: name,
             allNames: allNames,
             node: (
-              !isDirectProp && !astUtil.inLifeCycleMethod(context) ?
+              !isDirectProp && !astUtil.inConstructor(context) && !astUtil.inLifeCycleMethod(context) ?
                 node.parent.property :
                 node.property
             )
@@ -934,7 +942,7 @@ module.exports = {
         const directDestructuring =
           destructuring &&
           PROPS_REGEX.test(node.init.name) &&
-          (utils.getParentStatelessComponent() || astUtil.inLifeCycleMethod(context))
+          (utils.getParentStatelessComponent() || astUtil.inConstructor(context) || astUtil.inLifeCycleMethod(context))
         ;
 
         if (!thisDestructuring && !directDestructuring) {

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -3,7 +3,7 @@
  */
 'use strict';
 
-const LIFE_CYCLE_METHODS = ['constructor', 'componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
+const LIFE_CYCLE_METHODS = ['componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
 
 /**
  * Get properties name
@@ -69,9 +69,29 @@ function inLifeCycleMethod(context) {
   let scope = context.getScope();
   while (scope) {
     if (
-      scope.block && scope.block.parent &&
+      scope.block &&
+      scope.block.parent &&
       scope.block.parent.key &&
-        LIFE_CYCLE_METHODS.indexOf(scope.block.parent.key.name) >= 0
+      LIFE_CYCLE_METHODS.indexOf(scope.block.parent.key.name) >= 0
+    ) {
+      return true;
+    }
+    scope = scope.upper;
+  }
+  return false;
+}
+
+/**
+ * Check if we are in a class constructor
+ * @return {boolean} true if we are in a class constructor, false if not
+ */
+function inConstructor(context) {
+  let scope = context.getScope();
+  while (scope) {
+    if (
+      scope.block &&
+        scope.block.parent &&
+        scope.block.parent.kind === 'constructor'
     ) {
       return true;
     }
@@ -84,5 +104,6 @@ module.exports = {
   findReturnStatement: findReturnStatement,
   getPropertyName: getPropertyName,
   getComponentProperties: getComponentProperties,
+  inConstructor: inConstructor,
   inLifeCycleMethod: inLifeCycleMethod
 };

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -3,6 +3,8 @@
  */
 'use strict';
 
+const LIFE_CYCLE_METHODS = ['constructor', 'componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
+
 /**
  * Get properties name
  * @param {Object} node - Property.
@@ -59,8 +61,28 @@ function findReturnStatement(node) {
   return false;
 }
 
+/**
+ * Check if we are in a lifecycle method
+ * @return {boolean} true if we are in a lifecycle method, false if not
+ **/
+function inLifeCycleMethod(context) {
+  let scope = context.getScope();
+  while (scope) {
+    if (
+      scope.block && scope.block.parent &&
+      scope.block.parent.key &&
+        LIFE_CYCLE_METHODS.indexOf(scope.block.parent.key.name) >= 0
+    ) {
+      return true;
+    }
+    scope = scope.upper;
+  }
+  return false;
+}
+
 module.exports = {
+  findReturnStatement: findReturnStatement,
   getPropertyName: getPropertyName,
   getComponentProperties: getComponentProperties,
-  findReturnStatement: findReturnStatement
+  inLifeCycleMethod: inLifeCycleMethod
 };

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -3247,6 +3247,23 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  static propTypes = {',
         '    unused: PropTypes.bool',
         '  }',
+        '  constructor(props) {',
+        '    this.state = { something: props.something }',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'unused\' PropType is defined but prop is never used',
+        line: 3,
+        column: 13
+      }]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = {',
+        '    unused: PropTypes.bool',
+        '  }',
         '  componentWillReceiveProps ({something}, nextState) {',
         '    return something;',
         '  }',

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1677,7 +1677,7 @@ ruleTester.run('prop-types', rule, {
 
         class Bar extends React.Component {
           props: Props;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar}</div>
           }
@@ -1693,7 +1693,7 @@ ruleTester.run('prop-types', rule, {
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar} - {this.props.zap}</div>
           }
@@ -1709,7 +1709,7 @@ ruleTester.run('prop-types', rule, {
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar} - {this.props.zap}</div>
           }
@@ -1721,12 +1721,12 @@ ruleTester.run('prop-types', rule, {
         type PropsA = { bar: string };
         type PropsB = { zap: string };
         type Props = PropsA & {
-          baz: string 
+          baz: string
         };
 
         class Bar extends React.Component {
           props: Props & PropsB;
-          
+
           render() {
             return <div>{this.props.bar} - {this.props.zap} - {this.props.baz}</div>
           }
@@ -1738,12 +1738,12 @@ ruleTester.run('prop-types', rule, {
         type PropsA = { bar: string };
         type PropsB = { zap: string };
         type Props =  {
-          baz: string 
+          baz: string
         } & PropsA;
 
         class Bar extends React.Component {
           props: Props & PropsB;
-          
+
           render() {
             return <div>{this.props.bar} - {this.props.zap} - {this.props.baz}</div>
           }
@@ -3024,6 +3024,23 @@ ruleTester.run('prop-types', rule, {
     }, {
       code: [
         'class Hello extends Component {',
+        '  shouldComponentUpdate(nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return;',
+        '    }',
+        '  }',
+        '  render() {',
+        '    return <div />;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [
+        {message: '\'foo\' is missing in props validation'}
+      ]
+    }, {
+      code: [
+        'class Hello extends Component {',
         '  static propTypes = {',
         '    bar: PropTypes.func',
         '  }',
@@ -3431,7 +3448,7 @@ ruleTester.run('prop-types', rule, {
 
         class MyComponent extends React.Component {
           props: Props;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar} - {this.props.fooBar}</div>
           }
@@ -3450,7 +3467,7 @@ ruleTester.run('prop-types', rule, {
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar} - {this.props.zap} - {this.props.fooBar}</div>
           }
@@ -3465,12 +3482,12 @@ ruleTester.run('prop-types', rule, {
         type PropsB = { bar: string };
         type PropsC = { zap: string };
         type Props = PropsB & {
-          baz: string 
+          baz: string
         };
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.bar} - {this.props.baz} - {this.props.fooBar}</div>
           }
@@ -3485,12 +3502,12 @@ ruleTester.run('prop-types', rule, {
         type PropsB = { bar: string };
         type PropsC = { zap: string };
         type Props = {
-          baz: string 
+          baz: string
         } & PropsB;
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.bar} - {this.props.baz} - {this.props.fooBar}</div>
           }


### PR DESCRIPTION
Follow-up for: https://github.com/yannickcr/eslint-plugin-react/pull/1526

Basically in `prop-types` and `no-unused-prop-types` there is quite a bit of duplicate code. I tried to do a HUGE refactoring to remove a lot of it but it turned out... well... not good 😄 So maybe smaller PRs is a better idea.

Basically made the "are we in a lifecycle method" detection similar between `prop-types` and `no-unused-prop-types`. Both rules were doing it differently but the results were the same. There was also duplicated methods like `inComponentWillReceiveProps`.

There should be some new cases detected now, e.g. in `prop-types` rule: `nextProps` should be considered not only for `componentWillReceiveProps`, but also for `shouldComponentUpdate`.

 On that note, I noticed that `prevProps` is not supported for `prop-types` rule, with a lifecycle method of `componentDidUpdate` for example. There's some further refactoring needed to align the two rules more to get that properly working which I'd like to tackle in a PR after this.