### PR TITLE
New rule: Report usages of class methods besides render returning JSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Enable the rules that you would like to use.
 * [react/no-unused-state](docs/rules/no-unused-state.md): Prevent definitions of unused state properties
 * [react/no-will-update-set-state](docs/rules/no-will-update-set-state.md): Prevent usage of `setState` in `componentWillUpdate`
 * [react/prefer-es6-class](docs/rules/prefer-es6-class.md): Enforce ES5 or ES6 class for React Components
+* [react/prefer-separate-components](docs/rules/prefer-separate-components.md): Report usages of class methods besides render returning JSX
 * [react/prefer-stateless-function](docs/rules/prefer-stateless-function.md): Enforce stateless React Components to be written as a pure function
 * [react/prop-types](docs/rules/prop-types.md): Prevent missing props validation in a React component definition
 * [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md): Prevent missing `React` when using JSX

--- a/docs/rules/prefer-separate-components.md
+++ b/docs/rules/prefer-separate-components.md
@@ -1,0 +1,95 @@
+# Report usages of class methods besides render returning JSX (react/prefer-separate-components)
+
+If component functions other than `render` are returning JSX, they should be moved into separate components.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```jsx
+class Foo extends React.Component {
+  renderBar() {
+    return <span>bar</span>;
+  }
+  render() {
+    return (
+      <div>
+        foo
+        {this.renderBar()}
+      </div>
+    );
+  }
+}
+
+class Foo extends React.Component {
+  renderBar() {
+    return React.createElement('span', null, 'bar');
+  }
+  render() {
+    return React.createElement(
+      'div',
+      null,
+      'foo',
+      this.renderBar()
+    );
+  }
+}
+
+class Foo extends React.Component {
+  renderBars() {
+    const bars = ['bar', 'bar', 'bar'];
+    return bars.map((bar) => <span>{bar}</span>);
+  }
+  render() {
+    return (
+      <div>
+        foo
+        {this.renderBars()}
+      </div>
+    );
+  }
+}
+
+class Foo extends React.Component {
+  renderBars() {
+    const bars = ['bar', 'bar', 'bar'];
+    return bars.map((bar) => React.createElement('span', null, bar));
+  }
+  render() {
+    return React.createElement(
+      'div',
+      null,
+      'foo',
+      this.renderBars()
+    );
+  }
+}
+```
+
+The following patterns are **not** considered warnings:
+
+```jsx
+class Foo extends React.Component {
+  render() {
+    return <div>foo</div>;
+  }
+}
+
+class Foo extends React.Component {
+  render() {
+    return React.createElement('div', null, 'foo');
+  }
+}
+
+createReactClass({
+  render() {
+    return <div>foo</div>;
+  }
+});
+
+createReactClass({
+  render() {
+    return React.createElement('div', null, 'foo');
+  }
+});
+```

--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ const allRules = {
   'no-unused-state': require('./lib/rules/no-unused-state'),
   'no-will-update-set-state': require('./lib/rules/no-will-update-set-state'),
   'prefer-es6-class': require('./lib/rules/prefer-es6-class'),
+  'prefer-separate-components': require('./lib/rules/prefer-separate-components'),
   'prefer-stateless-function': require('./lib/rules/prefer-stateless-function'),
   'prop-types': require('./lib/rules/prop-types'),
   'react-in-jsx-scope': require('./lib/rules/react-in-jsx-scope'),

--- a/lib/rules/prefer-separate-components.js
+++ b/lib/rules/prefer-separate-components.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Report usages of class methods besides render returning JSX
+ */
+'use strict';
+
+const Components = require('../util/Components');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Report usages of class methods besides render returning JSX',
+      category: 'Best Practices',
+      recommended: false
+    },
+    schema: []
+  },
+
+  create: Components.detect((context, components, utils) => {
+    function report(node) {
+      context.report({
+        node,
+        message: '{{ function }} should be moved into a separate component.',
+        data: {
+          function: node.key.name
+        }
+      });
+    }
+
+    return {
+      MethodDefinition: function(node) {
+        if (!utils.getParentES6Component()) {
+          return;
+        }
+        if (node.key.name !== 'render' && utils.isReturningJSX(node)) {
+          report(node);
+        }
+      }
+    };
+  })
+};

