### PR TITLE
For deprecated lifecycle methods, report identifier AST node instead of the class node

### DIFF
--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -106,19 +106,19 @@ module.exports = {
       );
     }
 
-    function checkDeprecation(node, method) {
-      if (!isDeprecated(method)) {
+    function checkDeprecation(node, methodName, methodNode) {
+      if (!isDeprecated(methodName)) {
         return;
       }
       const deprecated = getDeprecated();
-      const version = deprecated[method][0];
-      const newMethod = deprecated[method][1];
-      const refs = deprecated[method][2];
+      const version = deprecated[methodName][0];
+      const newMethod = deprecated[methodName][1];
+      const refs = deprecated[methodName][2];
       context.report({
-        node: node,
+        node: methodNode || node,
         message: DEPRECATED_MESSAGE,
         data: {
-          oldMethod: method,
+          oldMethod: methodName,
           version,
           newMethod: newMethod ? `, use ${newMethod} instead` : '',
           refs: refs ? `, see ${refs}` : ''
@@ -150,7 +150,10 @@ module.exports = {
      */
     function getLifeCycleMethods(node) {
       const properties = astUtil.getComponentProperties(node);
-      return properties.map(property => astUtil.getPropertyName(property));
+      return properties.map(property => ({
+        name: astUtil.getPropertyName(property),
+        node: astUtil.getPropertyNameNode(property)
+      }));
     }
 
     /**
@@ -160,7 +163,7 @@ module.exports = {
     function checkLifeCycleMethods(node) {
       if (utils.isES5Component(node) || utils.isES6Component(node)) {
         const methods = getLifeCycleMethods(node);
-        methods.forEach(method => checkDeprecation(node, method));
+        methods.forEach(method => checkDeprecation(node, method.name, method.node));
       }
     }
 

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -28,17 +28,27 @@ function findReturnStatement(node) {
 }
 
 /**
+ * Get node with property's name
+ * @param {Object} node - Property.
+ * @returns {Object} Property name node.
+ */
+function getPropertyNameNode(node) {
+  if (node.key || ['MethodDefinition', 'Property'].indexOf(node.type) !== -1) {
+    return node.key;
+  } else if (node.type === 'MemberExpression') {
+    return node.property;
+  }
+  return null;
+}
+
+/**
  * Get properties name
  * @param {Object} node - Property.
  * @returns {String} Property name.
  */
 function getPropertyName(node) {
-  if (node.key || ['MethodDefinition', 'Property'].indexOf(node.type) !== -1) {
-    return node.key.name;
-  } else if (node.type === 'MemberExpression') {
-    return node.property.name;
-  }
-  return '';
+  const nameNode = getPropertyNameNode(node);
+  return nameNode ? nameNode.name : '';
 }
 
 /**
@@ -88,6 +98,7 @@ function isNodeFirstInLine(context, node) {
 module.exports = {
   findReturnStatement: findReturnStatement,
   getPropertyName: getPropertyName,
+  getPropertyNameNode: getPropertyNameNode,
   getComponentProperties: getComponentProperties,
   isNodeFirstInLine: isNodeFirstInLine
 };

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -223,18 +223,21 @@ ruleTester.run('no-deprecated', rule, {
           message: errorMessage(
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
-          )
+          ),
+          type: 'Identifier'
         }
       ]
     },
@@ -253,18 +256,21 @@ ruleTester.run('no-deprecated', rule, {
           message: errorMessage(
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
-          )
+          ),
+          type: 'Identifier'
         }
       ]
     },
@@ -281,18 +287,21 @@ ruleTester.run('no-deprecated', rule, {
           message: errorMessage(
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
-          )
+          ),
+          type: 'Identifier'
         }
       ]
     },
@@ -309,18 +318,21 @@ ruleTester.run('no-deprecated', rule, {
           message: errorMessage(
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
-          )
+          ),
+          type: 'Identifier'
         }
       ]
     },
@@ -337,18 +349,21 @@ ruleTester.run('no-deprecated', rule, {
           message: errorMessage(
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
-          )
+          ),
+          type: 'Identifier'
         }
       ]
     },
@@ -365,23 +380,26 @@ ruleTester.run('no-deprecated', rule, {
           message: errorMessage(
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
-          )
+          ),
+          type: 'Identifier'
         }
       ]
     },
     {
-      code: `
+      code: `un
         class Foo extends React.Component {
           constructor() {}
           componentWillMount() {}
@@ -394,18 +412,21 @@ ruleTester.run('no-deprecated', rule, {
           message: errorMessage(
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
-          )
+          ),
+          type: 'Identifier'
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
-          )
+          ),
+          type: 'Identifier'
         }
       ]
     }

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -224,20 +224,32 @@ ruleTester.run('no-deprecated', rule, {
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 3,
+          column: 11,
+          endLine: 3,
+          endColumn: 29
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 36
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30
         }
       ]
     },
@@ -257,20 +269,32 @@ ruleTester.run('no-deprecated', rule, {
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 4,
+          column: 13,
+          endLine: 4,
+          endColumn: 31
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 5,
+          column: 13,
+          endLine: 5,
+          endColumn: 38
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 6,
+          column: 13,
+          endLine: 6,
+          endColumn: 32
         }
       ]
     },
@@ -288,20 +312,32 @@ ruleTester.run('no-deprecated', rule, {
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 3,
+          column: 11,
+          endLine: 3,
+          endColumn: 29
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 36
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30
         }
       ]
     },
@@ -319,20 +355,32 @@ ruleTester.run('no-deprecated', rule, {
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 3,
+          column: 11,
+          endLine: 3,
+          endColumn: 29
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 36
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30
         }
       ]
     },
@@ -350,20 +398,32 @@ ruleTester.run('no-deprecated', rule, {
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 3,
+          column: 11,
+          endLine: 3,
+          endColumn: 29
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 36
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30
         }
       ]
     },
@@ -381,25 +441,37 @@ ruleTester.run('no-deprecated', rule, {
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 3,
+          column: 11,
+          endLine: 3,
+          endColumn: 29
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 36
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30
         }
       ]
     },
     {
-      code: `un
+      code: `
         class Foo extends React.Component {
           constructor() {}
           componentWillMount() {}
@@ -413,20 +485,32 @@ ruleTester.run('no-deprecated', rule, {
             'componentWillMount', '16.3.0', 'UNSAFE_componentWillMount',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 29
         },
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.3.0', 'UNSAFE_componentWillReceiveProps',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 36
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
             'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate'
           ),
-          type: 'Identifier'
+          type: 'Identifier',
+          line: 6,
+          column: 11,
+          endLine: 6,
+          endColumn: 30
         }
       ]
     }

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -226,9 +226,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 3,
-          column: 11,
-          endLine: 3,
-          endColumn: 29
+          column: 11
         },
         {
           message: errorMessage(
@@ -237,9 +235,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 4,
-          column: 11,
-          endLine: 4,
-          endColumn: 36
+          column: 11
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
@@ -247,9 +243,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 5,
-          column: 11,
-          endLine: 5,
-          endColumn: 30
+          column: 11
         }
       ]
     },
@@ -271,9 +265,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 4,
-          column: 13,
-          endLine: 4,
-          endColumn: 31
+          column: 13
         },
         {
           message: errorMessage(
@@ -282,9 +274,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 5,
-          column: 13,
-          endLine: 5,
-          endColumn: 38
+          column: 13
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
@@ -292,9 +282,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 6,
-          column: 13,
-          endLine: 6,
-          endColumn: 32
+          column: 13
         }
       ]
     },
@@ -314,9 +302,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 3,
-          column: 11,
-          endLine: 3,
-          endColumn: 29
+          column: 11
         },
         {
           message: errorMessage(
@@ -325,9 +311,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 4,
-          column: 11,
-          endLine: 4,
-          endColumn: 36
+          column: 11
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
@@ -335,9 +319,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 5,
-          column: 11,
-          endLine: 5,
-          endColumn: 30
+          column: 11
         }
       ]
     },
@@ -357,9 +339,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 3,
-          column: 11,
-          endLine: 3,
-          endColumn: 29
+          column: 11
         },
         {
           message: errorMessage(
@@ -368,9 +348,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 4,
-          column: 11,
-          endLine: 4,
-          endColumn: 36
+          column: 11
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
@@ -378,9 +356,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 5,
-          column: 11,
-          endLine: 5,
-          endColumn: 30
+          column: 11
         }
       ]
     },
@@ -400,9 +376,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 3,
-          column: 11,
-          endLine: 3,
-          endColumn: 29
+          column: 11
         },
         {
           message: errorMessage(
@@ -411,9 +385,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 4,
-          column: 11,
-          endLine: 4,
-          endColumn: 36
+          column: 11
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
@@ -421,9 +393,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 5,
-          column: 11,
-          endLine: 5,
-          endColumn: 30
+          column: 11
         }
       ]
     },
@@ -443,9 +413,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 3,
-          column: 11,
-          endLine: 3,
-          endColumn: 29
+          column: 11
         },
         {
           message: errorMessage(
@@ -454,9 +422,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 4,
-          column: 11,
-          endLine: 4,
-          endColumn: 36
+          column: 11
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
@@ -464,9 +430,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 5,
-          column: 11,
-          endLine: 5,
-          endColumn: 30
+          column: 11
         }
       ]
     },
@@ -487,9 +451,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 4,
-          column: 11,
-          endLine: 4,
-          endColumn: 29
+          column: 11
         },
         {
           message: errorMessage(
@@ -498,9 +460,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 5,
-          column: 11,
-          endLine: 5,
-          endColumn: 36
+          column: 11
         },
         {
           message: errorMessage('componentWillUpdate', '16.3.0', 'UNSAFE_componentWillUpdate',
@@ -508,9 +468,7 @@ ruleTester.run('no-deprecated', rule, {
           ),
           type: 'Identifier',
           line: 6,
-          column: 11,
-          endLine: 6,
-          endColumn: 30
+          column: 11
         }
       ]
     }


### PR DESCRIPTION
When the `no-deprecated` rule finds a deprecated lifecycle method, it reports the whole class declaration as the AST node for the error. Doesn't look good in editor: makes the whole class declaration red and obscures all other ESLint errors inside the class.

<img width="818" alt="screen shot 2018-06-26 at 11 53 22" src="https://user-images.githubusercontent.com/664258/41904055-b7c8a968-7937-11e8-91b7-b951229d4d02.png">

This patch changes the reported AST node to the method name identifier. The errors are much better targeted at the infringing code and look much better when shown in editor UI.

<img width="819" alt="screen shot 2018-06-26 at 11 29 01" src="https://user-images.githubusercontent.com/664258/41904076-c30e2e60-7937-11e8-9c85-54bd117d3a31.png">

Added also test coverage to check for the reported AST node type.