### PR TITLE
Stop crashing on undefined or null properties in flow intersection

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -360,7 +360,7 @@ module.exports = {
         and property value. (key, value) => void
      */
     function iterateProperties(properties, fn) {
-      if (properties.length && typeof fn === 'function') {
+      if (properties && properties.length && typeof fn === 'function') {
         for (let i = 0, j = properties.length; i < j; i++) {
           const node = properties[i];
           const key = getKeyValue(node);

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1872,6 +1872,25 @@ ruleTester.run('prop-types', rule, {
       };
     `,
       parser: 'babel-eslint'
+    },
+    {
+      code: `
+      // @flow
+      import * as React from 'react'
+
+      type Props = {}
+
+      const func = <OP: *>(arg) => arg
+
+      const hoc = <OP>() => () => {
+        class Inner extends React.Component<Props & OP> {
+          render() {
+            return <div />
+          }
+        }
+      }
+    `,
+      parser: 'babel-eslint'
     }
   ],
 
@@ -3625,6 +3644,38 @@ ruleTester.run('prop-types', rule, {
       `,
       errors: [{
         message: '\'fooBar\' is missing in props validation'
+      }],
+      parser: 'babel-eslint'
+    },
+    {
+      code: `
+      type ReduxState = {bar: number};
+
+      const mapStateToProps = (state: ReduxState) => ({
+          foo: state.bar,
+      });
+      // utility to extract the return type from a function
+      type ExtractReturn_<R, Fn: (...args: any[]) => R> = R;
+      type ExtractReturn<T> = ExtractReturn_<*, T>;
+
+      type PropsFromRedux = ExtractReturn<typeof mapStateToProps>;
+
+      type OwnProps = {
+          baz: string,
+      }
+
+      // I want my Props to be {baz: string, foo: number}
+      type Props = PropsFromRedux & OwnProps;
+
+      const Component = (props: Props) => (
+        <div>
+            {props.baz}
+            {props.bad}
+        </div>
+      );
+    `,
+      errors: [{
+        message: '\'bad\' is missing in props validation'
       }],
       parser: 'babel-eslint'
     }


### PR DESCRIPTION
Similar to other fix for flow intersection (#1806). I am not sure if this is the correct fix but the change stops Eslint crashing.

Fixes #1770
Fixes #1631 