### PR TITLE
Fix an issue with the documentation for 'jsx-child-element-spacing'

### DIFF
--- a/docs/rules/jsx-child-element-spacing.md
+++ b/docs/rules/jsx-child-element-spacing.md
@@ -1,4 +1,4 @@
-# Enforce or disallow spaces inside of curly braces in JSX attributes and expressions. (react/jsx-curly-spacing)
+# Enforce or disallow spaces inside of curly braces in JSX attributes and expressions. (react/jsx-child-element-spacing)
 
 ## Rule Details
 


### PR DESCRIPTION
Fixed a typo in the documentation which referenced `(react/jsx-curly-spacing)` instead of `(react/jsx-child-element-spacing)`.