### PR TITLE
Add null avoidance in rule `require-optimization`

### DIFF
--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -106,7 +106,7 @@ module.exports = {
       let hasPR = false;
       if (node.value && node.value.elements) {
         for (let i = 0, l = node.value.elements.length; i < l; i++) {
-          if (node.value.elements[i].name === 'PureRenderMixin') {
+          if (node.value.elements[i] && node.value.elements[i].name === 'PureRenderMixin') {
             hasPR = true;
             break;
           }

--- a/tests/lib/rules/require-optimization.js
+++ b/tests/lib/rules/require-optimization.js
@@ -112,6 +112,10 @@ ruleTester.run('react-require-optimization', rule, {
     `,
     parser: 'babel-eslint',
     options: [{allowDecorators: ['renderPure', 'pureRender']}]
+  }, {
+    code: `
+      const obj = { prop: [,,,,,] }
+    `
   }],
 
   invalid: [{


### PR DESCRIPTION
Hello, thanks for the great ESLint rule.

This is an error report.
When the rule `require-optimization` encounters arrays with empty items as values in object (ex. `{ 
const obj = { prop: [,,,,,] } }`),  an error rises.

This PR provides null avoidance, simply.