### PR TITLE
Potential autofix improvement for jsx-wrap-mulitlines

### DIFF
--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -104,12 +104,19 @@ module.exports = {
       return node.loc.start.line !== node.loc.end.line;
     }
 
-    function report(node, message, fixerFn) {
+    function report(node, message, fix) {
       context.report({
-        node: node,
-        message: message,
-        fix: fixerFn
+        node,
+        message,
+        fix
       });
+    }
+
+    function trimTokenBeforeNewline(node, tokenBefore) {
+      // if the token before the jsx is a bracket or curly brace
+      // we don't want a space between the opening parentheses and the multiline jsx
+      const isBracket = tokenBefore.value === '{' || tokenBefore.value === '[';
+      return `${tokenBefore.value.trim()}${isBracket ? '' : ' '}`;
     }
 
     function check(node, type) {
@@ -125,7 +132,21 @@ module.exports = {
 
       if (option === 'parens-new-line' && isMultilines(node)) {
         if (!isParenthesised(node)) {
-          report(node, MISSING_PARENS, fixer => fixer.replaceText(node, `(\n${sourceCode.getText(node)}\n)`));
+          const tokenBefore = sourceCode.getTokenBefore(node, {includeComments: true});
+          const tokenAfter = sourceCode.getTokenAfter(node, {includeComments: true});
+          if (tokenBefore.loc.end.line < node.loc.start.line) {
+            // Strip newline after operator if parens newline is specified
+            report(
+              node,
+              MISSING_PARENS,
+              fixer => fixer.replaceTextRange(
+                [tokenBefore.range[0], tokenAfter.range[0]],
+                `${trimTokenBeforeNewline(node, tokenBefore)}(\n${sourceCode.getText(node)}\n)`
+              )
+            );
+          } else {
+            report(node, MISSING_PARENS, fixer => fixer.replaceText(node, `(\n${sourceCode.getText(node)}\n)`));
+          }
         } else if (needsNewLines(node)) {
           report(node, PARENS_NEW_LINES, fixer => fixer.replaceText(node, `\n${sourceCode.getText(node)}\n`));
         }
@@ -171,7 +192,7 @@ module.exports = {
         }
       },
 
-      'ArrowFunctionExpression:exit': function (node) {
+      'ArrowFunctionExpression:exit': function(node) {
         const arrowBody = node.body;
         const type = 'arrow';
 
@@ -195,7 +216,7 @@ module.exports = {
         }
       },
 
-      JSXAttribute: function (node) {
+      JSXAttribute: function(node) {
         const type = 'prop';
         if (isEnabled(type) && node.value && node.value.type === 'JSXExpressionContainer') {
           check(node.value.expression, type);

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -249,6 +249,16 @@ const LOGICAL_NO_PAREN = `
   </div>
 `;
 
+const LOGICAL_PAREN_NEW_LINE_AUTOFIX = `
+  <div>
+    {foo && (
+<div>
+        <p>Hello World</p>
+      </div>
+)}
+  </div>
+`;
+
 const LOGICAL_PAREN_NEW_LINE = `
   <div>
     {foo && (
@@ -287,6 +297,16 @@ const ATTR_PAREN_NEW_LINE = `
       <p>Hello</p>
     </div>
   )}>
+    <p>Hello</p>
+  </div>
+`;
+
+const ATTR_PAREN_NEW_LINE_AUTOFIX = `
+  <div prop={(
+<div>
+      <p>Hello</p>
+    </div>
+)}>
     <p>Hello</p>
   </div>
 `;
@@ -640,7 +660,7 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       errors: [{message: PARENS_NEW_LINES}]
     }, {
       code: LOGICAL_NO_PAREN,
-      output: addNewLineSymbols(LOGICAL_PAREN),
+      output: LOGICAL_PAREN_NEW_LINE_AUTOFIX,
       options: [{logical: 'parens-new-line'}],
       errors: [{message: MISSING_PARENS}]
     }, {
@@ -650,9 +670,8 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       errors: [{message: PARENS_NEW_LINES}]
     }, {
       code: ATTR_NO_PAREN,
-      output: addNewLineSymbols(ATTR_PAREN),
+      output: ATTR_PAREN_NEW_LINE_AUTOFIX,
       options: [{prop: 'parens-new-line'}],
       errors: [{message: MISSING_PARENS}]
-    }
-  ]
+    }]
 });


### PR DESCRIPTION
This change removes the newline that comes before opening parentheses, if `"parens-new-line"` is specified as an option and the multiline JSX starts on a new line.

i.e. when `"parens-new-line"` is specified,  instead of fixing these cases: 
```jsx
  <div prop={
    <div>
      <p>Hello</p>
    </div>
  }>
    <p>Hello</p>
  </div>

// &

  <div>
    {foo &&
      <div>
        <p>Hello World</p>
      </div>
    }
  </div>
```
like this: 
```jsx
  <div prop={
(
    <div>
      <p>Hello</p>
    </div>
)
  }>

// &

  <div>
    {foo &&
(
      <div>
        <p>Hello World</p>
      </div>
)
}
  </div>
```
this change will inline the opening parentheses: 

```jsx
  <div prop={(
    <div>
      <p>Hello</p>
    </div>
)}>

// &

  <div>
    {foo && (
      <div>
        <p>Hello World</p>
      </div>
)}
  </div>
```

~I did not change the position of closing parens in this PR, I'm not sure if there is another rule that might cover that? if not, I can also try and collapse the bottom parens to be more consistent.~

cc. @ljharb 

**Update**: this change will now inject the closing paren before the token after the jsx body, so the autofix will not leave the closing paren on its own line.