### PR TITLE
Fix failures of jsx-max-depth on empty nodes

### DIFF
--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -38,7 +38,7 @@ module.exports = {
     const maxDepth = has(option, 'max') ? option.max : DEFAULT_DEPTH;
 
     function isJSXElement(node) {
-      return node.type === 'JSXElement';
+      return node && node.type === 'JSXElement';
     }
 
     function isExpression(node) {
@@ -90,7 +90,8 @@ module.exports = {
 
             return isJSXElement(writeExpr)
               && writeExpr
-              || writeExpr.type === 'Identifier'
+              || writeExpr 
+              && writeExpr.type === 'Identifier'
               && findJSXElement(variables, writeExpr.name);
           }
         }

--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -90,7 +90,7 @@ module.exports = {
 
             return isJSXElement(writeExpr)
               && writeExpr
-              || writeExpr 
+              || writeExpr
               && writeExpr.type === 'Identifier'
               && findJSXElement(variables, writeExpr.name);
           }


### PR DESCRIPTION
On some my code (didn't check what code exactly) I got this:

```
Cannot read property 'type' of null
TypeError: Cannot read property 'type' of null
    at find (/path/to/package/node_modules/eslint-plugin-react/lib/rules/jsx-max-depth.js:93:27)
    at findJSXElement (/path/to/package/node_modules/eslint-plugin-react/lib/rules/jsx-max-depth.js:102:49)
    at JSXExpressionContainer (/path/to/package/node_modules/eslint-plugin-react/lib/rules/jsx-max-depth.js:137:25)
```

So, for now, I just have fixed it. No tests have been changed as I didn't investigate it.