### PR TITLE
Adding the option to provide a custom message to jsx-no-bind

### DIFF
--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -9,11 +9,13 @@ The following patterns are considered warnings:
 ```jsx
 <div onClick={this._handleClick.bind(this)}></div>
 ```
+
 ```jsx
 <div onClick={() => console.log('Hello!')}></div>
 ```
 
 The following patterns are **not** considered warnings:
+
 ```jsx
 <div onClick={this._handleClick}></div>
 ```
@@ -26,6 +28,7 @@ The following patterns are **not** considered warnings:
   "allowArrowFunctions": <boolean> || false,
   "allowFunctions": <boolean> || false,
   "allowBind": <boolean> || false
+  "customMessage": <string> || undefined
 }]
 ```
 
@@ -61,6 +64,26 @@ When `true` the following is **not** considered a warning:
 ```jsx
 <div onClick={this._handleClick.bind(this)} />
 ```
+
+### `customMessage`
+
+When `customMessage` is set, it will override the default error message for each rule violation,
+for example, with the following config:
+
+```js
+"react/jsx-no-bind": [true, {
+  "customMessage": "A bind call in a JSX prop will cause performance issues related to garbage collection"
+}]
+```
+
+And the below code:
+
+```jsx
+<div onCilck={this._handleClick.bind(this)} />
+```
+
+The default error of `JSX props should not use .bind()` will be replaced by
+`A bind call in a JSX prop will cause performance issues related to garbage collection`.
 
 ## Protips
 

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -48,6 +48,10 @@ module.exports = {
         ignoreRefs: {
           default: false,
           type: 'boolean'
+        },
+        customMessage: {
+          default: '',
+          type: 'string'
         }
       },
       additionalProperties: false
@@ -117,7 +121,11 @@ module.exports = {
 
       return violationTypes.find(type => {
         if (blockSets[type].has(name)) {
-          context.report({node: node, message: violationMessageStore[type]});
+          context.report({
+            node: node,
+            message: configuration.customMessage || violationMessageStore[type]
+          });
+
           return true;
         }
 
@@ -167,7 +175,9 @@ module.exports = {
           findVariableViolation(node, valueNode.name);
         } else if (nodeViolationType) {
           context.report({
-            node: node, message: violationMessageStore[nodeViolationType]
+            node: node,
+            message: configuration.customMessage ||
+              violationMessageStore[nodeViolationType]
           });
         }
       }

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -279,6 +279,11 @@ ruleTester.run('jsx-no-bind', rule, {
       errors: [{message: 'JSX props should not use .bind()'}]
     },
     {
+      code: '<div onClick={this._handleClick.bind(this)}></div>',
+      options: [{customMessage: 'JSX props should not call bind or use arrow functions for performance reasons'}],
+      errors: [{message: 'JSX props should not call bind or use arrow functions for performance reasons'}]
+    },
+    {
       code: '<div onClick={someGlobalFunction.bind(this)}></div>',
       errors: [{message: 'JSX props should not use .bind()'}]
     },
@@ -397,11 +402,36 @@ ruleTester.run('jsx-no-bind', rule, {
       ],
       parser: 'babel-eslint'
     },
+    {
+      code: [
+        'class Hello23 extends React.Component {',
+        '  renderDiv = () => {',
+        '    const click = () => true',
+        '    const renderStuff = () => {',
+        '      const click = this.doSomething.bind(this, "hey")',
+        '      return <div onClick={click} />',
+        '    }',
+        '    return <div onClick={click}>Hello</div>;',
+        '  }',
+        '};'
+      ].join('\n'),
+      options: [{customMessage: 'JSX props should not call bind or use arrow functions for performance reasons'}],
+      errors: [
+        {message: 'JSX props should not call bind or use arrow functions for performance reasons'},
+        {message: 'JSX props should not call bind or use arrow functions for performance reasons'}
+      ],
+      parser: 'babel-eslint'
+    },
 
     // Arrow functions
     {
       code: '<div onClick={() => alert("1337")}></div>',
       errors: [{message: 'JSX props should not use arrow functions'}]
+    },
+    {
+      code: '<div onClick={() => alert("1337")}></div>',
+      options: [{customMessage: 'JSX props should not call bind or use arrow functions for performance reasons'}],
+      errors: [{message: 'JSX props should not call bind or use arrow functions for performance reasons'}]
     },
     {
       code: '<div onClick={async () => alert("1337")}></div>',
@@ -516,11 +546,36 @@ ruleTester.run('jsx-no-bind', rule, {
       ],
       parser: 'babel-eslint'
     },
+    {
+      code: [
+        'class Hello23 extends React.Component {',
+        '  renderDiv = () => {',
+        '    const click = ::this.onChange',
+        '    const renderStuff = () => {',
+        '      const click = () => true',
+        '      return <div onClick={click} />',
+        '    }',
+        '    return <div onClick={click}>Hello</div>;',
+        '  }',
+        '};'
+      ].join('\n'),
+      options: [{customMessage: 'JSX props should not call bind or use arrow functions for performance reasons'}],
+      errors: [
+        {message: 'JSX props should not call bind or use arrow functions for performance reasons'},
+        {message: 'JSX props should not call bind or use arrow functions for performance reasons'}
+      ],
+      parser: 'babel-eslint'
+    },
 
     // Functions
     {
       code: '<div onClick={function () { alert("1337") }}></div>',
       errors: [{message: 'JSX props should not use functions'}]
+    },
+    {
+      code: '<div onClick={function () { alert("1337") }}></div>',
+      options: [{customMessage: 'JSX props should not call bind or use functions for performance reasons'}],
+      errors: [{message: 'JSX props should not call bind or use functions for performance reasons'}]
     },
     {
       code: '<div onClick={function * () { alert("1337") }}></div>',
@@ -664,11 +719,37 @@ ruleTester.run('jsx-no-bind', rule, {
       ],
       parser: 'babel-eslint'
     },
+    {
+      code: [
+        'class Hello23 extends React.Component {',
+        '  renderDiv = () => {',
+        '    const click = ::this.onChange',
+        '    const renderStuff = () => {',
+        '      const click = function () { return true }',
+        '      return <div onClick={click} />',
+        '    }',
+        '    return <div onClick={click}>Hello</div>;',
+        '  }',
+        '};'
+      ].join('\n'),
+      options: [{customMessage: 'JSX props should not use functions or :: for performance reasons'}],
+      errors: [
+        {message: 'JSX props should not use functions or :: for performance reasons'},
+        {message: 'JSX props should not use functions or :: for performance reasons'}
+      ],
+      parser: 'babel-eslint'
+    },
 
     // Bind expression
     {
       code: '<div foo={::this.onChange} />',
       errors: [{message: 'JSX props should not use ::'}],
+      parser: 'babel-eslint'
+    },
+    {
+      code: '<div foo={::this.onChange} />',
+      options: [{customMessage: 'JSX props should not use :: for performance reasons'}],
+      errors: [{message: 'JSX props should not use :: for performance reasons'}],
       parser: 'babel-eslint'
     },
     {


### PR DESCRIPTION
Changes
- added the ability to provide a custom message to the `jsx-no-bind` rule
- added tests around the rule to ensure the custom message _always_ overrides the default
- added documentation illustrating the usage of the rule

Context
- in my current role we are trying to educate developers about best practice and performance concerns
- custom messages on linter rules allow us to provide information about _why_ they should follow these practices (or conversely, why they should avoid patterns detected by linter rules) as an expansion on what the default messages provide (ie. the pattern they should avoid)

If it will help this get merged I can amend the request to enable custom messages to be set for each of the four configuration options. Let me know if you would rather I pursued this option.