### PR TITLE
Handle nodes without init

### DIFF
--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -143,7 +143,7 @@ module.exports = {
       },
 
       ObjectPattern(node) {
-        const isDerivedFromThis = node.parent.init.type === 'ThisExpression';
+        const isDerivedFromThis = node.parent.init && node.parent.init.type === 'ThisExpression';
         node.properties.forEach(property => {
           if (property.key.name === 'state' && isDerivedFromThis) {
             vars.push({

--- a/tests/lib/rules/no-access-state-in-setstate.js
+++ b/tests/lib/rules/no-access-state-in-setstate.js
@@ -75,6 +75,13 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '});'
     ].join('\n'),
     parserOptions: parserOptions
+  }, {
+    // https://github.com/yannickcr/eslint-plugin-react/pull/1611
+    code: `
+      function testFunction({a, b}) {
+      };
+    `,
+    parserOptions: parserOptions
   }],
 
   invalid: [{


### PR DESCRIPTION
Avoids this error which appears in `master` in the `no-access-state-in-setstate` rule

```
TypeError: Cannot read property 'type' of undefined
    at ObjectPattern (/Users/patrick/dev/sigopt-api/node_modules/eslint-plugin-react/lib/rules/no-access-state-in-setstate.js:158:52)
    at listeners.(anonymous function).forEach.listener (/Users/patrick/dev/sigopt-api/node_modules/eslint/lib/util/safe-emitter.js:47:58)
    at Array.forEach (<anonymous>)
    at Object.emit (/Users/patrick/dev/sigopt-api/node_modules/eslint/lib/util/safe-emitter.js:47:38)
    at NodeEventGenerator.applySelector (/Users/patrick/dev/sigopt-api/node_modules/eslint/lib/util/node-event-generator.js:251:26)
    at NodeEventGenerator.applySelectors (/Users/patrick/dev/sigopt-api/node_modules/eslint/lib/util/node-event-generator.js:280:22)
    at NodeEventGenerator.enterNode (/Users/patrick/dev/sigopt-api/node_modules/eslint/lib/util/node-event-generator.js:294:14)
    at CodePathAnalyzer.enterNode (/Users/patrick/dev/sigopt-api/node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:608:23)
    at Traverser.enter (/Users/patrick/dev/sigopt-api/node_modules/eslint/lib/linter.js:956:32)
    at Traverser.__execute (/Users/patrick/dev/sigopt-api/node_modules/estraverse/estraverse.js:397:31)
```