### PR TITLE
support for custom propTypes with isRequired in no-typos

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -59,9 +59,15 @@ module.exports = {
       if (node && node.type === 'MemberExpression' && node.object.type === 'MemberExpression') {
         checkValidPropType(node.object.property);
         checkValidPropTypeQualfier(node.property);
-      } else if (node && node.type === 'MemberExpression' && node.object.type === 'Identifier') {
+      } else if (node && node.type === 'MemberExpression' && node.object.type === 'Identifier' && node.property.name !== 'isRequired') {
         checkValidPropType(node.property);
-      } else if (node && node.type === 'CallExpression') {
+      } else if (node && (
+        node.type === 'MemberExpression' && node.object.type === 'CallExpression' || node.type === 'CallExpression'
+      )) {
+        if (node.type === 'MemberExpression') {
+          checkValidPropTypeQualfier(node.property);
+          node = node.object;
+        }
         const callee = node.callee;
         if (callee.type === 'MemberExpression' && callee.property.name === 'shape') {
           checkValidPropObject(node.arguments[0]);

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -378,6 +378,16 @@ ruleTester.run('no-typos', rule, {
        }).isRequired
      }
    `,
+    parserOptions: parserOptions
+  }, {
+    code: `class Component extends React.Component {};
+     Component.propTypes = {
+       b: string.isRequired,
+       c: PropTypes.shape({
+         d: number.isRequired,
+       }).isRequired
+     }
+   `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }],
@@ -809,25 +819,32 @@ ruleTester.run('no-typos', rule, {
   }, {
     code: `class Component extends React.Component {};
      Component.propTypes = {
-       b: string.isrequired
+       a: string.isrequired,
+       b: shape({
+         c: number
+       }).isrequired
+     }
+   `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `class Component extends React.Component {};
+     Component.propTypes = {
+       a: string.isrequired,
+       b: shape({
+         c: number
+       }).isrequired
      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{
       message: 'Typo in declared prop type: isrequired'
-    }]
-  }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-       c: shape({
-         d: number,
-       }).isrequired
-      }
-   `,
-    parser: 'babel-eslint',
-    parserOptions: parserOptions,
-    errors: [{
+    }, {
       message: 'Typo in prop type chain qualifier: isrequired'
     }]
   }]

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -369,6 +369,17 @@ ruleTester.run('no-typos', rule, {
       };
     `,
     parser: 'babel-eslint'
+  }, {
+    code: `class Component extends React.Component {};
+     Component.propTypes = {
+       b: string.isRequired,
+       c: PropTypes.shape({
+         d: number.isRequired,
+       }).isRequired
+     }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
   }],
 
   invalid: [{
@@ -794,6 +805,30 @@ ruleTester.run('no-typos', rule, {
       message: 'Typo in declared prop type: function'
     }, {
       message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `class Component extends React.Component {};
+     Component.propTypes = {
+       b: string.isrequired
+     }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: isrequired'
+    }]
+  }, {
+    code: `class Component extends React.Component {};
+     Component.propTypes = {
+       c: shape({
+         d: number,
+       }).isrequired
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
     }]
   }]
 });


### PR DESCRIPTION
fixes: #1607 and helps in #1389.

if will add support for the following cases:
```js
{
  a: string.isRequired,
  b: customProp.isRequired,
  // added support for isRequired in call expressions. No validation is done inside
  c: PropTypes.shape({
    d: string
  }).isRequired
  e: customShape({
    f: number
  }).isRequired
}
```

for a custom prop type like `string.isrequired` the error message will be: `Typo in declared prop type: isrequired` because currently it doesn't know that it's a prop type cualifier

for call expressions like `customShape({}).isrequired` the error message will be `Typo in prop type chain qualifier: isrequired` and it will work as long as it's not something like `customShape().number.isRequired`