### PR TITLE
Add JSX prop alignment based on the first prop & between-prop space consistency

### DIFF
--- a/docs/rules/jsx-indent-props.md
+++ b/docs/rules/jsx-indent-props.md
@@ -29,11 +29,12 @@ firstName="John"
 
 ## Rule Options
 
-It takes an option as the second parameter which can be `"tab"` for tab-based indentation or a positive number for space indentations.
+It takes an option as the second parameter which can be `"tab"` for tab-based indentation, a positive number for space indentations or `"first"` for aligning the first prop for each line with the tag's first prop.
+Note that using the `"first"` option allows very inconsistent indentation unless you also enable a rule that enforces the position of the first prop.
 
 ```js
 ...
-"react/jsx-indent-props": [<enabled>, 'tab'|<number>]
+"react/jsx-indent-props": [<enabled>, 'tab'|<number>|'first']
 ...
 ```
 
@@ -50,6 +51,13 @@ The following patterns are considered warnings:
 // [2, 'tab']
 <Hello
   firstName="John"
+/>
+
+// aligned with first prop
+// [2, 'first']
+<Hello
+  firstName="John"
+    lastName="Doe"
 />
 ```
 
@@ -77,6 +85,21 @@ The following patterns are **not** warnings:
 <Hello
 firstName="John"
 />
+
+// aligned with first prop
+// [2, 'first']
+<Hello
+  firstName="John"
+  lastName="Doe"
+/>
+
+<Hello
+       firstName="John"
+       lastName="Doe"
+/>
+
+<Hello firstName="Jane"
+       lastName="Doe" />
 ```
 
 ## When not to use

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -47,7 +47,7 @@ module.exports = {
 
     schema: [{
       oneOf: [{
-        enum: ['tab', 'aligned']
+        enum: ['tab', 'first']
       }, {
         type: 'integer'
       }]
@@ -64,8 +64,8 @@ module.exports = {
     const sourceCode = context.getSourceCode();
 
     if (context.options.length) {
-      if (context.options[0] === 'aligned') {
-        indentSize = 'aligned';
+      if (context.options[0] === 'first') {
+        indentSize = 'first';
         indentType = 'space';
       } else if (context.options[0] === 'tab') {
         indentSize = 1;
@@ -167,24 +167,9 @@ module.exports = {
           return;
         }
         let propIndent;
-        if (indentSize === 'aligned') {
+        if (indentSize === 'first') {
           const firstPropNode = node.attributes[0];
-          // '<' and any space following it
-          const beforeNameLength = node.name.range[0] - node.range[0];
-          // the name itself
-          const nameLength = node.name.range[1] - node.name.range[0];
-          // any space between the name and the first attribute
-          const afterNameLength = Math.max(1, firstPropNode.loc.start.column - node.name.loc.end.column);
-          if (afterNameLength !== 1) {
-            // this is not easily fixable, so we just report another error for it.
-            // it should be unlikely enough to be triggered anyway
-            context.report({
-              node: node,
-              message: 'Found too much whitespace between tag name and first attribute.'
-            });
-          }
-          // use the indentation of the element relative to the beginning of the line
-          propIndent = node.loc.start.column + beforeNameLength + nameLength + afterNameLength;
+          propIndent = firstPropNode.loc.start.column;
         } else {
           const elementIndent = getNodeIndent(node);
           propIndent = elementIndent + indentSize;

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -47,7 +47,7 @@ module.exports = {
 
     schema: [{
       oneOf: [{
-        enum: ['tab']
+        enum: ['tab', 'aligned']
       }, {
         type: 'integer'
       }]
@@ -64,7 +64,10 @@ module.exports = {
     const sourceCode = context.getSourceCode();
 
     if (context.options.length) {
-      if (context.options[0] === 'tab') {
+      if (context.options[0] === 'aligned') {
+        indentSize = 'aligned';
+        indentType = 'space';
+      } else if (context.options[0] === 'tab') {
         indentSize = 1;
         indentType = 'tab';
       } else if (typeof context.options[0] === 'number') {
@@ -160,8 +163,33 @@ module.exports = {
 
     return {
       JSXOpeningElement: function(node) {
-        const elementIndent = getNodeIndent(node);
-        checkNodesIndent(node.attributes, elementIndent + indentSize);
+        if (!node.attributes.length) {
+          return;
+        }
+        let propIndent;
+        if (indentSize === 'aligned') {
+          const firstPropNode = node.attributes[0];
+          // '<' and any space following it
+          const beforeNameLength = node.name.range[0] - node.range[0];
+          // the name itself
+          const nameLength = node.name.range[1] - node.name.range[0];
+          // any space between the name and the first attribute
+          const afterNameLength = Math.max(1, firstPropNode.loc.start.column - node.name.loc.end.column);
+          if (afterNameLength !== 1) {
+            // this is not easily fixable, so we just report another error for it.
+            // it should be unlikely enough to be triggered anyway
+            context.report({
+              node: node,
+              message: 'Found too much whitespace between tag name and first attribute.'
+            });
+          }
+          // use the indentation of the element relative to the beginning of the line
+          propIndent = node.loc.start.column + beforeNameLength + nameLength + afterNameLength;
+        } else {
+          const elementIndent = getNodeIndent(node);
+          propIndent = elementIndent + indentSize;
+        }
+        checkNodesIndent(node.attributes, propIndent);
       }
     };
   }

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -81,9 +81,8 @@ module.exports = {
      * @param {ASTNode} node Node violating the indent rule
      * @param {Number} needed Expected indentation character count
      * @param {Number} gotten Indentation character count in the actual node/code
-     * @param {Object=} loc Error line and column location
      */
-    function report(node, needed, gotten, loc) {
+    function report(node, needed, gotten) {
       const msgContext = {
         needed: needed,
         type: indentType,
@@ -91,52 +90,32 @@ module.exports = {
         gotten: gotten
       };
 
-      if (loc) {
-        context.report({
-          node: node,
-          loc: loc,
-          message: MESSAGE,
-          data: msgContext
-        });
-      } else {
-        context.report({
-          node: node,
-          message: MESSAGE,
-          data: msgContext,
-          fix: function(fixer) {
-            return fixer.replaceTextRange([node.range[0] - node.loc.start.column, node.range[0]],
-              Array(needed + 1).join(indentType === 'space' ? ' ' : '\t'));
-          }
-        });
-      }
+      context.report({
+        node: node,
+        message: MESSAGE,
+        data: msgContext,
+        fix: function(fixer) {
+          return fixer.replaceTextRange([node.range[0] - node.loc.start.column, node.range[0]],
+            Array(needed + 1).join(indentType === 'space' ? ' ' : '\t'));
+        }
+      });
     }
 
     /**
      * Get node indent
      * @param {ASTNode} node Node to examine
-     * @param {Boolean} byLastLine get indent of node's last line
-     * @param {Boolean} excludeCommas skip comma on start of line
      * @return {Number} Indent
      */
-    function getNodeIndent(node, byLastLine, excludeCommas) {
-      byLastLine = byLastLine || false;
-      excludeCommas = excludeCommas || false;
-
+    function getNodeIndent(node) {
       let src = sourceCode.getText(node, node.loc.start.column + extraColumnStart);
       const lines = src.split('\n');
-      if (byLastLine) {
-        src = lines[lines.length - 1];
-      } else {
-        src = lines[0];
-      }
-
-      const skip = excludeCommas ? ',' : '';
+      src = lines[0];
 
       let regExp;
       if (indentType === 'space') {
-        regExp = new RegExp(`^[ ${skip}]+`);
+        regExp = /^[ ]+/;
       } else {
-        regExp = new RegExp(`^[\t${skip}]+`);
+        regExp = /^[\t]+/;
       }
 
       const indent = regExp.exec(src);
@@ -149,9 +128,9 @@ module.exports = {
      * @param {Number} indent needed indent
      * @param {Boolean} excludeCommas skip comma on start of line
      */
-    function checkNodesIndent(nodes, indent, excludeCommas) {
+    function checkNodesIndent(nodes, indent) {
       nodes.forEach(node => {
-        const nodeIndent = getNodeIndent(node, false, excludeCommas);
+        const nodeIndent = getNodeIndent(node);
         if (
           node.type !== 'ArrayExpression' && node.type !== 'ObjectExpression' &&
           nodeIndent !== indent && astUtil.isNodeFirstInLine(context, node)

--- a/tests/lib/rules/jsx-indent-props.js
+++ b/tests/lib/rules/jsx-indent-props.js
@@ -63,7 +63,7 @@ ruleTester.run('jsx-indent-props', rule, {
     code: [
       '<App/>'
     ].join('\n'),
-    options: ['aligned']
+    options: ['first']
   }, {
     code: [
       '<App aaa',
@@ -71,7 +71,15 @@ ruleTester.run('jsx-indent-props', rule, {
       '     cc',
       '/>'
     ].join('\n'),
-    options: ['aligned']
+    options: ['first']
+  }, {
+    code: [
+      '<App   aaa',
+      '       b',
+      '       cc',
+      '/>'
+    ].join('\n'),
+    options: ['first']
   }, {
     code: [
       'const test = <App aaa',
@@ -79,7 +87,7 @@ ruleTester.run('jsx-indent-props', rule, {
       '                  cc',
       '             />'
     ].join('\n'),
-    options: ['aligned']
+    options: ['first']
   }, {
     code: [
       '<App aaa x',
@@ -87,7 +95,7 @@ ruleTester.run('jsx-indent-props', rule, {
       '     cc',
       '/>'
     ].join('\n'),
-    options: ['aligned']
+    options: ['first']
   }, {
     code: [
       'const test = <App aaa x',
@@ -95,7 +103,7 @@ ruleTester.run('jsx-indent-props', rule, {
       '                  cc',
       '             />'
     ].join('\n'),
-    options: ['aligned']
+    options: ['first']
   }, {
     code: [
       '<App aaa',
@@ -105,7 +113,7 @@ ruleTester.run('jsx-indent-props', rule, {
       '           d/>',
       '</App>'
     ].join('\n'),
-    options: ['aligned']
+    options: ['first']
   }, {
     code: [
       '<Fragment>',
@@ -119,7 +127,15 @@ ruleTester.run('jsx-indent-props', rule, {
       '  />',
       '</Fragment>'
     ].join('\n'),
-    options: ['aligned']
+    options: ['first']
+  }, {
+    code: [
+      '<App',
+      '  a',
+      '  b',
+      '/>'
+    ].join('\n'),
+    options: ['first']
   }],
 
   invalid: [{
@@ -184,20 +200,7 @@ ruleTester.run('jsx-indent-props', rule, {
       '     b',
       '/>'
     ].join('\n'),
-    options: ['aligned'],
-    errors: [{message: 'Expected indentation of 5 space characters but found 2.'}]
-  }, {
-    code: [
-      '<App a x',
-      '  b y',
-      '/>'
-    ].join('\n'),
-    output: [
-      '<App a x',
-      '     b y',
-      '/>'
-    ].join('\n'),
-    options: ['aligned'],
+    options: ['first'],
     errors: [{message: 'Expected indentation of 5 space characters but found 2.'}]
   }, {
     code: [
@@ -210,11 +213,8 @@ ruleTester.run('jsx-indent-props', rule, {
       '      b',
       '/>'
     ].join('\n'),
-    options: ['aligned'],
-    errors: [
-      {message: 'Found too much whitespace between tag name and first attribute.'},
-      {message: 'Expected indentation of 6 space characters but found 3.'}
-    ]
+    options: ['first'],
+    errors: [{message: 'Expected indentation of 6 space characters but found 3.'}]
   }, {
     code: [
       '<App',
@@ -228,28 +228,27 @@ ruleTester.run('jsx-indent-props', rule, {
       '      b',
       '/>'
     ].join('\n'),
-    options: ['aligned'],
-    errors: [
-      {message: 'Found too much whitespace between tag name and first attribute.'},
-      {message: 'Expected indentation of 6 space characters but found 3.'}
-    ]
+    options: ['first'],
+    errors: [{message: 'Expected indentation of 6 space characters but found 3.'}]
   }, {
     code: [
       '<App',
       '  a',
-      '  b',
+      ' b',
+      '   c',
       '/>'
     ].join('\n'),
     output: [
       '<App',
-      '     a',
-      '     b',
+      '  a',
+      '  b',
+      '  c',
       '/>'
     ].join('\n'),
-    options: ['aligned'],
+    options: ['first'],
     errors: [
-      {message: 'Expected indentation of 5 space characters but found 2.'},
-      {message: 'Expected indentation of 5 space characters but found 2.'}
+      {message: 'Expected indentation of 2 space characters but found 1.'},
+      {message: 'Expected indentation of 2 space characters but found 3.'}
     ]
   }]
 });

--- a/tests/lib/rules/jsx-indent-props.js
+++ b/tests/lib/rules/jsx-indent-props.js
@@ -82,6 +82,22 @@ ruleTester.run('jsx-indent-props', rule, {
     options: ['aligned']
   }, {
     code: [
+      '<App aaa x',
+      '     b y',
+      '     cc',
+      '/>'
+    ].join('\n'),
+    options: ['aligned']
+  }, {
+    code: [
+      'const test = <App aaa x',
+      '                  b y',
+      '                  cc',
+      '             />'
+    ].join('\n'),
+    options: ['aligned']
+  }, {
+    code: [
       '<App aaa',
       '     b',
       '>',
@@ -166,6 +182,19 @@ ruleTester.run('jsx-indent-props', rule, {
     output: [
       '<App a',
       '     b',
+      '/>'
+    ].join('\n'),
+    options: ['aligned'],
+    errors: [{message: 'Expected indentation of 5 space characters but found 2.'}]
+  }, {
+    code: [
+      '<App a x',
+      '  b y',
+      '/>'
+    ].join('\n'),
+    output: [
+      '<App a x',
+      '     b y',
       '/>'
     ].join('\n'),
     options: ['aligned'],

--- a/tests/lib/rules/jsx-indent-props.js
+++ b/tests/lib/rules/jsx-indent-props.js
@@ -59,6 +59,51 @@ ruleTester.run('jsx-indent-props', rule, {
       '/>'
     ].join('\n'),
     options: ['tab']
+  }, {
+    code: [
+      '<App/>'
+    ].join('\n'),
+    options: ['aligned']
+  }, {
+    code: [
+      '<App aaa',
+      '     b',
+      '     cc',
+      '/>'
+    ].join('\n'),
+    options: ['aligned']
+  }, {
+    code: [
+      'const test = <App aaa',
+      '                  b',
+      '                  cc',
+      '             />'
+    ].join('\n'),
+    options: ['aligned']
+  }, {
+    code: [
+      '<App aaa',
+      '     b',
+      '>',
+      '    <Child c',
+      '           d/>',
+      '</App>'
+    ].join('\n'),
+    options: ['aligned']
+  }, {
+    code: [
+      '<Fragment>',
+      '  <App aaa',
+      '       b',
+      '       cc',
+      '  />',
+      '  <OtherApp a',
+      '            bbb',
+      '            c',
+      '  />',
+      '</Fragment>'
+    ].join('\n'),
+    options: ['aligned']
   }],
 
   invalid: [{
@@ -112,5 +157,70 @@ ruleTester.run('jsx-indent-props', rule, {
     ].join('\n'),
     options: ['tab'],
     errors: [{message: 'Expected indentation of 1 tab character but found 3.'}]
+  }, {
+    code: [
+      '<App a',
+      '  b',
+      '/>'
+    ].join('\n'),
+    output: [
+      '<App a',
+      '     b',
+      '/>'
+    ].join('\n'),
+    options: ['aligned'],
+    errors: [{message: 'Expected indentation of 5 space characters but found 2.'}]
+  }, {
+    code: [
+      '<App  a',
+      '   b',
+      '/>'
+    ].join('\n'),
+    output: [
+      '<App  a',
+      '      b',
+      '/>'
+    ].join('\n'),
+    options: ['aligned'],
+    errors: [
+      {message: 'Found too much whitespace between tag name and first attribute.'},
+      {message: 'Expected indentation of 6 space characters but found 3.'}
+    ]
+  }, {
+    code: [
+      '<App',
+      '      a',
+      '   b',
+      '/>'
+    ].join('\n'),
+    output: [
+      '<App',
+      '      a',
+      '      b',
+      '/>'
+    ].join('\n'),
+    options: ['aligned'],
+    errors: [
+      {message: 'Found too much whitespace between tag name and first attribute.'},
+      {message: 'Expected indentation of 6 space characters but found 3.'}
+    ]
+  }, {
+    code: [
+      '<App',
+      '  a',
+      '  b',
+      '/>'
+    ].join('\n'),
+    output: [
+      '<App',
+      '     a',
+      '     b',
+      '/>'
+    ].join('\n'),
+    options: ['aligned'],
+    errors: [
+      {message: 'Expected indentation of 5 space characters but found 2.'},
+      {message: 'Expected indentation of 5 space characters but found 2.'}
+    ]
   }]
 });


### PR DESCRIPTION
This adds support for the JSX prop style suggested in #398 which is the default of the various JetBrains IDEs.
I haven't updated the docs yet since writing docs isn't fun so I'd rather know first that the PR has a chance of getting accepted before doing that.

Fixes #398.