### PR TITLE
Add URL to rule documentation to the metadata

### DIFF
--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -7,6 +7,7 @@
 const has = require('has');
 const Components = require('../util/Components');
 const propsUtil = require('../util/props');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +18,8 @@ module.exports = {
     docs: {
       category: 'Stylistic Issues',
       description: 'Enforces consistent naming for boolean props',
-      recommended: false
+      recommended: false,
+      url: docsUrl('boolean-prop-naming')
     },
 
     schema: [{

--- a/lib/rules/button-has-type.js
+++ b/lib/rules/button-has-type.js
@@ -6,6 +6,7 @@
 
 const getProp = require('jsx-ast-utils/getProp');
 const getLiteralPropValue = require('jsx-ast-utils/getLiteralPropValue');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -27,7 +28,8 @@ module.exports = {
     docs: {
       description: 'Forbid "button" element without an explicit "type" attribute',
       category: 'Possible Errors',
-      recommended: false
+      recommended: false,
+      url: docsUrl('button-has-type')
     },
     schema: [{
       type: 'object',

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -11,6 +11,7 @@ const variableUtil = require('../util/variable');
 const annotations = require('../util/annotations');
 const astUtil = require('../util/ast');
 const propsUtil = require('../util/props');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -20,7 +21,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Enforce all defaultProps are defined and not "required" in propTypes.',
-      category: 'Best Practices'
+      category: 'Best Practices',
+      url: docsUrl('default-props-match-prop-types')
     },
 
     schema: [{

--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 const DEFAULT_OPTION = 'always';
 
@@ -12,7 +13,8 @@ module.exports = {
     docs: {
       description: 'Enforce consistent usage of destructuring assignment of props, state, and context',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('destructuring-assignment')
     },
     schema: [{
       type: 'string',

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -6,6 +6,7 @@
 
 const has = require('has');
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -16,7 +17,8 @@ module.exports = {
     docs: {
       description: 'Prevent missing displayName in a React component definition',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('display-name')
     },
 
     schema: [{

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
@@ -19,7 +21,8 @@ module.exports = {
     docs: {
       description: 'Forbid certain props on components',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('forbid-component-props')
     },
 
     schema: [{

--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
@@ -19,7 +21,8 @@ module.exports = {
     docs: {
       description: 'Forbid certain props on DOM Nodes',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('forbid-dom-props')
     },
 
     schema: [{

--- a/lib/rules/forbid-elements.js
+++ b/lib/rules/forbid-elements.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const has = require('has');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Forbid certain elements',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('forbid-elements')
     },
 
     schema: [{

--- a/lib/rules/forbid-foreign-prop-types.js
+++ b/lib/rules/forbid-foreign-prop-types.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
@@ -18,7 +20,8 @@ module.exports = {
     docs: {
       description: 'Forbid using another component\'s propTypes',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('forbid-foreign-prop-types')
     }
   },
 

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -6,6 +6,7 @@
 const variableUtil = require('../util/variable');
 const propsUtil = require('../util/props');
 const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -22,7 +23,8 @@ module.exports = {
     docs: {
       description: 'Forbid certain propTypes',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('forbid-prop-types')
     },
 
     schema: [{

--- a/lib/rules/jsx-boolean-value.js
+++ b/lib/rules/jsx-boolean-value.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -48,7 +50,8 @@ module.exports = {
     docs: {
       description: 'Enforce boolean attributes notation in JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-boolean-value')
     },
     fixable: 'code',
 

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const has = require('has');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -14,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Validate closing bracket location in JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-closing-bracket-location')
     },
     fixable: 'code',
 

--- a/lib/rules/jsx-closing-tag-location.js
+++ b/lib/rules/jsx-closing-tag-location.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -14,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Validate closing tag location for multiline JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-closing-tag-location')
     },
     fixable: 'whitespace'
   },

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
@@ -31,7 +33,8 @@ module.exports = {
         'Disallow unnecessary JSX expressions when literals alone are sufficient ' +
           'or enfore JSX expressions on literals in JSX children or attributes',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-curly-brace-presence')
     },
     fixable: 'code',
 

--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -11,6 +11,7 @@
 'use strict';
 
 const has = require('has');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -27,7 +28,8 @@ module.exports = {
     docs: {
       description: 'Enforce or disallow spaces inside of curly braces in JSX attributes',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-curly-spacing')
     },
     fixable: 'code',
 

--- a/lib/rules/jsx-equals-spacing.js
+++ b/lib/rules/jsx-equals-spacing.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -13,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Disallow or enforce spaces around equal signs in JSX attributes',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-equals-spacing')
     },
     fixable: 'code',
 

--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const path = require('path');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -23,7 +24,8 @@ module.exports = {
     docs: {
       description: 'Restrict file extensions that may contain JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-filename-extension')
     },
 
     schema: [{

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -13,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Ensure proper position of the first property in JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-first-prop-new-line')
     },
     fixable: 'code',
 

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -13,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Enforce event handler naming conventions in JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-handler-names')
     },
 
     schema: [{

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -30,6 +30,7 @@
 'use strict';
 
 const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -39,7 +40,8 @@ module.exports = {
     docs: {
       description: 'Validate props indentation in JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-indent-props')
     },
     fixable: 'code',
 

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -30,6 +30,7 @@
 'use strict';
 
 const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -39,7 +40,8 @@ module.exports = {
     docs: {
       description: 'Validate JSX indentation',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-indent')
     },
     fixable: 'whitespace',
     schema: [{

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -4,8 +4,8 @@
  */
 'use strict';
 
-// var Components = require('../util/Components');
 const hasProp = require('jsx-ast-utils/hasProp');
+const docsUrl = require('../util/docsUrl');
 
 
 // ------------------------------------------------------------------------------
@@ -17,7 +17,8 @@ module.exports = {
     docs: {
       description: 'Report missing `key` props in iterators/collection literals',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('jsx-key')
     },
     schema: []
   },

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -14,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Limit maximum of props on a single line in JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-max-props-per-line')
     },
     fixable: 'code',
     schema: [{

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -6,8 +6,9 @@
  */
 'use strict';
 
-const Components = require('../util/Components');
 const propName = require('jsx-ast-utils/propName');
+const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // -----------------------------------------------------------------------------
 // Rule Definition
@@ -25,7 +26,8 @@ module.exports = {
     docs: {
       description: 'Prevents usage of Function.prototype.bind and arrow functions in React component props',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-no-bind')
     },
 
     schema: [{

--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -13,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Comments inside children section of tag should be placed inside braces',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('jsx-no-comment-textnodes')
     },
 
     schema: [{

--- a/lib/rules/jsx-no-duplicate-props.js
+++ b/lib/rules/jsx-no-duplicate-props.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const has = require('has');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -16,7 +17,8 @@ module.exports = {
     docs: {
       description: 'Enforce no duplicate props',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('jsx-no-duplicate-props')
     },
 
     schema: [{

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -5,6 +5,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -14,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Prevent using string literals in React component definition',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-no-literals')
     },
 
     schema: [{

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -36,7 +38,8 @@ module.exports = {
     docs: {
       description: 'Forbid target="_blank" attribute without rel="noopener noreferrer"',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('jsx-no-target-blank')
     },
     schema: []
   },

--- a/lib/rules/jsx-no-undef.js
+++ b/lib/rules/jsx-no-undef.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 /**
  * Checks if a node name match the JSX tag convention.
  * @param {String} name - Name of the node to check.
@@ -24,7 +26,8 @@ module.exports = {
     docs: {
       description: 'Disallow undeclared variables in JSX',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('jsx-no-undef')
     },
     schema: [{
       type: 'object',

--- a/lib/rules/jsx-one-expression-per-line.js
+++ b/lib/rules/jsx-one-expression-per-line.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -14,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Limit to one expression per line in JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-one-expression-per-line')
     },
     fixable: 'whitespace',
     schema: []

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const elementType = require('jsx-ast-utils/elementType');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -24,7 +25,8 @@ module.exports = {
     docs: {
       description: 'Enforce PascalCase for user-defined JSX components',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-pascal-case')
     },
 
     schema: [{

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -6,6 +6,7 @@
 
 const elementType = require('jsx-ast-utils/elementType');
 const propName = require('jsx-ast-utils/propName');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -168,7 +169,8 @@ module.exports = {
     docs: {
       description: 'Enforce props alphabetical sorting',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-sort-props')
     },
     fixable: 'code',
     schema: [{

--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -6,6 +6,8 @@
 'use strict';
 
 const getTokenBeforeClosingBracket = require('../util/getTokenBeforeClosingBracket');
+const docsUrl = require('../util/docsUrl');
+
 let isWarnedForDeprecation = false;
 
 // ------------------------------------------------------------------------------
@@ -18,7 +20,8 @@ module.exports = {
     docs: {
       description: 'Validate spacing before closing bracket in JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-space-before-closing')
     },
     fixable: 'code',
 

--- a/lib/rules/jsx-tag-spacing.js
+++ b/lib/rules/jsx-tag-spacing.js
@@ -6,6 +6,7 @@
 
 const has = require('has');
 const getTokenBeforeClosingBracket = require('../util/getTokenBeforeClosingBracket');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Validators
@@ -174,7 +175,9 @@ function validateAfterOpening(context, node, option) {
 
 module.exports = {
   meta: {
-    docs: {},
+    docs: {
+      url: docsUrl('jsx-tag-spacing')
+    },
     fixable: 'whitespace',
     schema: [
       {

--- a/lib/rules/jsx-uses-react.js
+++ b/lib/rules/jsx-uses-react.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const pragmaUtil = require('../util/pragma');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Prevent React to be marked as unused',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('jsx-uses-react')
     },
     schema: []
   },

--- a/lib/rules/jsx-uses-vars.js
+++ b/lib/rules/jsx-uses-vars.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -13,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Prevent variables used in JSX to be marked as unused',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('jsx-uses-vars')
     },
     schema: []
   },

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const has = require('has');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -32,7 +33,8 @@ module.exports = {
     docs: {
       description: 'Prevent missing parentheses around multilines JSX',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('jsx-wrap-multilines')
     },
     fixable: 'code',
 

--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -14,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Reports when this.state is accessed within setState',
       category: 'Possible Errors',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-access-state-in-setstate')
     }
   },
 

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const has = require('has');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Prevent usage of Array index in keys',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-array-index-key')
     },
 
     schema: []

--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Helpers
 // ------------------------------------------------------------------------------
@@ -31,7 +33,8 @@ module.exports = {
     docs: {
       description: 'Prevent passing of children as props.',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-children-prop')
     },
     schema: []
   },

--- a/lib/rules/no-danger-with-children.js
+++ b/lib/rules/no-danger-with-children.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const variableUtil = require('../util/variable');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -14,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Report when a DOM element is using both children and dangerouslySetInnerHTML',
       category: '',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-danger-with-children')
     },
     schema: [] // no options
   },

--- a/lib/rules/no-danger.js
+++ b/lib/rules/no-danger.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
@@ -51,7 +53,8 @@ module.exports = {
     docs: {
       description: 'Prevent usage of dangerous JSX props',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-danger')
     },
     schema: []
   },

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -9,6 +9,7 @@ const has = require('has');
 
 const pragmaUtil = require('../util/pragma');
 const versionUtil = require('../util/version');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -30,7 +31,8 @@ module.exports = {
     docs: {
       description: 'Prevent usage of deprecated methods',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-deprecated')
     },
     schema: []
   },

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -16,7 +17,8 @@ module.exports = {
     docs: {
       description: 'Prevent direct mutation of this.state',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-direct-mutation-state')
     }
   },
 

--- a/lib/rules/no-find-dom-node.js
+++ b/lib/rules/no-find-dom-node.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -13,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Prevent usage of findDOMNode',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-find-dom-node')
     },
     schema: []
   },

--- a/lib/rules/no-is-mounted.js
+++ b/lib/rules/no-is-mounted.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -13,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Prevent usage of isMounted',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-is-mounted')
     },
     schema: []
   },

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -6,6 +6,7 @@
 
 const has = require('has');
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -16,7 +17,8 @@ module.exports = {
     docs: {
       description: 'Prevent multiple component definition per file',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-multi-comp')
     },
 
     schema: [{

--- a/lib/rules/no-redundant-should-component-update.js
+++ b/lib/rules/no-redundant-should-component-update.js
@@ -5,6 +5,7 @@
 
 const Components = require('../util/Components');
 const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
 
 function errorMessage(node) {
   return `${node} does not need shouldComponentUpdate when extending React.PureComponent.`;
@@ -19,7 +20,8 @@ module.exports = {
     docs: {
       description: 'Flag shouldComponentUpdate when extending PureComponent',
       category: 'Possible Errors',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-redundant-should-component-update')
     },
     schema: []
   },

--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const versionUtil = require('../util/version');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Prevent usage of the return value of React.render',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-render-return-value')
     },
     schema: []
   },

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -6,6 +6,7 @@
 
 const has = require('has');
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -16,7 +17,8 @@ module.exports = {
     docs: {
       description: 'Prevent usage of setState',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-set-state')
     },
     schema: []
   },

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Prevent string definitions for references and prevent referencing this.refs',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-string-refs')
     },
     schema: []
   },

--- a/lib/rules/no-this-in-sfc.js
+++ b/lib/rules/no-this-in-sfc.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -20,7 +21,8 @@ module.exports = {
     docs: {
       description: 'Report "this" being used in stateless components',
       category: 'Possible Errors',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-this-in-sfc')
     },
     schema: []
   },

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -4,6 +4,7 @@
 'use strict';
 
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -28,7 +29,8 @@ module.exports = {
     docs: {
       description: 'Prevent common typos',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-typos')
     },
     schema: []
   },

--- a/lib/rules/no-unescaped-entities.js
+++ b/lib/rules/no-unescaped-entities.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -18,7 +20,8 @@ module.exports = {
     docs: {
       description: 'Detect unescaped HTML entities, which might represent malformed tags',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-unescaped-entities')
     },
     schema: [{
       type: 'object',

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Constants
 // ------------------------------------------------------------------------------
@@ -176,7 +178,8 @@ module.exports = {
     docs: {
       description: 'Prevent usage of unknown DOM property',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('no-unknown-property')
     },
     fixable: 'code',
 

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -13,6 +13,7 @@ const variable = require('../util/variable');
 const annotations = require('../util/annotations');
 const versionUtil = require('../util/version');
 const propsUtil = require('../util/props');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -32,7 +33,8 @@ module.exports = {
     docs: {
       description: 'Prevent definitions of unused prop types',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-unused-prop-types')
     },
 
     schema: [{

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -10,6 +10,7 @@
 'use strict';
 
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // Descend through all wrapping TypeCastExpressions and return the expression
 // that was cast.
@@ -63,7 +64,8 @@ module.exports = {
     docs: {
       description: 'Prevent definition of unused state fields',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-unused-state')
     },
     schema: []
   },

--- a/lib/rules/prefer-es6-class.js
+++ b/lib/rules/prefer-es6-class.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Enforce ES5 or ES6 class for React Components',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('prefer-es6-class')
     },
 
     schema: [{

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -10,6 +10,7 @@ const has = require('has');
 const Components = require('../util/Components');
 const versionUtil = require('../util/version');
 const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -20,7 +21,8 @@ module.exports = {
     docs: {
       description: 'Enforce stateless components to be written as a pure function',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('prefer-stateless-function')
     },
     schema: [{
       type: 'object',

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -13,6 +13,7 @@ const variable = require('../util/variable');
 const annotations = require('../util/annotations');
 const versionUtil = require('../util/version');
 const propsUtil = require('../util/props');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -30,7 +31,8 @@ module.exports = {
     docs: {
       description: 'Prevent missing props validation in a React component definition',
       category: 'Best Practices',
-      recommended: true
+      recommended: true,
+      url: docsUrl('prop-types')
     },
 
     schema: [{

--- a/lib/rules/react-in-jsx-scope.js
+++ b/lib/rules/react-in-jsx-scope.js
@@ -6,6 +6,7 @@
 
 const variableUtil = require('../util/variable');
 const pragmaUtil = require('../util/pragma');
+const docsUrl = require('../util/docsUrl');
 
 // -----------------------------------------------------------------------------
 // Rule Definition
@@ -16,7 +17,8 @@ module.exports = {
     docs: {
       description: 'Prevent missing React when using JSX',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('react-in-jsx-scope')
     },
     schema: []
   },

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -10,6 +10,7 @@ const variableUtil = require('../util/variable');
 const annotations = require('../util/annotations');
 const astUtil = require('../util/ast');
 const propsUtil = require('../util/props');
+const docsUrl = require('../util/docsUrl');
 
 const QUOTES_REGEX = /^["']|["']$/g;
 
@@ -21,7 +22,8 @@ module.exports = {
   meta: {
     docs: {
       description: 'Enforce a defaultProps definition for every prop that is not a required prop.',
-      category: 'Best Practices'
+      category: 'Best Practices',
+      url: docsUrl('require-default-props')
     },
 
     schema: [{

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -6,13 +6,15 @@
 
 const has = require('has');
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 module.exports = {
   meta: {
     docs: {
       description: 'Enforce React components to have a shouldComponentUpdate method',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('require-optimization')
     },
 
     schema: [{

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -7,6 +7,7 @@
 const has = require('has');
 const Components = require('../util/Components');
 const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +18,8 @@ module.exports = {
     docs: {
       description: 'Enforce ES5 or ES6 class for returning value in render function',
       category: 'Possible Errors',
-      recommended: true
+      recommended: true,
+      url: docsUrl('require-render-return')
     },
     schema: [{}]
   },

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -13,7 +15,8 @@ module.exports = {
     docs: {
       description: 'Prevent extra closing tags for components without children',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('self-closing-comp')
     },
     fixable: 'code',
 

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -9,6 +9,7 @@ const util = require('util');
 
 const Components = require('../util/Components');
 const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
 
 const defaultConfig = {
   order: [
@@ -76,7 +77,8 @@ module.exports = {
     docs: {
       description: 'Enforce component methods order',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('sort-comp')
     },
 
     schema: [{

--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -5,6 +5,7 @@
 
 const variableUtil = require('../util/variable');
 const propsUtil = require('../util/props');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Enforce propTypes declarations alphabetical sorting',
       category: 'Stylistic Issues',
-      recommended: false
+      recommended: false,
+      url: docsUrl('sort-prop-types')
     },
 
     schema: [{

--- a/lib/rules/style-prop-object.js
+++ b/lib/rules/style-prop-object.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const variableUtil = require('../util/variable');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,7 +16,8 @@ module.exports = {
     docs: {
       description: 'Enforce style prop value is an object',
       category: '',
-      recommended: false
+      recommended: false,
+      url: docsUrl('style-prop-object')
     },
     schema: []
   },

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -8,6 +8,7 @@
 const has = require('has');
 
 const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -51,7 +52,8 @@ module.exports = {
     docs: {
       description: 'Prevent passing of children to void DOM elements (e.g. <br />).',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('void-dom-elements-no-children')
     },
     schema: []
   },

--- a/lib/util/docsUrl.js
+++ b/lib/util/docsUrl.js
@@ -1,0 +1,7 @@
+'use strict';
+
+function docsUrl(ruleName) {
+  return `https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules/${ruleName}.md`;
+}
+
+module.exports = docsUrl;

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -4,6 +4,8 @@
  */
 'use strict';
 
+const docsUrl = require('./docsUrl');
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -14,7 +16,8 @@ function makeNoMethodSetStateRule(methodName) {
       docs: {
         description: `Prevent usage of setState in ${methodName}`,
         category: 'Best Practices',
-        recommended: false
+        recommended: false,
+        url: docsUrl(methodName)
       },
 
       schema: [{


### PR DESCRIPTION
ESLint v4.15.0 added an official location for rules to store a URL to their documentation in the rule metadata in eslint/eslint#9788. This adds the URL to all the existing rules so anything consuming them can
know where their documentation is without having to resort to external packages to guess.