### PR TITLE
no-did-mount-set-state with cDU or cDM as ClassProperties

### DIFF
--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -76,7 +76,7 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
               depth++;
             }
             if (
-              (ancestor.type !== 'Property' && ancestor.type !== 'MethodDefinition') ||
+              (ancestor.type !== 'Property' && ancestor.type !== 'MethodDefinition' && ancestor.type !== 'ClassProperty') ||
               !nameMatches(ancestor.key.name) ||
               (mode !== 'disallow-in-func' && depth > 1)
             ) {

--- a/tests/lib/rules/no-did-mount-set-state.js
+++ b/tests/lib/rules/no-did-mount-set-state.js
@@ -109,6 +109,20 @@ ruleTester.run('no-did-mount-set-state', rule, {
     }]
   }, {
     code: `
+      class Hello extends React.Component {
+        componentDidMount = () => {
+          this.setState({
+            data: data
+          });
+        }
+      }
+    `,
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Do not use setState in componentDidMount'
+    }]
+  }, {
+    code: `
       var Hello = createReactClass({
         componentDidMount: function() {
           this.setState({

--- a/tests/lib/rules/no-did-update-set-state.js
+++ b/tests/lib/rules/no-did-update-set-state.js
@@ -109,6 +109,20 @@ ruleTester.run('no-did-update-set-state', rule, {
     }]
   }, {
     code: `
+      class Hello extends React.Component {
+        componentDidUpdate = () => {
+          this.setState({
+            data: data
+          });
+        }
+      }
+    `,
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Do not use setState in componentDidUpdate'
+    }]
+  }, {
+    code: `
       var Hello = createReactClass({
         componentDidUpdate: function() {
           this.setState({


### PR DESCRIPTION
This fixes #1595, catching this.setState used within cDU/cDM when cDU/cDM is defined as ClassProperties. 

Even though defining cDU/cDM as ClassProperties may not be the smartest thing to do, this rule should still handle it. 