### PR TITLE
Fix crash when using Unions in flow propTypes

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -780,6 +780,10 @@ module.exports = {
           return declarePropTypesForObjectTypeAnnotation(annotation, declaredPropTypes);
         }
 
+        if (annotation.type === 'UnionTypeAnnotation') {
+          return true;
+        }
+
         const typeNode = typeScope(annotation.id.name);
 
         if (!typeNode) {

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -726,6 +726,10 @@ module.exports = {
           return declarePropTypesForObjectTypeAnnotation(annotation, declaredPropTypes);
         }
 
+        if (annotation.type === 'UnionTypeAnnotation') {
+          return true;
+        }
+
         const typeNode = typeScope(annotation.id.name);
 
         if (!typeNode) {

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1099,6 +1099,28 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: [
+        'type PropsUnionA = {',
+        '  a: string,',
+        '  b?: void,',
+        '};',
+        'type PropsUnionB = {',
+        '  a?: void,',
+        '  b: string,',
+        '};',
+        'type Props = {',
+        '  name: string,',
+        '} & (PropsUnionA | PropsUnionB);',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  render() {',
+        '    const {name} = this.props;',
+        '    return name;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
         'Card.propTypes = {',
         '  title: PropTypes.string.isRequired,',
         '  children: PropTypes.element.isRequired,',

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1131,6 +1131,28 @@ ruleTester.run('prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: [
+        'type PropsUnionA = {',
+        '  a: string,',
+        '  b?: void,',
+        '};',
+        'type PropsUnionB = {',
+        '  a?: void,',
+        '  b: string,',
+        '};',
+        'type Props = {',
+        '  name: string,',
+        '} & (PropsUnionA | PropsUnionB);',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  render() {',
+        '    const {name} = this.props;',
+        '    return name;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
         'Card.propTypes = {',
         '  title: PropTypes.string.isRequired,',
         '  children: PropTypes.element.isRequired,',


### PR DESCRIPTION
This will fix the crash when using Union flowtypes for the following rules:

- `prop-types`
- `no-unused-prop-types`

The library already escapes early when facing a `typeNode` it doesn't recognize; this will escape early when we can't even figure out the `typeNode` because `UnionTypeAnnotation`s don't have an `annotation.id`.

This will not actually resolve the issue of using unions; it will simply prevent eslint from crashing.

Fixes issue https://github.com/yannickcr/eslint-plugin-react/issues/1468