### PR TITLE
[Fix] `boolean-prop-naming`: add missing default config

### DIFF
--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -13,6 +13,8 @@ const docsUrl = require('../util/docsUrl');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const ruleDefault = '^(is|has)[A-Z]([A-Za-z0-9]?)+';
+
 module.exports = {
   meta: {
     docs: {
@@ -34,7 +36,7 @@ module.exports = {
           uniqueItems: true
         },
         rule: {
-          default: '^(is|has)[A-Z]([A-Za-z0-9]?)+',
+          default: ruleDefault,
           minLength: 1,
           type: 'string'
         },
@@ -50,7 +52,8 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     const sourceCode = context.getSourceCode();
     const config = context.options[0] || {};
-    const rule = config.rule ? new RegExp(config.rule) : null;
+    const pattern = config.rule || ruleDefault;
+    const rule = pattern ? new RegExp(pattern) : null;
     const propTypeNames = config.propTypeNames || ['bool'];
     const propWrapperFunctions = new Set(context.settings.propWrapperFunctions || []);
 
@@ -146,7 +149,7 @@ module.exports = {
           data: {
             component: propName,
             propName: propName,
-            pattern: config.rule
+            pattern: pattern
           }
         });
       });

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -351,6 +351,17 @@ ruleTester.run('boolean-prop-naming', rule, {
   }],
 
   invalid: [{
+    // createReactClass components with PropTypes, default config
+    code: `
+      var Hello = createReactClass({
+        propTypes: {something: PropTypes.bool},
+        render: function() { return <div />; }
+      });
+    `,
+    errors: [{
+      message: 'Prop name (something) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+    }]
+  }, {
     // createReactClass components with PropTypes
     code: `
       var Hello = createReactClass({


### PR DESCRIPTION
This might be semver-major, since the rule has never had any default behavior previously.

Fixes #1551. Probably fixes #1540.