### PR TITLE
Not allow constructor in React components

### DIFF
--- a/docs/rules/no-constructor-in-component.md
+++ b/docs/rules/no-constructor-in-component.md
@@ -1,0 +1,52 @@
+# Do not allow constructor in React components (react/no-constructor-in-component)
+
+In most cases, we don't need a constructor in React Components instead we can use a static propTypes property to pass props in a component. This rule does not allow you to use a constructor in components.
+
+## Rule Details
+
+Will enforce not to use a constructor for React Components.
+
+The following patterns are considered bad:
+
+```jsx
+  class OneComponent extends Component {
+    static propTypes = {}
+    state = {}
+  }
+```
+```jsx
+  class OneComponent extends React.Component {
+    static propTypes = {}
+    state = {}
+  }
+```
+```jsx
+  const Component = class OneComponent extends React.Component {
+    static propTypes = {}
+    state = {}
+  }
+```
+
+The following patterns are **not** considered bad:
+
+```jsx
+  class OneComponent extends Component {
+    constructor(props) {
+      super(props);
+    }
+  }
+```
+```jsx
+  class OneComponent extends React.Component {
+    constructor(props) {
+      super(props);
+    }
+  }
+```
+```jsx
+  const Component = class OneComponent extends Component {
+    constructor(props) {
+      super(props);
+    }
+  }
+```

--- a/docs/rules/no-constructor-in-component.md
+++ b/docs/rules/no-constructor-in-component.md
@@ -7,46 +7,18 @@ In most cases, we don't need a constructor in React Components instead we can us
 Will enforce not to use a constructor for React Components.
 
 The following patterns are considered bad:
-
 ```jsx
   class OneComponent extends Component {
-    static propTypes = {}
-    state = {}
-  }
-```
-```jsx
-  class OneComponent extends React.Component {
-    static propTypes = {}
-    state = {}
-  }
-```
-```jsx
-  const Component = class OneComponent extends React.Component {
-    static propTypes = {}
-    state = {}
+    constructor(props) {
+      super(props);
+    }
   }
 ```
 
 The following patterns are **not** considered bad:
-
 ```jsx
   class OneComponent extends Component {
-    constructor(props) {
-      super(props);
-    }
-  }
-```
-```jsx
-  class OneComponent extends React.Component {
-    constructor(props) {
-      super(props);
-    }
-  }
-```
-```jsx
-  const Component = class OneComponent extends Component {
-    constructor(props) {
-      super(props);
-    }
+    static propTypes = {}
+    state = {}
   }
 ```

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ const allRules = {
   'no-access-state-in-setstate': require('./lib/rules/no-access-state-in-setstate'),
   'no-array-index-key': require('./lib/rules/no-array-index-key'),
   'no-children-prop': require('./lib/rules/no-children-prop'),
+  'no-constructor-in-component': require('./lib/rules/no-constructor-in-component'),
   'no-danger': require('./lib/rules/no-danger'),
   'no-danger-with-children': require('./lib/rules/no-danger-with-children'),
   'no-deprecated': require('./lib/rules/no-deprecated'),

--- a/lib/rules/no-constructor-in-component.js
+++ b/lib/rules/no-constructor-in-component.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Prevent using constructor in React components
+ * @author Alex Husakov <@zoomchik>
+ */
+'use strict';
+
+const Components = require('../util/Components');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prevent using constructor in React components, insted use static propTypes properties',
+      category: 'Best Practices'
+    }
+  },
+
+  create: Components.detect((context, components) => {
+    function reportConstructorInComponent(node) {
+      context.report({
+        node: node,
+        message: 'Do not use constructor in React components'
+      });
+    }
+
+    return {
+      'Program:exit': function() {
+        const list = components.list();
+        let constructors = [];
+
+        Object.keys(list).forEach(key => {
+          const methods = list[key].node.body.body.filter(item =>
+            item.type === 'MethodDefinition' &&
+            item.kind === 'constructor');
+
+          constructors = constructors.concat(methods);
+        });
+
+        constructors.forEach(node => {
+          reportConstructorInComponent(node);
+        });
+      }
+    };
+  })
+};

