### PR TITLE
Add flow `Union` tests for `no-unused-prop-types` and `prop-types` with `import`

### DIFF
--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1121,6 +1121,17 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: [
+        'import type { FieldProps } from "redux-form"',
+        '',
+        'type Props = {',
+        'label: string,',
+        '  type: string,',
+        '  options: Array<SelectOption>',
+        '} & FieldProps'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
         'Card.propTypes = {',
         '  title: PropTypes.string.isRequired,',
         '  children: PropTypes.element.isRequired,',

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1153,6 +1153,17 @@ ruleTester.run('prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: [
+        'import type { FieldProps } from "redux-form"',
+        '',
+        'type Props = {',
+        'label: string,',
+        '  type: string,',
+        '  options: Array<SelectOption>',
+        '} & FieldProps'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
         'Card.propTypes = {',
         '  title: PropTypes.string.isRequired,',
         '  children: PropTypes.element.isRequired,',
@@ -1699,7 +1710,7 @@ ruleTester.run('prop-types', rule, {
 
         class Bar extends React.Component {
           props: Props;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar}</div>
           }
@@ -1715,7 +1726,7 @@ ruleTester.run('prop-types', rule, {
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar} - {this.props.zap}</div>
           }
@@ -1731,7 +1742,7 @@ ruleTester.run('prop-types', rule, {
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar} - {this.props.zap}</div>
           }
@@ -1743,12 +1754,12 @@ ruleTester.run('prop-types', rule, {
         type PropsA = { bar: string };
         type PropsB = { zap: string };
         type Props = PropsA & {
-          baz: string 
+          baz: string
         };
 
         class Bar extends React.Component {
           props: Props & PropsB;
-          
+
           render() {
             return <div>{this.props.bar} - {this.props.zap} - {this.props.baz}</div>
           }
@@ -1760,12 +1771,12 @@ ruleTester.run('prop-types', rule, {
         type PropsA = { bar: string };
         type PropsB = { zap: string };
         type Props =  {
-          baz: string 
+          baz: string
         } & PropsA;
 
         class Bar extends React.Component {
           props: Props & PropsB;
-          
+
           render() {
             return <div>{this.props.bar} - {this.props.zap} - {this.props.baz}</div>
           }
@@ -3453,7 +3464,7 @@ ruleTester.run('prop-types', rule, {
 
         class MyComponent extends React.Component {
           props: Props;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar} - {this.props.fooBar}</div>
           }
@@ -3472,7 +3483,7 @@ ruleTester.run('prop-types', rule, {
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.foo} - {this.props.bar} - {this.props.zap} - {this.props.fooBar}</div>
           }
@@ -3487,12 +3498,12 @@ ruleTester.run('prop-types', rule, {
         type PropsB = { bar: string };
         type PropsC = { zap: string };
         type Props = PropsB & {
-          baz: string 
+          baz: string
         };
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.bar} - {this.props.baz} - {this.props.fooBar}</div>
           }
@@ -3507,12 +3518,12 @@ ruleTester.run('prop-types', rule, {
         type PropsB = { bar: string };
         type PropsC = { zap: string };
         type Props = {
-          baz: string 
+          baz: string
         } & PropsB;
 
         class Bar extends React.Component {
           props: Props & PropsC;
-          
+
           render() {
             return <div>{this.props.bar} - {this.props.baz} - {this.props.fooBar}</div>
           }


### PR DESCRIPTION
Please note this only tests that using `import` and `Union` propTypes won't crash eslint. This does _not_ actually test that the propTypes are not unused or that they are defined when used.

Contributes to issue https://github.com/yannickcr/eslint-plugin-react/issues/1468