### PR TITLE
guard against accidental anonymous react imports

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -155,8 +155,9 @@ module.exports = {
         if (node.source && node.source.value === 'prop-types') { // import PropType from "prop-types"
           propTypesPackageName = node.specifiers[0].local.name;
         } else if (node.source && node.source.value === 'react') { // import { PropTypes } from "react"
-          reactPackageName = node.specifiers[0].local.name;
-
+          if (node.specifiers.length > 0) {
+            reactPackageName = node.specifiers[0].local.name; // guard against accidental anonymous `import "react"`
+          }
           if (node.specifiers.length >= 1) {
             const propTypesSpecifier = node.specifiers.find(specifier => (
               specifier.imported && specifier.imported.name === 'PropTypes'

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -1172,6 +1172,14 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+     import 'react';
+     class Component extends React.Component {};
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: []
+  }, {
+    code: `
       import { PropTypes } from 'react';
       class Component extends React.Component {};
       Component.childContextTypes = {


### PR DESCRIPTION
There was a file in an old code base that improperly imported react anonymously...and had been unnoticed until we added this no-typos rule and eslint crashed. :)