--- a/lib/rules/prefer-separate-components.js
+++ b/lib/rules/prefer-separate-components.js
@@ -38,6 +38,15 @@ module.exports = {
         if (node.key.name !== 'render' && utils.isReturningJSX(node)) {
           report(node);
         }
+      },
+
+      Property: function(node) {
+        if (!utils.getParentES5Component) {
+          return;
+        }
+        if (node.key.name !== 'render' && utils.isReturningJSX(node)) {
+          report(node);
+        }
       }
     };
   })

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -303,6 +303,16 @@ function componentRule(rule, context) {
       return calledOnReact;
     },
 
+    isReturningArrayMap(node) {
+      return (
+        node.type === 'ReturnStatement' &&
+        node.argument &&
+        node.argument.type === 'CallExpression' &&
+        node.argument.callee.property &&
+        node.argument.callee.property.name === 'map'
+      );
+    },
+
     getReturnPropertyAndNode(ASTnode) {
       let property;
       let node = ASTnode;
@@ -320,6 +330,9 @@ function componentRule(rule, context) {
         default:
           node = utils.findReturnStatement(node);
           property = 'argument';
+      }
+      if (this.isReturningArrayMap(node)) {
+        return this.getReturnPropertyAndNode(node.argument.arguments[0]);
       }
       return {
         node: node,

--- a/tests/lib/rules/prefer-separate-components.js
+++ b/tests/lib/rules/prefer-separate-components.js
@@ -31,9 +31,25 @@ ruleTester.run('prefer-separate-components', rule, {
     `
   }, {
     code: `
+      class Foo extends React.Component {
+        render() {
+          return React.createElement('div', null, 'foo');
+        }
+      }
+    `
+  }, {
+    code: `
       createReactClass({
         render() {
           return <div>foo</div>;
+        }
+      });
+    `
+  }, {
+    code: `
+      createReactClass({
+        render() {
+          return React.createElement('div', null, 'foo');
         }
       });
     `
@@ -58,6 +74,23 @@ ruleTester.run('prefer-separate-components', rule, {
   }, {
     code: `
       class Foo extends React.Component {
+        renderBar() {
+          return React.createElement('span', null, 'bar');
+        }
+        render() {
+          return React.createElement(
+            'div',
+            null,
+            'foo',
+            this.renderBar()
+          );
+        }
+      }
+    `,
+    errors: 1
+  }, {
+    code: `
+      class Foo extends React.Component {
         renderBars() {
           const bars = ['bar', 'bar', 'bar'];
           return bars.map((bar) => <span>{bar}</span>);
@@ -68,6 +101,24 @@ ruleTester.run('prefer-separate-components', rule, {
               foo
               {this.renderBars()}
             </div>
+          );
+        }
+      }
+    `,
+    errors: 1
+  }, {
+    code: `
+      class Foo extends React.Component {
+        renderBars() {
+          const bars = ['bar', 'bar', 'bar'];
+          return bars.map((bar) => React.createElement('span', null, bar));
+        }
+        render() {
+          return React.createElement(
+            'div',
+            null,
+            'foo',
+            this.renderBars()
           );
         }
       }
@@ -94,6 +145,24 @@ ruleTester.run('prefer-separate-components', rule, {
   }, {
     code: `
       createReactClass({
+        renderBars() {
+          const bars = ['bar', 'bar', 'bar'];
+          return bars.map((bar) => React.createElement('span', null, bar));
+        },
+        render() {
+          return React.createElement(
+            'div',
+            null,
+            'foo',
+            this.renderBars()
+          );
+        }
+      });
+    `,
+    errors: 1
+  }, {
+    code: `
+      createReactClass({
         renderBar() {
           return <span>bar</span>;
         },
@@ -103,6 +172,23 @@ ruleTester.run('prefer-separate-components', rule, {
               foo
               {this.renderBar()}
             </div>
+          );
+        }
+      });
+    `,
+    errors: 1
+  }, {
+    code: `
+      createReactClass({
+        renderBar() {
+          return React.createElement('span', null, 'bar');
+        },
+        render() {
+          return React.createElement(
+            'div',
+            null,
+            'foo',
+            this.renderBar()
           );
         }
       });

--- a/tests/lib/rules/prefer-separate-components.js
+++ b/tests/lib/rules/prefer-separate-components.js
@@ -47,5 +47,23 @@ ruleTester.run('prefer-separate-components', rule, {
       }
     `,
     errors: 1
+  }, {
+    code: `
+      class Foo extends React.Component {
+        renderBars() {
+          const bars = ['bar', 'bar', 'bar'];
+          return bars.map((bar) => <span>{bar}</span>);
+        }
+        render() {
+          return (
+            <div>
+              foo
+              {this.renderBars()}
+            </div>
+          );
+        }
+      }
+    `,
+    errors: 1
   }]
 });

--- a/tests/lib/rules/prefer-separate-components.js
+++ b/tests/lib/rules/prefer-separate-components.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Report usages of class methods besides render returning JSX
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/prefer-separate-components');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true
+  }
+};
+
+const ruleTester = new RuleTester({parserOptions});
+ruleTester.run('prefer-separate-components', rule, {
+  valid: [{
+    code: `
+      class Foo extends React.Component {
+        render() {
+          return <div>foo</div>;
+        }
+      }
+    `
+  }],
+  invalid: [{
+    code: `
+      class Foo extends React.Component {
+        renderBar() {
+          return <span>bar</span>;
+        }
+        render() {
+          return (
+            <div>
+              foo
+              {this.renderBar()}
+            </div>
+          );
+        }
+      }
+    `,
+    errors: 1
+  }]
+});

--- a/tests/lib/rules/prefer-separate-components.js
+++ b/tests/lib/rules/prefer-separate-components.js
@@ -29,6 +29,14 @@ ruleTester.run('prefer-separate-components', rule, {
         }
       }
     `
+  }, {
+    code: `
+      createReactClass({
+        render() {
+          return <div>foo</div>;
+        }
+      });
+    `
   }],
   invalid: [{
     code: `
@@ -63,6 +71,41 @@ ruleTester.run('prefer-separate-components', rule, {
           );
         }
       }
