### PR TITLE
Rule prop-types includes nextProps checking in shouldComponentUpdate

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -122,6 +122,24 @@ module.exports = {
     }
 
     /**
+     * Check if we are in a class constructor
+     * @return {boolean} true if we are in a class constructor, false if not
+     */
+    function inShouldComponentUpdate() {
+      let scope = context.getScope();
+      while (scope) {
+        if (
+          scope.block && scope.block.parent &&
+          scope.block.parent.key && scope.block.parent.key.name === 'shouldComponentUpdate'
+        ) {
+          return true;
+        }
+        scope = scope.upper;
+      }
+      return false;
+    }
+
+    /**
     * Checks if a prop is being assigned a value props.bar = 'bar'
     * @param {ASTNode} node The AST node being checked.
     * @returns {Boolean}
@@ -146,7 +164,7 @@ module.exports = {
         node.object.type === 'ThisExpression' && node.property.name === 'props'
       );
       const isStatelessFunctionUsage = node.object.name === 'props' && !isAssignmentToProp(node);
-      const isNextPropsUsage = node.object.name === 'nextProps' && inComponentWillReceiveProps();
+      const isNextPropsUsage = node.object.name === 'nextProps' && (inComponentWillReceiveProps() || inShouldComponentUpdate());
       return isClassUsage || isStatelessFunctionUsage || isNextPropsUsage;
     }
 
@@ -549,7 +567,9 @@ module.exports = {
       const isInClassComponent = utils.getParentES6Component() || utils.getParentES5Component();
       const isNotInConstructor = !inConstructor();
       const isNotInComponentWillReceiveProps = !inComponentWillReceiveProps();
-      if (isDirectProp && isInClassComponent && isNotInConstructor && isNotInComponentWillReceiveProps) {
+      const isNotInShouldComponentUpdate = !inShouldComponentUpdate();
+      if (isDirectProp && isInClassComponent && isNotInConstructor && isNotInComponentWillReceiveProps
+        && isNotInShouldComponentUpdate) {
         return void 0;
       }
       if (!isDirectProp) {

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -1043,6 +1043,10 @@ module.exports = {
           markPropTypesAsUsed(node);
         }
 
+        if (node.key.name === 'shouldComponentUpdate' && destructuring) {
+          markPropTypesAsUsed(node);
+        }
+
         if (!node.static || node.kind !== 'get' || !propsUtil.isPropTypesDeclaration(node)) {
           return;
         }

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3071,6 +3071,29 @@ ruleTester.run('prop-types', rule, {
     }, {
       code: [
         'class Hello extends Component {',
+        '  static propTypes = forbidExtraProps({',
+        '    bar: PropTypes.func',
+        '  })',
+        '  shouldComponentUpdate(nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return;',
+        '    }',
+        '  }',
+        '  render() {',
+        '    return <div bar={this.props.bar} />;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      settings: Object.assign({}, settings, {
+        propWrapperFunctions: ['forbidExtraProps']
+      }),
+      errors: [
+        {message: '\'foo\' is missing in props validation'}
+      ]
+    }, {
+      code: [
+        'class Hello extends Component {',
         '  static propTypes = {',
         '    bar: PropTypes.func',
         '  }',

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3071,29 +3071,6 @@ ruleTester.run('prop-types', rule, {
     }, {
       code: [
         'class Hello extends Component {',
-        '  static propTypes = forbidExtraProps({',
-        '    bar: PropTypes.func',
-        '  })',
-        '  shouldComponentUpdate(nextProps) {',
-        '    if (nextProps.foo) {',
-        '      return;',
-        '    }',
-        '  }',
-        '  render() {',
-        '    return <div bar={this.props.bar} />;',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint',
-      settings: Object.assign({}, settings, {
-        propWrapperFunctions: ['forbidExtraProps']
-      }),
-      errors: [
-        {message: '\'foo\' is missing in props validation'}
-      ]
-    }, {
-      code: [
-        'class Hello extends Component {',
         '  static propTypes = {',
         '    bar: PropTypes.func',
         '  }',
@@ -3156,6 +3133,48 @@ ruleTester.run('prop-types', rule, {
       code: [
         'class Hello extends Component {',
         '  componentWillReceiveProps({foo}) {',
+        '    if (foo) {',
+        '      return;',
+        '    }',
+        '  }',
+        '  render() {',
+        '    return <div bar={this.props.bar} />;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '    bar: PropTypes.func',
+        '  }'
+      ].join('\n'),
+      errors: [
+        {message: '\'foo\' is missing in props validation'}
+      ]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  static propTypes = forbidExtraProps({',
+        '    bar: PropTypes.func',
+        '  })',
+        '  shouldComponentUpdate(nextProps) {',
+        '    if (nextProps.foo) {',
+        '      return;',
+        '    }',
+        '  }',
+        '  render() {',
+        '    return <div bar={this.props.bar} />;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      settings: Object.assign({}, settings, {
+        propWrapperFunctions: ['forbidExtraProps']
+      }),
+      errors: [
+        {message: '\'foo\' is missing in props validation'}
+      ]
+    }, {
+      code: [
+        'class Hello extends Component {',
+        '  shouldComponentUpdate({foo}) {',
         '    if (foo) {',
         '      return;',
         '    }',


### PR DESCRIPTION
Resolves #1684 

I've added the `shouldComponentUpdate` to the list of functions to include with this rule, following how `componentWillReceiveProps` was implemented.

The only thing outstanding are the tests, I've only included a single test but it may need to be put in a different spot. 