### PR TITLE
Add jsx-props-no-multi-spaces rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Enable the rules that you would like to use.
 * [react/jsx-one-expression-per-line](docs/rules/jsx-one-expression-per-line.md): Limit to one expression per line in JSX
 * [react/jsx-curly-brace-presence](docs/rules/jsx-curly-brace-presence.md): Enforce curly braces or disallow unnecessary curly braces in JSX
 * [react/jsx-pascal-case](docs/rules/jsx-pascal-case.md): Enforce PascalCase for user-defined JSX components
+* [react/jsx-props-no-multi-spaces](docs/rules/jsx-props-no-multi-spaces.md): Disallow multiple spaces between inline JSX props (fixable)
 * [react/jsx-sort-default-props](docs/rules/jsx-sort-default-props.md): Enforce default props alphabetical sorting
 * [react/jsx-sort-props](docs/rules/jsx-sort-props.md): Enforce props alphabetical sorting (fixable)
 * [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md): Validate spacing before closing bracket in JSX (fixable)

--- a/docs/rules/jsx-props-no-multi-spaces.md
+++ b/docs/rules/jsx-props-no-multi-spaces.md
@@ -1,0 +1,29 @@
+# Disallow multiple spaces between inline JSX props
+
+Enforces that there is exactly one space between two JSX attributes or the JSX tag name and the first JSX attribute in the same line.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```jsx
+<App  spacy />
+```
+
+```jsx
+<App too  spacy />
+```
+
+The following patterns are **not** considered warnings:
+
+```jsx
+<App cozy />
+```
+
+```jsx
+<App very cozy />
+```
+
+## When Not To Use It
+
+If you are not using JSX or don't care about the space between two props in the same line.

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const allRules = {
   'jsx-no-undef': require('./lib/rules/jsx-no-undef'),
   'jsx-curly-brace-presence': require('./lib/rules/jsx-curly-brace-presence'),
   'jsx-pascal-case': require('./lib/rules/jsx-pascal-case'),
+  'jsx-props-no-multi-spaces': require('./lib/rules/jsx-props-no-multi-spaces'),
   'jsx-sort-default-props': require('./lib/rules/jsx-sort-default-props'),
   'jsx-sort-props': require('./lib/rules/jsx-sort-props'),
   'jsx-space-before-closing': require('./lib/rules/jsx-space-before-closing'),

--- a/lib/rules/jsx-props-no-multi-spaces.js
+++ b/lib/rules/jsx-props-no-multi-spaces.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Disallow multiple spaces between inline JSX props
+ * @author Adrian Moennich
+ */
+
+'use strict';
+
+const docsUrl = require('../util/docsUrl');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow multiple spaces between inline JSX props',
+      category: 'Stylistic Issues',
+      recommended: false,
+      url: docsUrl('jsx-props-no-multi-spaces')
+    },
+    fixable: 'code',
+    schema: []
+  },
+
+  create: function (context) {
+    const sourceCode = context.getSourceCode();
+
+    function getPropName(propNode) {
+      if (propNode.type === 'JSXSpreadAttribute') {
+        return sourceCode.getText(propNode.argument);
+      } else if (propNode.type === 'JSXIdentifier') {
+        return propNode.name;
+      }
+      return propNode.name.name;
+    }
+
+    function checkSpacing(prev, node) {
+      if (prev.loc.end.line !== node.loc.end.line) {
+        return;
+      }
+      const between = sourceCode.text.slice(prev.range[1], node.range[0]);
+      if (between !== ' ') {
+        context.report({
+          node: node,
+          message: `Expected only one space between "${getPropName(prev)}" and "${getPropName(node)}"`,
+          fix: function(fixer) {
+            return fixer.replaceTextRange([prev.range[1], node.range[0]], ' ');
+          }
+        });
+      }
+    }
+
+    return {
+      JSXOpeningElement: function (node) {
+        node.attributes.reduce((prev, prop) => {
+          checkSpacing(prev, prop);
+          return prop;
+        }, node.name);
+      }
+    };
+  }
+};

--- a/tests/lib/rules/jsx-props-no-multi-spaces.js
+++ b/tests/lib/rules/jsx-props-no-multi-spaces.js
@@ -1,0 +1,111 @@
+/**
+ * @fileoverview Disallow multiple spaces between inline JSX props
+ * @author Adrian Moennich
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/jsx-props-no-multi-spaces');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 8,
+  sourceType: 'module',
+  ecmaFeatures: {
+    experimentalObjectRestSpread: true,
+    jsx: true
+  }
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({parserOptions});
+ruleTester.run('jsx-props-no-multi-spaces', rule, {
+  valid: [{
+    code: [
+      '<App />'
+    ].join('\n')
+  }, {
+    code: [
+      '<App foo />'
+    ].join('\n')
+  }, {
+    code: [
+      '<App foo bar />'
+    ].join('\n')
+  }, {
+    code: [
+      '<App foo="with  spaces   " bar />'
+    ].join('\n')
+  }, {
+    code: [
+      '<App',
+      '  foo bar />'
+    ].join('\n')
+  }, {
+    code: [
+      '<App',
+      '  foo',
+      '  bar />'
+    ].join('\n')
+  }, {
+    code: [
+      '<App',
+      '  foo {...test}',
+      '  bar />'
+    ].join('\n')
+  }],
+
+  invalid: [{
+    code: [
+      '<App  foo />'
+    ].join('\n'),
+    output: [
+      '<App foo />'
+    ].join('\n'),
+    errors: [{message: 'Expected only one space between "App" and "foo"'}]
+  }, {
+    code: [
+      '<App foo="with  spaces   "   bar />'
+    ].join('\n'),
+    output: [
+      '<App foo="with  spaces   " bar />'
+    ].join('\n'),
+    errors: [{message: 'Expected only one space between "foo" and "bar"'}]
+  }, {
+    code: [
+      '<App foo  bar />'
+    ].join('\n'),
+    output: [
+      '<App foo bar />'
+    ].join('\n'),
+    errors: [{message: 'Expected only one space between "foo" and "bar"'}]
+  }, {
+    code: [
+      '<App  foo   bar />'
+    ].join('\n'),
+    output: [
+      '<App foo bar />'
+    ].join('\n'),
+    errors: [
+      {message: 'Expected only one space between "App" and "foo"'},
+      {message: 'Expected only one space between "foo" and "bar"'}
+    ]
+  }, {
+    code: [
+      '<App foo  {...test}  bar />'
+    ].join('\n'),
+    output: [
+      '<App foo {...test} bar />'
+    ].join('\n'),
+    errors: [
+      {message: 'Expected only one space between "foo" and "test"'},
+      {message: 'Expected only one space between "test" and "bar"'}
+    ]
+  }]
+});


### PR DESCRIPTION
This rule enforced consistent spacing of JSX tag attributes and is especially useful together with `jsx-indent-props` in "first" mode (#1729) to actually require consistency of where the first attribute begins.