### PR TITLE
Fix crash in no-access-state-in-setstate

### DIFF
--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -95,7 +95,7 @@ module.exports = {
                 node: node
               });
               break;
-            } else if (current.type === 'FunctionExpression') {
+            } else if (current.type === 'FunctionExpression' && current.parent.key) {
               methods.push({
                 methodName: current.parent.key.name,
                 node: node

--- a/tests/lib/rules/no-access-state-in-setstate.js
+++ b/tests/lib/rules/no-access-state-in-setstate.js
@@ -46,6 +46,24 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '});'
     ].join('\n'),
     parserOptions: parserOptions
+  }, {
+    // issue 1559: don't crash
+    code: `
+      var SearchForm = createReactClass({
+        render: function () {
+          return (
+            <div>
+              {(function () {
+                if (this.state.prompt) {
+                  return <div>{this.state.prompt}</div>
+                }
+              }).call(this)}
+            </div>
+          );
+        }
+      });
+    `,
+    parserOptions: parserOptions
   }],
 
   invalid: [{


### PR DESCRIPTION
With an IIFE in the return statement of render that uses `this.state`,
there is no parent with a name. In this rule, the method names are later
checked to see if they are being called elsewhere in the file. Since
there is no intention of this being called anywhere else, the IIFE will
just be skipped being added to the list of methods.

Fixes #1559 