### PR TITLE
Allow crossOrigin on audio elements

### DIFF
--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -26,7 +26,7 @@ const DOM_ATTRIBUTE_NAMES = {
 };
 
 const ATTRIBUTE_TAGS_MAP = {
-  crossOrigin: ['script', 'img', 'video', 'link']
+  crossOrigin: ['script', 'img', 'video', 'audio', 'link']
 };
 
 const SVGDOM_ATTRIBUTE_NAMES = {

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -42,7 +42,8 @@ ruleTester.run('no-unknown-property', rule, {
       code: '<div class="bar"></div>;',
       options: [{ignore: ['class']}]
     },
-    {code: '<script crossOrigin />'}
+    {code: '<script crossOrigin />'},
+    {code: '<audio crossOrigin />'}
   ],
   invalid: [{
     code: '<div class="bar"></div>;',
@@ -88,6 +89,6 @@ ruleTester.run('no-unknown-property', rule, {
     errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}]
   }, {
     code: '<div crossOrigin />',
-    errors: [{message: 'Invalid property \'crossOrigin\' found on tag \'div\', but it is only allowed on: script, img, video, link'}]
+    errors: [{message: 'Invalid property \'crossOrigin\' found on tag \'div\', but it is only allowed on: script, img, video, audio, link'}]
   }]
 });


### PR DESCRIPTION
As audio elements also inherit from HTMLMediaElement and thus have the `crossOrigin` property

Also see:

Audio element: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio
HTMLAudioElement: https://developer.mozilla.org/en-US/docs/Web/API/HTMLAudioElement
HTMLMediaElement crossOrigin: https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/crossOrigin