--- a/lib/rules/no-constructor-in-component.js
+++ b/lib/rules/no-constructor-in-component.js
@@ -32,9 +32,9 @@ module.exports = {
         let constructors = [];
 
         Object.keys(list).forEach(key => {
-          const methods = list[key].node.body.body.filter(item =>
-            item.type === 'MethodDefinition' &&
-            item.kind === 'constructor');
+          const methods = list[key].node.body.body.filter(node =>
+            node.type === 'MethodDefinition' &&
+            node.kind === 'constructor');
 
           constructors = constructors.concat(methods);
         });

--- a/lib/rules/no-constructor-in-component.js
+++ b/lib/rules/no-constructor-in-component.js
@@ -18,7 +18,7 @@ module.exports = {
     }
   },
 
-  create: Components.detect((context, components) => {
+  create: Components.detect((context, components, utils) => {
     function reportConstructorInComponent(node) {
       context.report({
         node: node,
@@ -32,11 +32,15 @@ module.exports = {
         let constructors = [];
 
         Object.keys(list).forEach(key => {
-          const methods = list[key].node.body.body.filter(node =>
-            node.type === 'MethodDefinition' &&
-            node.kind === 'constructor');
+          const isES6Component = utils.isES6Component(list[key].node);
 
-          constructors = constructors.concat(methods);
+          if (isES6Component) {
+            const methods = list[key].node.body.body.filter(node =>
+              node.type === 'MethodDefinition' &&
+              node.kind === 'constructor');
+
+            constructors = constructors.concat(methods);
+          }
         });
 
         constructors.forEach(node => {

--- a/tests/lib/rules/no-constructor-in-component.js
+++ b/tests/lib/rules/no-constructor-in-component.js
@@ -1,0 +1,140 @@
+/**
+ * @fileoverview Prevent using constructor in React components
+ * @author Alex Husakov
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-constructor-in-component');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true
+  }
+};
+
+require('babel-eslint');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({parserOptions});
+ruleTester.run('no-constructor-in-component', rule, {
+
+  valid: [{
+    code: `
+      class OneClass extends AnotherClass {
+        constructor(props) {
+          super(props);
+        }
+        anotherMethod() {}
+      }
+    `,
+    parser: 'babel-eslint'
+  },
+  {
+    code: `
+      class OneComponent extends Component {
+        static propTypes = {}
+        state = {}
+        anotherMethod() {}
+      }
+    `,
+    parser: 'babel-eslint'
+  },
+  {
+    code: `
+      class OneComponent extends React.Component {
+        static propTypes = {}
+        state = {}
+        anotherMethod() {}
+      }
+    `,
+    parser: 'babel-eslint'
+  },
+  {
+    code: `
+      const Component = class OneComponent extends React.Component {
+        static propTypes = {}
+        state = {}
+        anotherMethod() {}
+      }
+    `,
+    parser: 'babel-eslint'
+  }
+  ],
+
+  invalid: [{
+    code: `
+      class OneComponent extends Component {
+        constructor(props) {
+          super(props);
+        }
+        anotherMethod() {}
+      }
+    `,
+    errors: [{
+      message: 'Do not use constructor in React components'
+    }],
+    parser: 'babel-eslint'
+  },
+  {
+    code: `
+      class OneComponent extends React.Component {
+        constructor(props) {
+          super(props);
+        }
+        anotherMethod() {}
+      }
+    `,
+    errors: [{
+      message: 'Do not use constructor in React components'
+    }],
+    parser: 'babel-eslint'
+  },
+  {
+    code: `
+      const Component = class OneComponent extends Component {
+        constructor(props) {
+          super(props);
+        }
+        anotherMethod() {}
+      }
+    `,
+    errors: [{
+      message: 'Do not use constructor in React components'
+    }],
+    parser: 'babel-eslint'
+  },
+  {
+    code: `
+      class OneComponent extends Component {
+        constructor(props) {
+          super(props);
+        }
+        anotherMethod() {}
+      }
+      class TwoComponent extends Component {
+        constructor(props) {
+          super(props);
+        }
+        anotherMethod() {}
+      }
+    `,
+    errors: [{
+      message: 'Do not use constructor in React components'
+    },
+    {
+      message: 'Do not use constructor in React components'
+    }],
+    parser: 'babel-eslint'
+  }]
+});


### PR DESCRIPTION
In most cases, we don't need a constructor in React Components instead we can use a static propTypes property to pass props in a component. This rule does not allow you to use a constructor in components.