### PR TITLE
Add support for eslint 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   global:
     - TEST=true
   matrix:
+    - ESLINT=5
     - ESLINT=4
     - ESLINT=3
 after_success:
@@ -28,8 +29,12 @@ matrix:
   include:
     - node_js: 'lts/*'
       env: PRETEST=true
+  exclude:
+    - node_js: '5'
+      env: ESLINT=5
+    - node_js: '4'
+      env: ESLINT=5
   allow_failures:
     - node_js: '9'
     - node_js: '7'
     - node_js: '5'
-    - env: TEST=true ESLINT=next

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ matrix:
     - nodejs_version: "9"
     - nodejs_version: "7"
     - nodejs_version: "5"
+    - nodejs_version: "4"
 
 platform:
   - x86

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
   "devDependencies": {
     "babel-eslint": "^8.2.3",
     "coveralls": "^3.0.1",
-    "eslint": "^4.19.1",
+    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0"
   },
   "peerDependencies": {
-    "eslint": "^3.0.0 || ^4.0.0"
+    "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "engines": {
     "node": ">=4"


### PR DESCRIPTION
Looks like it just works.

The peer dep change sees to it that this plugin can be used in projects that use eslint 5 and npm 2 (the default in node 4) without `npm install` failing.