### PR TITLE
[Fix] `react/jsx-no-bind` Add props to example

### DIFF
--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -121,8 +121,8 @@ Unfortunately [React ES6 classes](https://facebook.github.io/react/blog/2015/01/
 
 ```jsx
 class Foo extends React.Component {
-  constructor() {
-    super();
+  constructor(...args) {
+    super(...args);
     this._onClick = this._onClick.bind(this);
   }
   render() {


### PR DESCRIPTION
https://reactjs.org/blog/2015/01/27/react-v0.13.0-beta-1.html#autobinding