### PR TITLE
Issue #1632 - jsx-sort-props: reservedFirst conflicts with callbacksLast

### DIFF
--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -62,6 +62,12 @@ const ignoreCaseAndCallbackLastArgs = [
     ignoreCase: true,
   },
 ];
+const reservedFirstAndCallbacksLastArgs = [
+  {
+    callbacksLast: true,
+    reservedFirst: true,
+  },
+];
 const shorthandFirstArgs = [{ shorthandFirst: true }];
 const shorthandLastArgs = [{ shorthandLast: true }];
 const shorthandAndCallbackLastArgs = [
@@ -482,6 +488,12 @@ ruleTester.run('jsx-sort-props', rule, {
       code: '<App key={5} />',
       options: reservedFirstAsInvalidArrayArgs,
       errors: [expectedInvalidReservedFirstError],
+    },
+    {
+      code: '<App onBar z />;',
+      output: '<App z onBar />;',
+      options: reservedFirstAndCallbacksLastArgs,
+      errors: [expectedCallbackError],
     },
   ]),
 });


### PR DESCRIPTION
Updated unit test with failing case for callbacksLast not working when used in combination with reservedFirst. (First ever pull request - tell me if I did something wrong!)