### PR TITLE
Find edge case in no-access-state-in-setstate (#1597)

### DIFF
--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -107,7 +107,8 @@ module.exports = {
             if (current.type === 'VariableDeclarator') {
               vars.push({
                 node: node,
-                scope: context.getScope()
+                scope: context.getScope(),
+                variableName: current.id.name
               });
               break;
             }
@@ -123,11 +124,14 @@ module.exports = {
         while (current.parent.type === 'BinaryExpression') {
           current = current.parent;
         }
-        if (current.parent.value === current) {
+        if (
+          current.parent.value === current ||
+          current.parent.object === current
+        ) {
           while (current.type !== 'Program') {
             if (isSetStateCall(current)) {
               vars
-                .filter(v => v.scope === context.getScope())
+                .filter(v => v.scope === context.getScope() && v.variableName === node.name)
                 .map(v => context.report(
                   v.node,
                   'Use callback in setState when referencing the previous state.'
@@ -136,6 +140,19 @@ module.exports = {
             current = current.parent;
           }
         }
+      },
+
+      ObjectPattern(node) {
+        const isDerivedFromThis = node.parent.init.type === 'ThisExpression';
+        node.properties.forEach(property => {
+          if (property.key.name === 'state' && isDerivedFromThis) {
+            vars.push({
+              node: property.key,
+              scope: context.getScope(),
+              variableName: property.key.name
+            });
+          }
+        });
       }
     };
   }

--- a/tests/lib/rules/no-access-state-in-setstate.js
+++ b/tests/lib/rules/no-access-state-in-setstate.js
@@ -64,6 +64,17 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       });
     `,
     parserOptions: parserOptions
+  }, {
+    code: [
+      'var Hello = React.createClass({',
+      '  onClick: function() {',
+      '    var nextValueNotUsed = this.state.value + 1',
+      '    var nextValue = 2',
+      '    this.setState({value: nextValue})',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions
   }],
 
   invalid: [{
@@ -96,6 +107,19 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '  onClick: function() {',
       '    var nextValue = this.state.value + 1',
       '    this.setState({value: nextValue})',
+      '  }',
+      '});'
+    ].join('\n'),
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Use callback in setState when referencing the previous state.'
+    }]
+  }, {
+    code: [
+      'var Hello = React.createClass({',
+      '  onClick: function() {',
+      '    var {state} = this',
+      '    this.setState({value: state.value + 1})',
       '  }',
       '});'
     ].join('\n'),


### PR DESCRIPTION
This fixes #1597.

This also fixes another bug I found where the following were reported as an error (added a new test case for this): 
```js
var nextValueNotUsed = this.state.value + 1;
var nextValue = 2;
this.setState({value: nextValue});
```