### PR TITLE
sort-comp: enforcing static lifecycle methods order

### DIFF
--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -172,7 +172,7 @@ module.exports = {
         }
       }
 
-      if (method.static) {
+      if (method.static && methodsOrder.indexOf(method.name) === -1) {
         const staticIndex = methodsOrder.indexOf('static-methods');
         if (staticIndex >= 0) {
           indexes.push(staticIndex);

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -172,7 +172,7 @@ module.exports = {
         }
       }
 
-      if (method.static && methodsOrder.indexOf(method.name) === -1) {
+      if (method.static && method.name !== 'getDerivedStateFromProps') {
         const staticIndex = methodsOrder.indexOf('static-methods');
         if (staticIndex >= 0) {
           indexes.push(staticIndex);

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -172,7 +172,7 @@ module.exports = {
         }
       }
 
-      if (method.static && method.name !== 'getDerivedStateFromProps') {
+      if (indexes.length === 0 && method.static) {
         const staticIndex = methodsOrder.indexOf('static-methods');
         if (staticIndex >= 0) {
           indexes.push(staticIndex);

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -512,7 +512,6 @@ ruleTester.run('sort-comp', rule, {
       '  constructor() {}',
       '}'
     ].join('\n'),
-    parser: 'babel-eslint',
     errors: [{message: 'getDerivedStateFromProps should be placed after constructor'}]
   }, {
     // Type Annotations should not be at the top by default

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -505,6 +505,16 @@ ruleTester.run('sort-comp', rule, {
     parser: 'babel-eslint',
     errors: [{message: 'render should be placed after displayName'}]
   }, {
+    // Must validate static lifecycle methods
+    code: [
+      'class Hello extends React.Component {',
+      '  static getDerivedStateFromProps() {}',
+      '  constructor() {}',
+      '}'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    errors: [{message: 'getDerivedStateFromProps should be placed after constructor'}]
+  }, {
     // Type Annotations should not be at the top by default
     code: [
       'class Hello extends React.Component {',


### PR DESCRIPTION
Fixes bug: https://github.com/yannickcr/eslint-plugin-react/issues/1793

Example of **incorrect** code with `"react/sort-comp": "error"`:
```jsx
class Test extends React.Component {
	static getDerivedStateFromProps() {
		return null
	}

	constructor(props) {
		super(props)
		this.state = { test: 'test' }
	}

	render() {
		return this.state.test
	}
}
```


Example of **correct** code with `"react/sort-comp": "error"`:
```jsx
class Test extends React.Component {
	constructor(props) {
		super(props)
		this.state = { test: 'test' }
	}

	static getDerivedStateFromProps() {
		return null
	}

	render() {
		return this.state.test
	}
}
```