### PR TITLE
Prevent jsx-no-bind crash

### DIFF
--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -135,6 +135,9 @@ module.exports = {
       },
 
       VariableDeclarator(node) {
+        if (!node.init) {
+          return;
+        }
         const blockAncestors = getBlockStatementAncestors(node);
         const variableViolationType = getNodeViolationType(node.init);
 

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -258,6 +258,17 @@ ruleTester.run('jsx-no-bind', rule, {
         '};'
       ].join('\n'),
       parser: 'babel-eslint'
+    },
+    {
+      // issue #1543: don't crash on uninitialized variables
+      code: [
+        'class Hello extends Component {',
+        '  render() {',
+        '    let click;',
+        '    return <div onClick={onClick}>Hello</div>;',
+        '  }',
+        '}'
+      ].join('\n')
     }
   ],
 


### PR DESCRIPTION
The rule would assume a variable is initialized when checking a
VariableDeclarator node.

Fixes #1543 