### PR TITLE
Update no-unused-prop-types rule for new React class component lifecycles

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -22,15 +22,8 @@ const docsUrl = require('../util/docsUrl');
 const DIRECT_PROPS_REGEX = /^props\s*(\.|\[)/;
 const DIRECT_NEXT_PROPS_REGEX = /^nextProps\s*(\.|\[)/;
 const DIRECT_PREV_PROPS_REGEX = /^prevProps\s*(\.|\[)/;
-const LIFE_CYCLE_METHODS = [
-  'componentDidUpdate',
-  'componentWillReceiveProps',
-  'componentWillUpdate',
-  'getDerivedStateFromProps',
-  'shouldComponentUpdate',
-  'UNSAFE_componentWillReceiveProps',
-  'UNSAFE_componentWillUpdate'
-];
+const LIFE_CYCLE_METHODS = ['componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
+const ASYNC_SAFE_LIFE_CYCLE_METHODS = ['getDerivedStateFromProps', 'UNSAFE_componentWillReceiveProps', 'UNSAFE_componentWillUpdate'];
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -69,6 +62,7 @@ module.exports = {
     const skipShapeProps = configuration.skipShapeProps;
     const customValidators = configuration.customValidators || [];
     const propWrapperFunctions = new Set(context.settings.propWrapperFunctions || []);
+    const checkAsyncSafeLifeCycles = versionUtil.testReactVersion(context, '16.3.0');
 
     // Used to track the type annotations in scope.
     // Necessary because babel's scopes do not track type annotations.
@@ -99,12 +93,14 @@ module.exports = {
     function inLifeCycleMethod() {
       let scope = context.getScope();
       while (scope) {
-        if (
-          scope.block && scope.block.parent &&
-          scope.block.parent.key &&
-            LIFE_CYCLE_METHODS.indexOf(scope.block.parent.key.name) >= 0
-        ) {
-          return true;
+        if (scope.block && scope.block.parent && scope.block.parent.key) {
+          const name = scope.block.parent.key.name;
+
+          if (LIFE_CYCLE_METHODS.indexOf(name) >= 0) {
+            return true;
+          } else if (checkAsyncSafeLifeCycles && ASYNC_SAFE_LIFE_CYCLE_METHODS.indexOf(name) >= 0) {
+            return true;
+          }
         }
         scope = scope.upper;
       }
@@ -258,10 +254,16 @@ module.exports = {
      */
     function isNodeALifeCycleMethod(node) {
       const nodeKeyName = (node.key || {}).name;
-      return (
-        node.kind === 'constructor' ||
-        LIFE_CYCLE_METHODS.indexOf(nodeKeyName) >= 0
-      );
+
+      if (node.kind === 'constructor') {
+        return true;
+      } else if (LIFE_CYCLE_METHODS.indexOf(nodeKeyName) >= 0) {
+        return true;
+      } else if (checkAsyncSafeLifeCycles && ASYNC_SAFE_LIFE_CYCLE_METHODS.indexOf(nodeKeyName) >= 0) {
+        return true;
+      }
+
+      return false;
     }
 
     /**

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -22,7 +22,15 @@ const docsUrl = require('../util/docsUrl');
 const DIRECT_PROPS_REGEX = /^props\s*(\.|\[)/;
 const DIRECT_NEXT_PROPS_REGEX = /^nextProps\s*(\.|\[)/;
 const DIRECT_PREV_PROPS_REGEX = /^prevProps\s*(\.|\[)/;
-const LIFE_CYCLE_METHODS = ['componentWillReceiveProps', 'shouldComponentUpdate', 'componentWillUpdate', 'componentDidUpdate'];
+const LIFE_CYCLE_METHODS = [
+  'componentDidUpdate',
+  'componentWillReceiveProps',
+  'componentWillUpdate',
+  'getDerivedStateFromProps',
+  'shouldComponentUpdate',
+  'UNSAFE_componentWillReceiveProps',
+  'UNSAFE_componentWillUpdate'
+];
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -252,10 +260,7 @@ module.exports = {
       const nodeKeyName = (node.key || {}).name;
       return (
         node.kind === 'constructor' ||
-        nodeKeyName === 'componentWillReceiveProps' ||
-        nodeKeyName === 'shouldComponentUpdate' ||
-        nodeKeyName === 'componentWillUpdate' ||
-        nodeKeyName === 'componentDidUpdate'
+        LIFE_CYCLE_METHODS.indexOf(nodeKeyName) >= 0
       );
     }
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2838,6 +2838,7 @@ ruleTester.run('no-unused-prop-types', rule, {
           }
         }
       `].join('\n'),
+      settings: {react: {version: '16.3.0'}},
       parser: 'babel-eslint'
     }, {
       // Destructured props in the `UNSAFE_componentWillUpdate` method shouldn't throw errors
@@ -2852,6 +2853,7 @@ ruleTester.run('no-unused-prop-types', rule, {
           }
         }
       `].join('\n'),
+      settings: {react: {version: '16.3.0'}},
       parser: 'babel-eslint'
     }, {
       // Simple test of new static getDerivedStateFromProps lifecycle
@@ -2876,6 +2878,7 @@ ruleTester.run('no-unused-prop-types', rule, {
           }
         }
       `].join('\n'),
+      settings: {react: {version: '16.3.0'}},
       parser: 'babel-eslint'
     }
   ],
@@ -4423,6 +4426,67 @@ ruleTester.run('no-unused-prop-types', rule, {
       parser: 'babel-eslint',
       errors: [{
         message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [`
+        class Hello extends Component {
+          static propTypes = {
+            something: PropTypes.bool
+          };
+          UNSAFE_componentWillReceiveProps (nextProps) {
+            const {something} = nextProps;
+            doSomething(something);
+          }
+        }
+      `].join('\n'),
+      settings: {react: {version: '16.2.0'}},
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'something\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [`
+        class Hello extends Component {
+          static propTypes = {
+            something: PropTypes.bool
+          };
+          UNSAFE_componentWillUpdate (nextProps, nextState) {
+            const {something} = nextProps;
+            return something;
+          }
+        }
+      `].join('\n'),
+      settings: {react: {version: '16.2.0'}},
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'something\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [`
+        class MyComponent extends React.Component {
+          static propTypes = {
+            defaultValue: 'bar'
+          };
+          state = {
+            currentValue: null
+          };
+          static getDerivedStateFromProps(nextProps, prevState) {
+            if (prevState.currentValue === null) {
+              return {
+                currentValue: nextProps.defaultValue,
+              }
+            }
+            return null;
+          }
+          render() {
+            return <div>{ this.state.currentValue }</div>
+          }
+        }
+      `].join('\n'),
+      settings: {react: {version: '16.2.0'}},
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'defaultValue\' PropType is defined but prop is never used'
       }]
     }
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2825,6 +2825,58 @@ ruleTester.run('no-unused-prop-types', rule, {
         }
         MyComponent.propTypes = { * other() {} };
       `
+    }, {
+      // Sanity test coverage for new UNSAFE_componentWillReceiveProps lifecycles
+      code: [`
+        class Hello extends Component {
+          static propTypes = {
+            something: PropTypes.bool
+          };
+          UNSAFE_componentWillReceiveProps (nextProps) {
+            const {something} = nextProps;
+            doSomething(something);
+          }
+        }
+      `].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      // Destructured props in the `UNSAFE_componentWillUpdate` method shouldn't throw errors
+      code: [`
+        class Hello extends Component {
+          static propTypes = {
+            something: PropTypes.bool
+          };
+          UNSAFE_componentWillUpdate (nextProps, nextState) {
+            const {something} = nextProps;
+            return something;
+          }
+        }
+      `].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      // Simple test of new static getDerivedStateFromProps lifecycle
+      code: [`
+        class MyComponent extends React.Component {
+          static propTypes = {
+            defaultValue: 'bar'
+          };
+          state = {
+            currentValue: null
+          };
+          static getDerivedStateFromProps(nextProps, prevState) {
+            if (prevState.currentValue === null) {
+              return {
+                currentValue: nextProps.defaultValue,
+              }
+            }
+            return null;
+          }
+          render() {
+            return <div>{ this.state.currentValue }</div>
+          }
+        }
+      `].join('\n'),
+      parser: 'babel-eslint'
     }
   ],
 


### PR DESCRIPTION
The upcoming React 16.3 release will make a couple of changes to the class component lifecycles: `componentWillMount`, `componentWillReceiveProps`, and `componentWillUpdate` are being aliased to `UNSAFE_componentWillMount`, `UNSAFE_componentWillReceiveProps`, and `UNSAFE_componentWillUpdate` and a new static lifecycle, `getDerivedStateFromProps`, is being added.

For background information, see [RFC 6](https://github.com/reactjs/rfcs/blob/master/text/0006-static-lifecycle-methods.md).

When running codemods at Facebook to rename these lifecycles, I noticed that it caused a couple of false positives with the `react/no-unused-prop-types` lint rule since that rule was not yet aware of the lifecycle changes. I _think_ this PR corrects that. I added a couple of sanity check tests (which failed before my changes) to verify this.