+    `,
+    errors: 1
+  }, {
+    code: `
+      createReactClass({
+        renderBars() {
+          const bars = ['bar', 'bar', 'bar'];
+          return bars.map((bar) => <span>{bar}</span>);
+        },
+        render() {
+          return (
+            <div>
+              foo
+              {this.renderBars()}
+            </div>
+          );
+        }
+      });
+    `,
+    errors: 1
+  }, {
+    code: `
+      createReactClass({
+        renderBar() {
+          return <span>bar</span>;
+        },
+        render() {
+          return (
+            <div>
+              foo
+              {this.renderBar()}
+            </div>
+          );
+        }
+      });
     `,
     errors: 1
   }]

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1275,15 +1275,6 @@ ruleTester.run('prop-types', rule, {
       ].join('\n')
     }, {
       code: [
-        'function Hello({names}) {',
-        '  return names.map((name) => {',
-        '    return <div>{name}</div>;',
-        '  });',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint'
-    }, {
-      code: [
         'type Target = { target: EventTarget }',
         'class MyComponent extends Component {',
         '  static propTypes = {',
@@ -3531,6 +3522,18 @@ ruleTester.run('prop-types', rule, {
       `,
       errors: [{
         message: '\'fooBar\' is missing in props validation'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'function Hello({names}) {',
+        '  return names.map((name) => {',
+        '    return <div>{name}</div>;',
+        '  });',
+        '}'
+      ].join('\n'),
+      errors: [{
+        message: '\'names\' is missing in props validation'
       }],
       parser: 'babel-eslint'
     }


### PR DESCRIPTION
I saw #578 and thought that the requested rule was useful. I personally don't like components that define extra render* methods that return JSX. It is a way to clean up the main render method, but the better choice is to move the logic to separate components. This rule will try to enforce that.

I wasn't sure about the rule name, so I'm open to a better name if it's offered.

Closes #578 