### PR TITLE
Teach no-unused-prop-types about parameter aliases

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -276,6 +276,20 @@ module.exports = {
     }
 
     /**
+     * Figure out whether the source of this destructuring node has a default
+     * value of the same field in `this`. (See `isDeclaredWithDefaultFromInstanceField` for details).
+     * @param node Assignment node
+     * @returns {boolean}
+     */
+    function isDestructuringSourceThisAlias(node) {
+      const sourceVar = variable.getVariable(variable.variablesInScope(context), node.init.name);
+      if (sourceVar) {
+        return variable.isDeclaredWithDefaultFromInstanceField(sourceVar);
+      }
+      return false;
+    }
+
+    /**
      * Checks if a prop init name matches common naming patterns
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if the prop name matches
@@ -673,7 +687,8 @@ module.exports = {
             // let {firstname} = props
             const genericDestructuring = isPropAttributeName(node) && (
               utils.getParentStatelessComponent() ||
-              isInLifeCycleMethod(node)
+              isInLifeCycleMethod(node) ||
+              isDestructuringSourceThisAlias(node)
             );
 
             if (thisDestructuring) {
@@ -999,7 +1014,8 @@ module.exports = {
         // let {firstname} = props
         const statelessDestructuring = destructuring && isPropAttributeName(node) && (
           utils.getParentStatelessComponent() ||
-          isInLifeCycleMethod(node)
+          isInLifeCycleMethod(node) ||
+          isDestructuringSourceThisAlias(node)
         );
 
         if (!thisDestructuring && !statelessDestructuring) {

--- a/lib/util/variable.js
+++ b/lib/util/variable.js
@@ -71,9 +71,39 @@ function findVariableByName(context, name) {
   return variable.defs[0].node.init;
 }
 
+
+/**
+ * Figure out whether a parameter definition of `variable` has a default
+ * value of the same name as the variable itself, but in `this`.
+ *
+ * I.e. detect if `variable` is a parameter declared like
+ * `function foo(props = this.props) { ... }`.
+ *
+ * @param {Variable} variable The Variable object to inspect
+ * @returns {boolean} Whether it is an alias like described above.
+ */
+function isDeclaredWithDefaultFromInstanceField(variable) {
+  return variable.defs.some(def => {
+    if (def.type === 'Parameter') {
+      const assign = def.name.parent;
+      if (assign && assign.type === 'AssignmentPattern') {
+        if (assign.right && assign.right.type === 'MemberExpression') {
+          const object = assign.right.object;
+          const property = assign.right.property;
+          if (object && property && object.type === 'ThisExpression' && property.type === 'Identifier' && property.name === variable.name) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  });
+}
+
 module.exports = {
   findVariable: findVariable,
   findVariableByName: findVariableByName,
   getVariable: getVariable,
+  isDeclaredWithDefaultFromInstanceField: isDeclaredWithDefaultFromInstanceField,
   variablesInScope: variablesInScope
 };

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2480,6 +2480,22 @@ ruleTester.run('no-unused-prop-types', rule, {
         }
         MyComponent.propTypes = { * other() {} };
       `
+    },
+    {
+      code: `
+        class MyComponent extends React.Component {
+          componentDidMount() {
+            this.helperMethod();
+          }
+          componentWillReceiveProps(nextProps) {
+            this.helperMethod(nextProps);
+          }
+          helperMethod(props = this.props) {
+            const { message } = props;
+          }
+        }
+        MyComponent.propTypes = { message: PropTypes.string };
+      `
     }
   ],
 


### PR DESCRIPTION
This PR extends `no-unused-prop-types` to understand `const {...} = props;` destructuring even in methods that are not lifecycle methods, _iff_ the `props` name refers to a function parameter whose default value refers to the same field in the instance. (Now that's a complex sentence...)

Point being, it's fairly common to refactor code called from a lifecycle method into reusable bits, but when not being called from a lifecycle method (that might have the `nextProps` to pass in), one wants to use the component's current props, like so:

```javascript
class MyComponent extends React.Component {
  componentDidMount() {
    this.helperMethod();
  }
  componentWillReceiveProps(nextProps) {
    this.helperMethod(nextProps);
  }
  helperMethod(props = this.props) {
    const { message } = props;
    // ....
  }
}
MyComponent.propTypes = { message: PropTypes.string };
```

Previously, this would have failed (`message` was considered a defined prop that was never used), since the plugin did (and still doesn't) do code path analysis to realize that `helperMethod` is called from a lifecycle method.

Instead of full-blown code path analysis, we just assume that the pattern `x = this.x` (where `x` is one of the "well-known" props names `props`, `nextProps` and `prevProps`) in function arguments is this usage.

This is my first ever foray into writing an Eslint plugin or manipulating a Babylon AST, so I'm all ears for advice in case I'm doing something extra silly. :)

