### PR TITLE
Allow LHS in destructuring-assignment

### DIFF
--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -78,7 +78,8 @@ module.exports = {
       // this.props.Aprop || this.context.aProp || this.state.aState
       const isPropUsed = (
         node.object.type === 'MemberExpression' && node.object.object.type === 'ThisExpression' &&
-        (node.object.property.name === 'props' || node.object.property.name === 'context' || node.object.property.name === 'state')
+        (node.object.property.name === 'props' || node.object.property.name === 'context' || node.object.property.name === 'state') &&
+        !isAssignmentToProp(node)
       );
 
       if (isPropUsed && configuration === 'always') {

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -133,8 +133,7 @@ ruleTester.run('destructuring-assignment', rule, {
         this.state.foo = 'bar';
       }
     };`,
-    options: ['always'],
-    parser: 'babel-eslint'
+    options: ['always']
   }],
 
   invalid: [{

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -126,7 +126,17 @@ ruleTester.run('destructuring-assignment', rule, {
     };`,
     options: ['never'],
     parser: 'babel-eslint'
+  }, {
+    code: `const Foo = class extends React.PureComponent {
+      constructor() {
+        this.state = {};
+        this.state.foo = 'bar';
+      }
+    };`,
+    options: ['always'],
+    parser: 'babel-eslint'
   }],
+
   invalid: [{
     code: `const MyComponent = (props) => {
       return (<div id={props.id} />)


### PR DESCRIPTION
Resolves #1728

Not sure if this needs to also check that assignment is in the constructor? Also, would the following do anything useful / should this be allowed?
```js
constructor(props, context) {
  this.context.foo = 'blah';
}
```