### PR TITLE
Fixed crossorigin naming convention and missing tag support.

### DIFF
--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -21,8 +21,7 @@ const DOM_ATTRIBUTE_NAMES = {
   'accept-charset': 'acceptCharset',
   class: 'className',
   for: 'htmlFor',
-  'http-equiv': 'httpEquiv',
-  crossorigin: 'crossOrigin'
+  'http-equiv': 'httpEquiv'
 };
 
 const ATTRIBUTE_TAGS_MAP = {

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -21,7 +21,8 @@ const DOM_ATTRIBUTE_NAMES = {
   'accept-charset': 'acceptCharset',
   class: 'className',
   for: 'htmlFor',
-  'http-equiv': 'httpEquiv'
+  'http-equiv': 'httpEquiv',
+  crossorigin: 'crossOrigin'
 };
 
 const ATTRIBUTE_TAGS_MAP = {

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -25,7 +25,7 @@ const DOM_ATTRIBUTE_NAMES = {
 };
 
 const ATTRIBUTE_TAGS_MAP = {
-  crossOrigin: ['script', 'img', 'video']
+  crossOrigin: ['script', 'img', 'video', 'link']
 };
 
 const SVGDOM_ATTRIBUTE_NAMES = {

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -22,11 +22,11 @@ const DOM_ATTRIBUTE_NAMES = {
   class: 'className',
   for: 'htmlFor',
   'http-equiv': 'httpEquiv',
-  crossOrigin: 'crossorigin'
+  crossorigin: 'crossOrigin'
 };
 
 const ATTRIBUTE_TAGS_MAP = {
-  crossorigin: ['script', 'img', 'video']
+  crossOrigin: ['script', 'img', 'video']
 };
 
 const SVGDOM_ATTRIBUTE_NAMES = {

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -82,6 +82,6 @@ ruleTester.run('no-unknown-property', rule, {
     errors: [{message: 'Unknown property \'clip-path\' found, use \'clipPath\' instead'}]
   }, {
     code: '<div crossOrigin />',
-    errors: [{message: 'Invalid property \'crossOrigin\' found on tag \'div\', but it is only allowed on: script, img, video'}]
+    errors: [{message: 'Invalid property \'crossOrigin\' found on tag \'div\', but it is only allowed on: script, img, video, link'}]
   }]
 });

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -81,6 +81,12 @@ ruleTester.run('no-unknown-property', rule, {
     output: '<rect clipPath="bar" />;',
     errors: [{message: 'Unknown property \'clip-path\' found, use \'clipPath\' instead'}]
   }, {
+    code: '<script crossorigin />',
+    errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}]
+  }, {
+    code: '<div crossorigin />',
+    errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}]
+  }, {
     code: '<div crossOrigin />',
     errors: [{message: 'Invalid property \'crossOrigin\' found on tag \'div\', but it is only allowed on: script, img, video, link'}]
   }]

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -42,7 +42,7 @@ ruleTester.run('no-unknown-property', rule, {
       code: '<div class="bar"></div>;',
       options: [{ignore: ['class']}]
     },
-    {code: '<script crossorigin />'}
+    {code: '<script crossOrigin />'}
   ],
   invalid: [{
     code: '<div class="bar"></div>;',
@@ -81,13 +81,13 @@ ruleTester.run('no-unknown-property', rule, {
     output: '<rect clipPath="bar" />;',
     errors: [{message: 'Unknown property \'clip-path\' found, use \'clipPath\' instead'}]
   }, {
-    code: '<script crossOrigin />',
-    errors: [{message: 'Unknown property \'crossOrigin\' found, use \'crossorigin\' instead'}]
-  }, {
-    code: '<div crossOrigin />',
-    errors: [{message: 'Unknown property \'crossOrigin\' found, use \'crossorigin\' instead'}]
+    code: '<script crossorigin />',
+    errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}]
   }, {
     code: '<div crossorigin />',
-    errors: [{message: 'Invalid property \'crossorigin\' found on tag \'div\', but it is only allowed on: script, img, video'}]
+    errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}]
+  }, {
+    code: '<div crossOrigin />',
+    errors: [{message: 'Invalid property \'crossOrigin\' found on tag \'div\', but it is only allowed on: script, img, video'}]
   }]
 });

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -81,12 +81,6 @@ ruleTester.run('no-unknown-property', rule, {
     output: '<rect clipPath="bar" />;',
     errors: [{message: 'Unknown property \'clip-path\' found, use \'clipPath\' instead'}]
   }, {
-    code: '<script crossorigin />',
-    errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}]
-  }, {
-    code: '<div crossorigin />',
-    errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}]
-  }, {
     code: '<div crossOrigin />',
     errors: [{message: 'Invalid property \'crossOrigin\' found on tag \'div\', but it is only allowed on: script, img, video'}]
   }]


### PR DESCRIPTION
Fixed crossorigin naming convention to match React's supported HTML attributes.
https://reactjs.org/docs/dom-elements.html

Fixes #1656. Per https://github.com/yannickcr/eslint-plugin-react/issues/1642#issuecomment-360881470