### PR TITLE
Allow custom PropType classes with no-typos rule

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -85,7 +85,6 @@ module.exports = {
         node.properties.forEach(prop => checkValidProp(prop.value));
       }
     }
-    /* eslint-enable no-use-before-define */
 
     function reportErrorIfClassPropertyCasingTypo(node, propertyName) {
       if (propertyName === 'propTypes' || propertyName === 'contextTypes' || propertyName === 'childContextTypes') {

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -77,7 +77,9 @@ module.exports = {
       } else if (callee.type === 'MemberExpression' && callee.property.name === 'oneOfType') {
         const args = node.arguments[0];
         if (args && args.type === 'ArrayExpression') {
-          args.elements.forEach(el => checkValidProp(el));
+          args.elements.forEach(el => {
+            checkValidProp(el);
+          });
         }
       }
     }

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -37,6 +37,7 @@ module.exports = {
 
   create: Components.detect((context, components, utils) => {
     let propTypesPackageName;
+    let reactPackageName;
 
     function checkValidPropTypeQualfier(node) {
       if (node.name !== 'isRequired') {
@@ -58,7 +59,7 @@ module.exports = {
 
     /* eslint-disable no-use-before-define */
     function checkValidProp(node) {
-      if (!propTypesPackageName || !node) {
+      if ((!propTypesPackageName && !reactPackageName) || !node) {
         return;
       }
 
@@ -132,12 +133,14 @@ module.exports = {
       ImportDeclaration: function(node) {
         if (node.source && node.source.value === 'prop-types') { // import PropType from "prop-types"
           propTypesPackageName = node.specifiers[0].local.name;
-        }
-      },
+        } else if (node.source && node.source.value === 'react') { // import { PropTypes } from "react"
+          reactPackageName = node.specifiers[0].local.name;
 
-      CallExpression: function(node) {
-        if (node.callee.name === 'require' && node.arguments[0].value === 'prop-types') {
-          propTypesPackageName = node.parent.id.name;
+          propTypesPackageName = node.specifiers.length > 1 && (
+            node.specifiers
+              .filter(specifier => specifier.imported && specifier.imported.name === 'PropTypes')
+              .map(specifier => specifier.local.name)
+          );
         }
       },
 

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -36,6 +36,8 @@ module.exports = {
   },
 
   create: Components.detect((context, components, utils) => {
+    let propTypesPackageName;
+
     function checkValidPropTypeQualfier(node) {
       if (node.name !== 'isRequired') {
         context.report({
@@ -56,14 +58,28 @@ module.exports = {
 
     /* eslint-disable no-use-before-define */
     function checkValidProp(node) {
-      if (node && node.type === 'MemberExpression' && node.object.type === 'MemberExpression') {
+      if (!propTypesPackageName || !node) {
+        return;
+      }
+
+      if (
+        node.type === 'MemberExpression' &&
+        node.object.type === 'MemberExpression' &&
+        node.object.object.name === propTypesPackageName
+      ) { // PropTypes.myProp.isRequired
         checkValidPropType(node.object.property);
         checkValidPropTypeQualfier(node.property);
-      } else if (node && node.type === 'MemberExpression' && node.object.type === 'Identifier' && node.property.name !== 'isRequired') {
+      } else if (
+        node.type === 'MemberExpression' &&
+        node.object.type === 'Identifier' &&
+        node.object.name === propTypesPackageName &&
+        node.property.name !== 'isRequired'
+      ) { // PropTypes.myProp
         checkValidPropType(node.property);
-      } else if (node && (
-        node.type === 'MemberExpression' && node.object.type === 'CallExpression' || node.type === 'CallExpression'
-      )) {
+      } else if (
+        (node.type === 'MemberExpression' && node.object.type === 'CallExpression') ||
+        node.type === 'CallExpression'
+      ) { // Shapes
         if (node.type === 'MemberExpression') {
           checkValidPropTypeQualfier(node.property);
           node = node.object;
@@ -113,6 +129,18 @@ module.exports = {
     }
 
     return {
+      ImportDeclaration: function(node) {
+        if (node.source && node.source.value === 'prop-types') { // import PropType from "prop-types"
+          propTypesPackageName = node.specifiers[0].local.name;
+        }
+      },
+
+      CallExpression: function(node) {
+        if (node.callee.name === 'require' && node.arguments[0].value === 'prop-types') {
+          propTypesPackageName = node.parent.id.name;
+        }
+      },
+
       ClassProperty: function(node) {
         if (!node.static || !utils.isES6Component(node.parent.parent)) {
           return;

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -36,8 +36,8 @@ module.exports = {
   },
 
   create: Components.detect((context, components, utils) => {
-    let propTypesPackageName;
-    let reactPackageName;
+    let propTypesPackageName = null;
+    let reactPackageName = null;
 
     function checkValidPropTypeQualfier(node) {
       if (node.name !== 'isRequired') {
@@ -57,43 +57,53 @@ module.exports = {
       }
     }
 
+    function isPropTypesPackage(node) {
+      return (
+        node.type === 'Identifier' &&
+        node.name == propTypesPackageName
+      ) || (
+        node.type === 'MemberExpression' &&
+        node.property.name === 'PropTypes' &&
+        node.object.name == reactPackageName
+      );
+    }
+
+    function checkValidCallExpression(node) {
+      const callee = node.callee;
+      if (callee.type === 'MemberExpression' && callee.property.name === 'shape') {
+        checkValidPropObject(node.arguments[0]);
+      } else if (callee.type === 'MemberExpression' && callee.property.name === 'oneOfType') {
+        const args = node.arguments[0];
+        if (args && args.type === 'ArrayExpression') {
+          args.elements.forEach(el => checkValidProp(el));
+        }
+      }
+    }
+
     /* eslint-disable no-use-before-define */
     function checkValidProp(node) {
       if ((!propTypesPackageName && !reactPackageName) || !node) {
         return;
       }
 
-      if (
-        node.type === 'MemberExpression' &&
-        node.object.type === 'MemberExpression' &&
-        node.object.object.name === propTypesPackageName
-      ) { // PropTypes.myProp.isRequired
-        checkValidPropType(node.object.property);
-        checkValidPropTypeQualfier(node.property);
-      } else if (
-        node.type === 'MemberExpression' &&
-        node.object.type === 'Identifier' &&
-        node.object.name === propTypesPackageName &&
-        node.property.name !== 'isRequired'
-      ) { // PropTypes.myProp
-        checkValidPropType(node.property);
-      } else if (
-        (node.type === 'MemberExpression' && node.object.type === 'CallExpression') ||
-        node.type === 'CallExpression'
-      ) { // Shapes
-        if (node.type === 'MemberExpression') {
+      if (node.type === 'MemberExpression') {
+        if (
+          node.object.type === 'MemberExpression' &&
+          isPropTypesPackage(node.object.object)
+        ) { // PropTypes.myProp.isRequired
+          checkValidPropType(node.object.property);
           checkValidPropTypeQualfier(node.property);
-          node = node.object;
+        } else if (
+          isPropTypesPackage(node.object) &&
+          node.property.name !== 'isRequired'
+        ) { // PropTypes.myProp
+          checkValidPropType(node.property);
+        } else if (node.object.type === 'CallExpression') {
+          checkValidPropTypeQualfier(node.property);
+          checkValidCallExpression(node.object);
         }
-        const callee = node.callee;
-        if (callee.type === 'MemberExpression' && callee.property.name === 'shape') {
-          checkValidPropObject(node.arguments[0]);
-        } else if (callee.type === 'MemberExpression' && callee.property.name === 'oneOfType') {
-          const args = node.arguments[0];
-          if (args && args.type === 'ArrayExpression') {
-            args.elements.forEach(el => checkValidProp(el));
-          }
-        }
+      } else if (node.type === 'CallExpression') {
+        checkValidCallExpression(node);
       }
     }
 
@@ -136,11 +146,11 @@ module.exports = {
         } else if (node.source && node.source.value === 'react') { // import { PropTypes } from "react"
           reactPackageName = node.specifiers[0].local.name;
 
-          propTypesPackageName = node.specifiers.length > 1 && (
+          propTypesPackageName = node.specifiers.length >= 1 ? (
             node.specifiers
               .filter(specifier => specifier.imported && specifier.imported.name === 'PropTypes')
               .map(specifier => specifier.local.name)
-          );
+          ) : null;
         }
       },
 

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -151,11 +151,14 @@ module.exports = {
         } else if (node.source && node.source.value === 'react') { // import { PropTypes } from "react"
           reactPackageName = node.specifiers[0].local.name;
 
-          propTypesPackageName = node.specifiers.length >= 1 ? (
-            node.specifiers
-              .filter(specifier => specifier.imported && specifier.imported.name === 'PropTypes')
-              .map(specifier => specifier.local.name)
-          )[0] : null;
+          if (node.specifiers.length >= 1) {
+            const propTypesSpecifier = node.specifiers.find(specifier => (
+              specifier.imported && specifier.imported.name === 'PropTypes'
+            ));
+            if (propTypesSpecifier) {
+              propTypesPackageName = propTypesSpecifier.local.name;
+            }
+          }
         }
       },
 

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -58,6 +58,10 @@ module.exports = {
     }
 
     function isPropTypesPackage(node) {
+      // Note: we really do want == with the package names here,
+      // since we need value equality, not identity - and
+      // these values are always string or null.
+      /* eslint-disable eqeqeq */
       return (
         node.type === 'Identifier' &&
         node.name == propTypesPackageName
@@ -66,7 +70,10 @@ module.exports = {
         node.property.name === 'PropTypes' &&
         node.object.name == reactPackageName
       );
+      /* eslint-enable eqeqeq */
     }
+
+    /* eslint-disable no-use-before-define */
 
     function checkValidCallExpression(node) {
       const callee = node.callee;
@@ -80,7 +87,6 @@ module.exports = {
       }
     }
 
-    /* eslint-disable no-use-before-define */
     function checkValidProp(node) {
       if ((!propTypesPackageName && !reactPackageName) || !node) {
         return;
@@ -106,6 +112,8 @@ module.exports = {
         checkValidCallExpression(node);
       }
     }
+
+    /* eslint-enable no-use-before-define */
 
     function checkValidPropObject (node) {
       if (node && node.type === 'ObjectExpression') {

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -58,19 +58,14 @@ module.exports = {
     }
 
     function isPropTypesPackage(node) {
-      // Note: we really do want == with the package names here,
-      // since we need value equality, not identity - and
-      // these values are always string or null.
-      /* eslint-disable eqeqeq */
       return (
         node.type === 'Identifier' &&
-        node.name == propTypesPackageName
+        node.name === propTypesPackageName
       ) || (
         node.type === 'MemberExpression' &&
         node.property.name === 'PropTypes' &&
-        node.object.name == reactPackageName
+        node.object.name === reactPackageName
       );
-      /* eslint-enable eqeqeq */
     }
 
     /* eslint-disable no-use-before-define */
@@ -158,7 +153,7 @@ module.exports = {
             node.specifiers
               .filter(specifier => specifier.imported && specifier.imported.name === 'PropTypes')
               .map(specifier => specifier.local.name)
-          ) : null;
+          )[0] : null;
         }
       },
 

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -980,17 +980,5 @@ ruleTester.run('no-typos', rule, {
     }, {
       message: 'Typo in declared prop type: objectof'
     }]
-  }, {
-    code: `
-      import RealReactDifferentName from "react"
-      Component.propTypes = {
-        b: RealReactDifferentName.PropTypes.STRING,
-      }
-   `,
-    parser: 'babel-eslint',
-    parserOptions: parserOptions,
-    errors: [{
-      message: 'Typo in prop type chain qualifier: STRING'
-    }]
   }]
 });

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -364,6 +364,66 @@ ruleTester.run('no-typos', rule, {
         }).isRequired
       }
    `,
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.contextTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
+   `,
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from 'prop-types'
+      import * as MyPropTypes from 'lib/my-prop-types'
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string,
+        b: MyPropTypes.MYSTRING,
+        c: MyPropTypes.MYSTRING.isRequired,
+      }
+   `,
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from "prop-types"
+      import * as MyPropTypes from 'lib/my-prop-types'
+      class Component extends React.Component {};
+      Component.propTypes = {
+        b: PropTypes.string,
+        a: MyPropTypes.MYSTRING,
+      }
+   `,
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import CustomReact from "react"
+      class Component extends React.Component {};
+      Component.propTypes = {
+        b: CustomReact.PropTypes.string,
+      }
+   `,
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
+   `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
@@ -1060,6 +1120,158 @@ ruleTester.run('no-typos', rule, {
     }, {
       message: 'Typo in declared prop type: objectof'
     }]
+  }, {
+    code: `
+      import PropTypes from 'prop-types';
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.bools,
+        b: PropTypes.Array,
+        c: PropTypes.function,
+        d: PropTypes.objectof,
+      }
+    `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+     import PropTypes from 'prop-types';
+     class Component extends React.Component {};
+     Component.propTypes = {
+       a: PropTypes.string.isrequired,
+       b: PropTypes.shape({
+         c: PropTypes.number
+       }).isrequired
+     }
+    `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+     import PropTypes from 'prop-types';
+     class Component extends React.Component {};
+     Component.propTypes = {
+       a: PropTypes.string.isrequired,
+       b: PropTypes.shape({
+         c: PropTypes.number
+       }).isrequired
+     }
+   `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+      import RealPropTypes from 'prop-types';
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: RealPropTypes.bools,
+        b: RealPropTypes.Array,
+        c: RealPropTypes.function,
+        d: RealPropTypes.objectof,
+      }
+    `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+     import React from 'react';
+     class Component extends React.Component {};
+     Component.propTypes = {
+       a: React.PropTypes.string.isrequired,
+       b: React.PropTypes.shape({
+         c: React.PropTypes.number
+       }).isrequired
+     }
+   `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+      import React from 'react';
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: React.PropTypes.bools,
+        b: React.PropTypes.Array,
+        c: React.PropTypes.function,
+        d: React.PropTypes.objectof,
+      }
+    `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+     import { PropTypes } from 'react';
+     class Component extends React.Component {};
+     Component.propTypes = {
+       a: PropTypes.string.isrequired,
+       b: PropTypes.shape({
+         c: PropTypes.number
+       }).isrequired
+     }
+   `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+      import { PropTypes } from 'react';
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.bools,
+        b: PropTypes.Array,
+        c: PropTypes.function,
+        d: PropTypes.objectof,
+      }
+    `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
   }]
 /*
 // createClass tests below fail, so they're commented out
@@ -1098,6 +1310,48 @@ ruleTester.run('no-typos', rule, {
       });
     `,
     parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+      import React from 'react';
+      import PropTypes from 'prop-types';
+      const Component = React.createClass({
+        propTypes: {
+          a: PropTypes.string.isrequired,
+          b: PropTypes.shape({
+            c: PropTypes.number
+          }).isrequired
+        }
+      });
+    `,
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+      import React from 'react';
+      import PropTypes from 'prop-types';
+      const Component = React.createClass({
+        childContextTypes: {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      });
+    `,
     parserOptions: parserOptions,
     errors: [{
       message: 'Typo in declared prop type: bools'

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -260,81 +260,134 @@ ruleTester.run('no-typos', rule, {
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-       a: PropTypes.number.isRequired
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.number.isRequired
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-       e: PropTypes.shape({
-         ea: PropTypes.string,
-       })
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        e: PropTypes.shape({
+          ea: PropTypes.string,
+        })
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-       a: PropTypes.string,
-       b: PropTypes.string.isRequired,
-       c: PropTypes.shape({
-         d: PropTypes.string,
-         e: PropTypes.number.isRequired,
-       }).isRequired
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-    Component.propTypes = {
-       a: PropTypes.oneOfType([
-         PropTypes.string,
-         PropTypes.number
-       ])
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number
+        ])
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-    Component.propTypes = {
-       a: PropTypes.oneOf([
-         'hello',
-         'hi'
-       ])
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.oneOf([
+          'hello',
+          'hi'
+        ])
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.childContextTypes = {
-       a: PropTypes.string,
-       b: PropTypes.string.isRequired,
-       c: PropTypes.shape({
-         d: PropTypes.string,
-         e: PropTypes.number.isRequired,
-       }).isRequired
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.contextTypes = {
-       a: PropTypes.string,
-       b: PropTypes.string.isRequired,
-       c: PropTypes.shape({
-         d: PropTypes.string,
-         e: PropTypes.number.isRequired,
-       }).isRequired
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.contextTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from 'prop-types'
+      import * as MyPropTypes from 'lib/my-prop-types'
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string,
+        b: MyPropTypes.MYSTRING,
+        c: MyPropTypes.MYSTRING.isRequired,
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      const PropTypes = require('prop-types');
+      const MyPropTypes = require('lib/my-prop-types')
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string,
+        b: MyPropTypes.MYSTRING,
+        c: MyPropTypes.MYSTRING.isRequired,
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      const RealPropTypes = require('prop-types');
+      const MyPropTypes = require('lib/my-prop-types')
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: RealPropTypes.string,
+        b: MyPropTypes.MYSTRING,
+        c: MyPropTypes.MYSTRING.isRequired,
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
@@ -710,6 +763,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
           a: PropTypes.Number.isRequired
@@ -722,6 +776,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
           a: PropTypes.number.isrequired
@@ -734,6 +789,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
           a: PropTypes.Number
@@ -746,6 +802,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
         a: PropTypes.shape({
@@ -761,6 +818,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
         a: PropTypes.oneOfType([
@@ -776,6 +834,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
         a: PropTypes.bools,
@@ -797,6 +856,29 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.bools,
+        b: PropTypes.Array,
+        c: PropTypes.function,
+        d: PropTypes.objectof,
+      }
+    `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+      const PropTypes = require('prop-types');
       class Component extends React.Component {};
       Component.childContextTypes = {
         a: PropTypes.bools,
@@ -846,6 +928,28 @@ ruleTester.run('no-typos', rule, {
       message: 'Typo in declared prop type: isrequired'
     }, {
       message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+      const RealPropTypes = require('prop-types');
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: RealPropTypes.bools,
+        b: RealPropTypes.Array,
+        c: RealPropTypes.function,
+        d: RealPropTypes.objectof,
+      }
+    `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
     }]
   }]
 });

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -14,7 +14,8 @@ const parserOptions = {
   ecmaVersion: 6,
   ecmaFeatures: {
     jsx: true
-  }
+  },
+  sourceType: 'module'
 };
 
 // -----------------------------------------------------------------------------
@@ -341,6 +342,34 @@ ruleTester.run('no-typos', rule, {
     code: `
       import PropTypes from "prop-types";
       class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.oneOf([
+          'hello',
+          'hi'
+        ])
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
       Component.contextTypes = {
         a: PropTypes.string,
         b: PropTypes.string.isRequired,
@@ -367,26 +396,22 @@ ruleTester.run('no-typos', rule, {
     parserOptions: parserOptions
   }, {
     code: `
-      const PropTypes = require('prop-types');
-      const MyPropTypes = require('lib/my-prop-types')
+      import PropTypes from "prop-types"
+      import * as MyPropTypes from 'lib/my-prop-types'
       class Component extends React.Component {};
       Component.propTypes = {
-        a: PropTypes.string,
-        b: MyPropTypes.MYSTRING,
-        c: MyPropTypes.MYSTRING.isRequired,
+        b: PropTypes.string,
+        a: MyPropTypes.MYSTRING,
       }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
     code: `
-      const RealPropTypes = require('prop-types');
-      const MyPropTypes = require('lib/my-prop-types')
+      import CustomReact from "react"
       class Component extends React.Component {};
       Component.propTypes = {
-        a: RealPropTypes.string,
-        b: MyPropTypes.MYSTRING,
-        c: MyPropTypes.MYSTRING.isRequired,
+        b: CustomReact.PropTypes.string,
       }
    `,
     parser: 'babel-eslint',
@@ -878,7 +903,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
-      const PropTypes = require('prop-types');
+      import PropTypes from 'prop-types';
       class Component extends React.Component {};
       Component.childContextTypes = {
         a: PropTypes.bools,
@@ -900,7 +925,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
-     const PropTypes = require('prop-types');
+     import PropTypes from 'prop-types';
      class Component extends React.Component {};
      Component.propTypes = {
        a: PropTypes.string.isrequired,
@@ -908,7 +933,7 @@ ruleTester.run('no-typos', rule, {
          c: PropTypes.number
        }).isrequired
      }
-   `,
+    `,
     parserOptions: parserOptions,
     errors: [{
       message: 'Typo in prop type chain qualifier: isrequired'
@@ -917,7 +942,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
-     const PropTypes = require('prop-types');
+     import PropTypes from 'prop-types';
      class Component extends React.Component {};
      Component.propTypes = {
        a: PropTypes.string.isrequired,
@@ -935,7 +960,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
-      const RealPropTypes = require('prop-types');
+      import RealPropTypes from 'prop-types';
       class Component extends React.Component {};
       Component.childContextTypes = {
         a: RealPropTypes.bools,
@@ -954,6 +979,18 @@ ruleTester.run('no-typos', rule, {
       message: 'Typo in declared prop type: function'
     }, {
       message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+      import RealReactDifferentName from "react"
+      Component.propTypes = {
+        b: RealReactDifferentName.PropTypes.STRING,
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: STRING'
     }]
   }]
 });

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -899,33 +899,37 @@ ruleTester.run('no-typos', rule, {
       message: 'Typo in declared prop type: objectof'
     }]
   }, {
-    code: `class Component extends React.Component {};
+    code: `
+     const PropTypes = require('prop-types');
+     class Component extends React.Component {};
      Component.propTypes = {
-       a: string.isrequired,
-       b: shape({
-         c: number
+       a: PropTypes.string.isrequired,
+       b: PropTypes.shape({
+         c: PropTypes.number
        }).isrequired
      }
    `,
     parserOptions: parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: isrequired'
+      message: 'Typo in prop type chain qualifier: isrequired'
     }, {
       message: 'Typo in prop type chain qualifier: isrequired'
     }]
   }, {
-    code: `class Component extends React.Component {};
+    code: `
+     const PropTypes = require('prop-types');
+     class Component extends React.Component {};
      Component.propTypes = {
-       a: string.isrequired,
-       b: shape({
-         c: number
+       a: PropTypes.string.isrequired,
+       b: PropTypes.shape({
+         c: PropTypes.number
        }).isrequired
      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: isrequired'
+      message: 'Typo in prop type chain qualifier: isrequired'
     }, {
       message: 'Typo in prop type chain qualifier: isrequired'
     }]

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -1061,4 +1061,55 @@ ruleTester.run('no-typos', rule, {
       message: 'Typo in declared prop type: objectof'
     }]
   }]
+/*
+// createClass tests below fail, so they're commented out
+// ---------
+  }, {
+    code: `
+      import React from 'react';
+      import PropTypes from 'prop-types';
+      const Component = React.createClass({
+        propTypes: {
+          a: PropTypes.string.isrequired,
+          b: PropTypes.shape({
+            c: PropTypes.number
+          }).isrequired
+        }
+      });
+    `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+      import React from 'react';
+      import PropTypes from 'prop-types';
+      const Component = React.createClass({
+        childContextTypes: {
+          a: PropTypes.bools,
+          b: PropTypes.Array,
+          c: PropTypes.function,
+          d: PropTypes.objectof,
+        }
+      });
+    `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }]
+// ---------
+// createClass tests above fail, so they're commented out
+*/
 });

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -980,5 +980,85 @@ ruleTester.run('no-typos', rule, {
     }, {
       message: 'Typo in declared prop type: objectof'
     }]
+  }, {
+    code: `
+     import React from 'react';
+     class Component extends React.Component {};
+     Component.propTypes = {
+       a: React.PropTypes.string.isrequired,
+       b: React.PropTypes.shape({
+         c: React.PropTypes.number
+       }).isrequired
+     }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+      import React from 'react';
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: React.PropTypes.bools,
+        b: React.PropTypes.Array,
+        c: React.PropTypes.function,
+        d: React.PropTypes.objectof,
+      }
+    `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+     import { PropTypes } from 'react';
+     class Component extends React.Component {};
+     Component.propTypes = {
+       a: PropTypes.string.isrequired,
+       b: PropTypes.shape({
+         c: PropTypes.number
+       }).isrequired
+     }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }, {
+      message: 'Typo in prop type chain qualifier: isrequired'
+    }]
+  }, {
+    code: `
+      import { PropTypes } from 'react';
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.bools,
+        b: PropTypes.Array,
+        c: PropTypes.function,
+        d: PropTypes.objectof,
+      }
+    `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
   }]
 });


### PR DESCRIPTION
This is simply a rebase of @jseminck's branch, plus the removal of the
lingering failing test.

I removed the failing test because I believe it's a very small corner case
that should not block the resolution of this issue, which seems to affect
a lot of people and limits our ability to keep our components' proptypes DRY.

If it's determined that this corner case *should* be handled, I suggest creating
a new issue to track just that case.

Closes #1389.