### PR TITLE
Add empty params check for unused prop types rule to fix empty proptype functions from causing crashes

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -652,6 +652,9 @@ module.exports = {
         case 'ArrowFunctionExpression':
         case 'FunctionDeclaration':
         case 'FunctionExpression':
+          if (node.params.length === 0) {
+            break;
+          }
           type = 'destructuring';
           properties = node.params[0].properties;
           if (inSetStateUpdater()) {

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2440,6 +2440,17 @@ ruleTester.run('no-unused-prop-types', rule, {
       }
       `,
       parser: 'babel-eslint'
+    },
+    {
+      code: `
+        class MyComponent extends React.Component<Props> {
+          render() {
+            return <div>{ this.props.other }</div>
+          }
+        }
+        MyComponent.propTypes = { other: () => {} };
+      `,
+      parser: 'babel-eslint'
     }
   ],
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2443,14 +2443,43 @@ ruleTester.run('no-unused-prop-types', rule, {
     },
     {
       code: `
-        class MyComponent extends React.Component<Props> {
+        class MyComponent extends React.Component {
           render() {
             return <div>{ this.props.other }</div>
           }
         }
         MyComponent.propTypes = { other: () => {} };
-      `,
-      parser: 'babel-eslint'
+      `
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {
+          render() {
+            return <div>{ this.props.other }</div>
+          }
+        }
+        MyComponent.propTypes = { other() {} };
+      `
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {
+          render() {
+            return <div>{ this.props.other }</div>
+          }
+        }
+        MyComponent.propTypes = { other: function () {} };
+      `
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {
+          render() {
+            return <div>{ this.props.other }</div>
+          }
+        }
+        MyComponent.propTypes = { * other() {} };
+      `
     }
   ],
 


### PR DESCRIPTION
Summary
----------
There seems to still be an unresolved regression introduced in 7.5.0 from https://github.com/yannickcr/eslint-plugin-react/pull/1507 
(see https://github.com/yannickcr/eslint-plugin-react/issues/1581#issuecomment-351220583)

When passing an empty function as a PropType - it causes the `no-unused-prop-types` to crash eslint with the following error:
```js
Cannot read property 'properties' of undefined
TypeError: Cannot read property 'properties' of undefined
```

When this part of `no-unused-prop-types` is run:
https://github.com/yannickcr/eslint-plugin-react/blob/f6e4c891a474aaff8f69088b174de8c1317f8fa8/lib/rules/no-unused-prop-types.js#L652-L660

it breaks because `node.params` is an empty array. In my testing, it looks like #1507 introduced this breakage (the test I've included does not break when you revert it), it's unclear and hard to determine why #1507 caused this change.

This PR keeps the tests #1507 introduced passing, while also fixing the regression mentioned.

Changes Proposed
-------------------
- [x] Add empty params check in the `markPropTypesAsUsed` function to fix empty propType functions from causing crashes.
- [x] Add test for validating empty propType functions by `no-unused-prop-types`

To reproduce
--------------
Lint this code with `no-unused-prop-types` and it will crash. We're also seeing this live in CI deployments at https://github.com/react-bootstrap/react-bootstrap in tests relating to propTypes.

```es6
class MyComponent extends React.Component<Props> {
  render() {
    return <div>{ this.props.other }</div>
  }
}
MyComponent.propTypes = { other: () => {} };
```

---
Fixes #1542, #1581
cc: @ljharb 