### PR TITLE
fix(sort-prop-types): Fix sortShapeProp when shape is not an object literal

### DIFF
--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -77,6 +77,12 @@ module.exports = {
      * @returns {void}
      */
     function checkSorted(declarations) {
+      // Declarations will be `undefined` if the `shape` is not a literal. For
+      // example, if it is a propType imported from another file.
+      if (!declarations) {
+        return;
+      }
+
       declarations.reduce((prev, curr, idx, decls) => {
         if (/SpreadProperty$/.test(curr.type)) {
           return decls[idx + 1];

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -365,6 +365,24 @@ ruleTester.run('sort-prop-types', rule, {
     options: [{
       sortShapeProp: true
     }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        a: PropTypes.any,
+        b: PropTypes.any,
+        c: PropTypes.shape(
+          importedPropType,
+        ),
+      };
+    `,
+    options: [{
+      sortShapeProp: true
+    }]
   }],
 
   invalid: [{


### PR DESCRIPTION
Resolves issue https://github.com/yannickcr/eslint-plugin-react/issues/1668