### PR TITLE
Output a warning if React version is missing in settings

### DIFF
--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -7,6 +7,7 @@
 
 const getTokenBeforeClosingBracket = require('../util/getTokenBeforeClosingBracket');
 const docsUrl = require('../util/docsUrl');
+const log = require('../util/log');
 
 let isWarnedForDeprecation = false;
 
@@ -75,15 +76,13 @@ module.exports = {
       },
 
       Program: function() {
-        if (isWarnedForDeprecation || /\=-(f|-format)=/.test(process.argv.join('='))) {
+        if (isWarnedForDeprecation) {
           return;
         }
 
-        /* eslint-disable no-console */
-        console.log('The react/jsx-space-before-closing rule is deprecated. ' +
-                    'Please use the react/jsx-tag-spacing rule with the ' +
-                    '"beforeSelfClosing" option instead.');
-        /* eslint-enable no-console */
+        log('The react/jsx-space-before-closing rule is deprecated. ' +
+            'Please use the react/jsx-tag-spacing rule with the ' +
+            '"beforeSelfClosing" option instead.');
         isWarnedForDeprecation = true;
       }
     };

--- a/lib/util/log.js
+++ b/lib/util/log.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * Logs out a message if there is no format option set.
+ * @param {String} message - Message to log.
+ */
+function log(message) {
+  if (!/\=-(f|-format)=/.test(process.argv.join('='))) {
+    // eslint-disable-next-line no-console
+    console.log(message);
+  }
+}
+
+module.exports = log;

--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -4,11 +4,19 @@
  */
 'use strict';
 
+const log = require('./log');
+
+let warnedForMissingVersion = false;
+
 function getReactVersionFromContext(context) {
   let confVer = '999.999.999';
   // .eslintrc shared settings (http://eslint.org/docs/user-guide/configuring#adding-shared-settings)
   if (context.settings.react && context.settings.react.version) {
     confVer = context.settings.react.version;
+  } else if (!warnedForMissingVersion) {
+    log('Warning: React version not specified in eslint-plugin-react settings. ' +
+      'See https://github.com/yannickcr/eslint-plugin-react#configuration.');
+    warnedForMissingVersion = true;
   }
   confVer = /^[0-9]+\.[0-9]+$/.test(confVer) ? `${confVer}.0` : confVer;
   return confVer.split('.').map(part => Number(part));


### PR DESCRIPTION
Resolves #1789

This message will appear when running some of the tests. Not sure if that should be avoided.