### PR TITLE
Support recursive type annotations, fixes #913

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -466,11 +466,22 @@ module.exports = {
      * @return {Object} The representation of the declaration, empty object means
      *    the property is declared without the need for further analysis.
      */
-    function buildTypeAnnotationDeclarationTypes(annotation) {
+    function buildTypeAnnotationDeclarationTypes(annotation, seen) {
+      if (seen === void 0) {
+        // Keeps track of annotations we've already seen to
+        // prevent problems with recursive types.
+        seen = new Set();
+      }
+      if (seen.has(annotation)) {
+        // This must be a recursive type annotation, so just accept anything.
+        return true;
+      }
+      seen.add(annotation);
+
       switch (annotation.type) {
         case 'GenericTypeAnnotation':
           if (typeScope(annotation.id.name)) {
-            return buildTypeAnnotationDeclarationTypes(typeScope(annotation.id.name));
+            return buildTypeAnnotationDeclarationTypes(typeScope(annotation.id.name), seen);
           }
           return {};
         case 'ObjectTypeAnnotation':
@@ -483,7 +494,7 @@ module.exports = {
             if (!childKey && !childValue) {
               containsObjectTypeSpread = true;
             } else {
-              shapeTypeDefinition.children[childKey] = buildTypeAnnotationDeclarationTypes(childValue);
+              shapeTypeDefinition.children[childKey] = buildTypeAnnotationDeclarationTypes(childValue, seen);
             }
           });
 
@@ -498,7 +509,7 @@ module.exports = {
             children: []
           };
           for (let i = 0, j = annotation.types.length; i < j; i++) {
-            const type = buildTypeAnnotationDeclarationTypes(annotation.types[i]);
+            const type = buildTypeAnnotationDeclarationTypes(annotation.types[i], seen);
             // keep only complex type
             if (Object.keys(type).length > 0) {
               if (type.children === true) {
@@ -519,7 +530,7 @@ module.exports = {
           return {
             type: 'object',
             children: {
-              __ANY_KEY__: buildTypeAnnotationDeclarationTypes(annotation.elementType)
+              __ANY_KEY__: buildTypeAnnotationDeclarationTypes(annotation.elementType, seen)
             }
           };
         default:

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -467,7 +467,7 @@ module.exports = {
      *    the property is declared without the need for further analysis.
      */
     function buildTypeAnnotationDeclarationTypes(annotation, seen) {
-      if (seen === void 0) {
+      if (typeof seen === 'undefined') {
         // Keeps track of annotations we've already seen to
         // prevent problems with recursive types.
         seen = new Set();

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -474,7 +474,7 @@ module.exports = {
       }
       if (seen.has(annotation)) {
         // This must be a recursive type annotation, so just accept anything.
-        return true;
+        return {};
       }
       seen.add(annotation);
 

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1583,6 +1583,20 @@ ruleTester.run('prop-types', rule, {
       parser: 'babel-eslint'
     }, {
       code: [
+        'type Note = {text: string, children?: Note[]};',
+        'type Props = {',
+        '  notes: Note[];',
+        '};',
+        'class Hello extends React.Component<void, Props, void> {',
+        '  render () {',
+        '    return <div>Hello {this.props.notes[0].text}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      settings: {react: {flowVersion: '0.52'}},
+      parser: 'babel-eslint'
+    }, {
+      code: [
         'import type Props from "fake";',
         'class Hello extends React.Component<void, Props, void> {',
         '  render () {',


### PR DESCRIPTION
Originally written by @phpnode as part of #1138

That PR was closed in favor of #1377, which does not appear to include a solution for the recursive type definition issue.

This allows for code like

```js
type Note = {text: string, children?: Note[]}
type Props = {
  notes: Note[]
};
```

to run without triggering an infinite loop.