### PR TITLE
[sort-comp] Fix bug affecting `instance-methods` group

### DIFF
--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -384,10 +384,11 @@ module.exports = {
           node.value.type !== 'ArrowFunctionExpression' &&
           node.value.type !== 'FunctionExpression',
         instanceMethod: !node.static &&
-          node.type === 'ClassProperty' &&
           node.value &&
-          (node.value.type === 'ArrowFunctionExpression' ||
-            node.value.type === 'FunctionExpression'),
+          (
+            (node.type === 'ClassProperty' && node.value.type === 'ArrowFunctionExpression') ||
+            (node.type === 'MethodDefinition' && node.value.type === 'FunctionExpression')
+          ),
         typeAnnotation: !!node.typeAnnotation && node.value === null
       }));
 

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -315,8 +315,8 @@ ruleTester.run('sort-comp', rule, {
     code: [
       'class Hello extends React.Component {',
       '  foo = () => {}',
-      '  constructor() {}',
       '  classMethod() {}',
+      '  constructor() {}',
       '  static bar = () => {}',
       '  render() {',
       '    return <div>{this.props.text}</div>;',
@@ -573,7 +573,7 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: 'babel-eslint',
-    errors: [{message: 'foo should be placed before constructor'}],
+    errors: [{message: 'classMethod should be placed before constructor'}],
     options: [{
       order: [
         'instance-methods',


### PR DESCRIPTION
Many thanks to @yannickcr and [all contributors](https://github.com/yannickcr/eslint-plugin-react/graphs/contributors) for developing this great plugin :slightly_smiling_face:

Regarding issue #599 (_"`sort-comp`: Consider separating static fields & instance fields into separate groups"_), and PR #1470 (_"Add `instance-methods` and `instance-variables` to `sort-comp`"_) released in [v7.6.0](https://github.com/yannickcr/eslint-plugin-react/releases/tag/v7.6.0), there's a bug in the implementation of the `instance-methods` group :bug:

Class instance methods can be declared in two different ways ([AST Explorer snippet](https://astexplorer.net/#/gist/41d38f1bdf7c3502079bb85de20785f4/)):

```js
class Main extends React.Component {

    // MethodDefinition -> FunctionExpression
    foo() {}

    // ClassProperty -> ArrowFunctionExpression
    bar = () => {}

}
```

Using the [`babel-eslint`](https://www.npmjs.com/package/babel-eslint) parser, if a class instance method is declared as a `FunctionExpression`, then the parent AST node is a `MethodDefinition`, but the `sort-comp` rule is expecting the parent node to be a `ClassProperty`, which is wrong :x:

---

Unfortunately the unit tests didn't detect this bug.  Here's the source code for [the `valid` unit test](https://github.com/yannickcr/eslint-plugin-react/blob/d68ef96/tests/lib/rules/sort-comp.js#L314-L334), which I've annotated with comments showing the AST nodes and the relevant [`propertiesInfos`](https://github.com/yannickcr/eslint-plugin-react/blob/d68ef96/lib/rules/sort-comp.js#L376-L392) ([AST Explorer snippet](https://astexplorer.net/#/gist/a4f8b7d70fa35a7efde162d3e22a1bf9/)):

```jsx
class Hello extends React.Component {

    // ClassProperty -> ArrowFunctionExpression (instanceMethod == true)
    foo = () => {}

    // MethodDefinition -> FunctionExpression (instanceMethod == false)
    constructor() {}

    // MethodDefinition -> FunctionExpression (instanceMethod == false)
    classMethod() {}

    // ClassProperty -> ArrowFunctionExpression (static == true, instanceMethod == false)
    static bar = () => {}

    // MethodDefinition -> FunctionExpression (instanceMethod == false)
    render() {
        return <div>{this.props.text}</div>;
    }

}
```

For the `constructor()`, `classMethod()` and `render()` methods, `instanceMethod` is `false` but should be `true` :x:

The [group order for that unit test](https://github.com/yannickcr/eslint-plugin-react/blob/d68ef96/tests/lib/rules/sort-comp.js#L328-L333) is:

* `instance-methods`
* `lifecycle` – [group includes `constructor()`](https://github.com/yannickcr/eslint-plugin-react/blob/d68ef96/lib/rules/sort-comp.js#L30)
* `everything-else`
* `render`

so the expected order of methods is:

```js
foo          // instance-methods
classMethod  // instance-methods
constructor  // lifecycle
bar          // everything-else (static method)
render       // render
```

The test passes, but it should fail, because `constructor()` is placed before `classMethod()` in the source code, but it's expected to be after it.

The reason why the test passes is because `classMethod()` is being wrongly included in the `everything-else` group (it should be in `instance-methods`), and so the order of methods is:

```js
foo          // instance-methods
constructor  // lifecycle
classMethod  // everything-else (wrong group!)
bar          // everything-else (static method)
render       // render
```

---

This PR fixes the bug affecting [`instanceMethod`](https://github.com/yannickcr/eslint-plugin-react/blob/d68ef96/lib/rules/sort-comp.js#L386-L390) in [`checkPropsOrder()`](https://github.com/yannickcr/eslint-plugin-react/blob/d68ef96/lib/rules/sort-comp.js#L375), and updates the corresponding unit tests ([`valid`](https://github.com/yannickcr/eslint-plugin-react/blob/d68ef96/tests/lib/rules/sort-comp.js#L314-L334) and [`invalid`](https://github.com/yannickcr/eslint-plugin-react/blob/d68ef96/tests/lib/rules/sort-comp.js#L563-L584)).

PS: I was the 1,000th [forker](https://github.com/yannickcr/eslint-plugin-react/network) of this repo :slightly_smiling_face:
