### PR TITLE
Fix crash in no-unused-prop-types

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -134,7 +134,7 @@ module.exports = {
           // Make sure we are in the updater not the callback
           && scope.block.parent.arguments[0].start === scope.block.start
           && scope.block.parent.arguments[0].params
-          && scope.block.parent.arguments[0].params.length > 0
+          && scope.block.parent.arguments[0].params.length > 1
         ) {
           return scope.block.parent.arguments[0].params[1].name === node.object.name;
         }
@@ -949,7 +949,7 @@ module.exports = {
     }
 
     function handleSetStateUpdater(node) {
-      if (!node.params || !node.params.length || !inSetStateUpdater()) {
+      if (!node.params || node.params.length < 2 || !inSetStateUpdater()) {
         return;
       }
       markPropTypesAsUsed(node);

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2198,6 +2198,46 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint',
       options: [{skipShapeProps: false}]
     }, {
+      // issue #1542
+      code: [
+        'class MyComponent extends React.Component {',
+        '  onFoo() {',
+        '    this.setState((prevState) => {',
+        '      this.props.doSomething();',
+        '    });',
+        '  }',
+        '  render() {',
+        '    return (',
+        '       <div onClick={this.onFoo}>Test</div>',
+        '    );',
+        '  }',
+        '}',
+        'MyComponent.propTypes = {',
+        '  doSomething: PropTypes.func',
+        '};'
+      ].join('\n'),
+      options: [{skipShapeProps: false}]
+    }, {
+      // issue #1542
+      code: [
+        'class MyComponent extends React.Component {',
+        '  onFoo() {',
+        '    this.setState(({ something }) => {',
+        '      this.props.doSomething();',
+        '    });',
+        '  }',
+        '  render() {',
+        '    return (',
+        '       <div onClick={this.onFoo}>Test</div>',
+        '    );',
+        '  }',
+        '}',
+        'MyComponent.propTypes = {',
+        '  doSomething: PropTypes.func',
+        '};'
+      ].join('\n'),
+      options: [{skipShapeProps: false}]
+    }, {
       // issue #106
       code: `
         import React from 'react';


### PR DESCRIPTION
When checking props in setState updater functions, some assumptions were
being made about the props argument being defined.

Fixes #1542 