### PR TITLE
Fixed "PropType is defined but prop is never used  react/no-unused-prop-types"

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -266,7 +266,7 @@ module.exports = {
      * @return {Boolean} True if the node is inside a lifecycle method
      */
     function isInLifeCycleMethod(node) {
-      if (node.type === 'MethodDefinition' && isNodeALifeCycleMethod(node)) {
+      if ((node.type === 'MethodDefinition' || node.type === 'Property') && isNodeALifeCycleMethod(node)) {
         return true;
       }
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1229,6 +1229,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in componentWillReceiveProps shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  componentWillReceiveProps (nextProps) {',
+        '    const {something} = nextProps;',
+        '    doSomething(something);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
+    }, {
       // Destructured props in componentWillReceiveProps shouldn't throw errors when used createReactClass
       code: [
         'var Hello = createReactClass({',
@@ -1268,6 +1281,18 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured function props in componentWillReceiveProps shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  componentWillReceiveProps ({something}) {',
+        '    doSomething(something);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
     }, {
       // Destructured function props in componentWillReceiveProps shouldn't throw errors when used createReactClass
       code: [
@@ -1309,6 +1334,20 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in the constructor shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  constructor (props) {',
+        '    super(props);',
+        '    const {something} = props;',
+        '    doSomething(something);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
+    }, {
       // Destructured function props in the constructor shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1323,6 +1362,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured function props in the constructor shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  constructor ({something}) {',
+        '    super({something});',
+        '    doSomething(something);',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
+    }, {
       // Destructured props in the `shouldComponentUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1336,6 +1388,19 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured props in the `shouldComponentUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  shouldComponentUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
     }, {
       // Destructured props in `shouldComponentUpdate` shouldn't throw errors when used createReactClass
       code: [
@@ -1377,6 +1442,18 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured function props in the `shouldComponentUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  shouldComponentUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
+    }, {
       // Destructured function props in `shouldComponentUpdate` shouldn't throw errors when used createReactClass
       code: [
         'var Hello = createReactClass({',
@@ -1415,6 +1492,19 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured props in the `componentWillUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  componentWillUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
     }, {
       // Destructured props in `componentWillUpdate` shouldn't throw errors when used createReactClass
       code: [
@@ -1456,6 +1546,18 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured function props in the `componentWillUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  componentWillUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
+    }, {
       // Destructured function props in the `componentWillUpdate` method shouldn't throw errors when used createReactClass
       code: [
         'var Hello = createReactClass({',
@@ -1494,6 +1596,19 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured props in the `componentDidUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  componentDidUpdate (prevProps, prevState) {',
+        '    const {something} = prevProps;',
+        '    return something;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
     }, {
       // Destructured props in `componentDidUpdate` shouldn't throw errors when used createReactClass
       code: [
@@ -1535,6 +1650,18 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured function props in the `componentDidUpdate` method shouldn't throw errors
+      code: [
+        'class Hello extends Component {',
+        '  componentDidUpdate ({something}, prevState) {',
+        '    return something;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
+    }, {
       // Destructured function props in the `componentDidUpdate` method shouldn't throw errors when used createReactClass
       code: [
         'var Hello = createReactClass({',
@@ -1572,6 +1699,18 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured state props in `componentDidUpdate` [Issue #825]
+      code: [
+        'class Hello extends Component {',
+        '  componentDidUpdate ({something}, {state1, state2}) {',
+        '    return something;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  something: PropTypes.bool,',
+        '};'
+      ].join('\n')
     }, {
       // Destructured state props in `componentDidUpdate` [Issue #825] when used createReactClass
       code: [

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1243,6 +1243,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in componentWillReceiveProps shouldn't throw errors when used createReactClass, with default parser
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentWillReceiveProps (nextProps) {',
+        '    const {something} = nextProps;',
+        '    doSomething(something);',
+        '  }',
+        '})'
+      ].join('\n')
+    }, {
       // Destructured function props in componentWillReceiveProps shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1268,6 +1281,18 @@ ruleTester.run('no-unused-prop-types', rule, {
         '})'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured function props in componentWillReceiveProps shouldn't throw errors when used createReactClass, with default parser
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentWillReceiveProps ({something}) {',
+        '    doSomething(something);',
+        '  }',
+        '})'
+      ].join('\n')
     }, {
       // Destructured props in the constructor shouldn't throw errors
       code: [
@@ -1326,6 +1351,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in `shouldComponentUpdate` shouldn't throw errors when used createReactClass, with default parser
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  shouldComponentUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n')
+    }, {
       // Destructured function props in the `shouldComponentUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1351,6 +1389,18 @@ ruleTester.run('no-unused-prop-types', rule, {
         '})'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured function props in `shouldComponentUpdate` shouldn't throw errors when used createReactClass, with default parser
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  shouldComponentUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n')
     }, {
       // Destructured props in the `componentWillUpdate` method shouldn't throw errors
       code: [
@@ -1380,6 +1430,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in `componentWillUpdate` shouldn't throw errors when used createReactClass, with default parser
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentWillUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n')
+    }, {
       // Destructured function props in the `componentWillUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1405,6 +1468,18 @@ ruleTester.run('no-unused-prop-types', rule, {
         '})'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured function props in the `componentWillUpdate` method shouldn't throw errors when used createReactClass, with default parser
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentWillUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n')
     }, {
       // Destructured props in the `componentDidUpdate` method shouldn't throw errors
       code: [
@@ -1434,6 +1509,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in `componentDidUpdate` shouldn't throw errors when used createReactClass, with default parser
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentDidUpdate (prevProps, prevState) {',
+        '    const {something} = prevProps;',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n')
+    }, {
       // Destructured function props in the `componentDidUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1459,6 +1547,18 @@ ruleTester.run('no-unused-prop-types', rule, {
         '})'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      // Destructured function props in the `componentDidUpdate` method shouldn't throw errors when used createReactClass, with default parser
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentDidUpdate ({something}, prevState) {',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n')
     }, {
       // Destructured state props in `componentDidUpdate` [Issue #825]
       code: [

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1229,6 +1229,20 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in componentWillReceiveProps shouldn't throw errors when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentWillReceiveProps (nextProps) {',
+        '    const {something} = nextProps;',
+        '    doSomething(something);',
+        '  }',
+        '})'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
       // Destructured function props in componentWillReceiveProps shouldn't throw errors
       code: [
         'class Hello extends Component {',

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1256,6 +1256,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured function props in componentWillReceiveProps shouldn't throw errors when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentWillReceiveProps ({something}) {',
+        '    doSomething(something);',
+        '  }',
+        '})'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
       // Destructured props in the constructor shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1285,33 +1298,6 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
-      // Destructured props in the `componentWillReceiveProps` method shouldn't throw errors
-      code: [
-        'class Hello extends Component {',
-        '  static propTypes = {',
-        '    something: PropTypes.bool',
-        '  }',
-        '  componentWillReceiveProps (nextProps, nextState) {',
-        '    const {something} = nextProps;',
-        '    return something;',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint'
-    }, {
-      // Destructured function props in the `componentWillReceiveProps` method shouldn't throw errors
-      code: [
-        'class Hello extends Component {',
-        '  static propTypes = {',
-        '    something: PropTypes.bool',
-        '  }',
-        '  componentWillReceiveProps ({something}, nextState) {',
-        '    return something;',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint'
-    }, {
       // Destructured props in the `shouldComponentUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1326,6 +1312,20 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in `shouldComponentUpdate` shouldn't throw errors when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  shouldComponentUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
       // Destructured function props in the `shouldComponentUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1336,6 +1336,19 @@ ruleTester.run('no-unused-prop-types', rule, {
         '    return something;',
         '  }',
         '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      // Destructured function props in `shouldComponentUpdate` shouldn't throw errors when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  shouldComponentUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '})'
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
@@ -1353,6 +1366,20 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured props in `componentWillUpdate` shouldn't throw errors when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentWillUpdate (nextProps, nextState) {',
+        '    const {something} = nextProps;',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
       // Destructured function props in the `componentWillUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
@@ -1366,17 +1393,44 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured function props in the `componentWillUpdate` method shouldn't throw errors when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentWillUpdate ({something}, nextState) {',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
       // Destructured props in the `componentDidUpdate` method shouldn't throw errors
       code: [
         'class Hello extends Component {',
         '  static propTypes = {',
         '    something: PropTypes.bool',
         '  }',
-        '  componentDidUpdate (prevProps, nextState) {',
+        '  componentDidUpdate (prevProps, prevState) {',
         '    const {something} = prevProps;',
         '    return something;',
         '  }',
         '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      // Destructured props in `componentDidUpdate` shouldn't throw errors when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentDidUpdate (prevProps, prevState) {',
+        '    const {something} = prevProps;',
+        '    return something;',
+        '  }',
+        '})'
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
@@ -1386,10 +1440,23 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  static propTypes = {',
         '    something: PropTypes.bool',
         '  }',
-        '  componentDidUpdate ({something}, nextState) {',
+        '  componentDidUpdate ({something}, prevState) {',
         '    return something;',
         '  }',
         '}'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      // Destructured function props in the `componentDidUpdate` method shouldn't throw errors when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentDidUpdate ({something}, prevState) {',
+        '    return something;',
+        '  }',
+        '})'
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
@@ -1406,6 +1473,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      // Destructured state props in `componentDidUpdate` [Issue #825] when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentDidUpdate ({something}, {state1, state2}) {',
+        '    return something;',
+        '  }',
+        '})'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
       // Destructured state props in `componentDidUpdate` without custom parser [Issue #825]
       code: [
         'var Hello = React.Component({',
@@ -1416,6 +1496,18 @@ ruleTester.run('no-unused-prop-types', rule, {
         '    return something;',
         '  }',
         '});'
+      ].join('\n')
+    }, {
+      // Destructured state props in `componentDidUpdate` without custom parser [Issue #825] when used createReactClass
+      code: [
+        'var Hello = createReactClass({',
+        '  propTypes: {',
+        '    something: PropTypes.bool,',
+        '  },',
+        '  componentDidUpdate: function ({something}, {state1, state2}) {',
+        '    return something;',
+        '  }',
+        '})'
       ].join('\n')
     }, {
       // Destructured props in a stateless function


### PR DESCRIPTION
We got `PropType is defined but prop is never used  react/no-unused-prop-types` when used **createReactClass**.
Added fix, tests and removed 2 duplicated tests.