### PR TITLE
add rule checking deperated componentWillReceiveProps is not used

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,7 @@ const allRules = {
   'no-access-state-in-setstate': require('./lib/rules/no-access-state-in-setstate'),
   'no-array-index-key': require('./lib/rules/no-array-index-key'),
   'no-children-prop': require('./lib/rules/no-children-prop'),
+  'no-component-will-receive-props': require('./lib/rules/no-component-will-receive-props'),
   'no-danger': require('./lib/rules/no-danger'),
   'no-danger-with-children': require('./lib/rules/no-danger-with-children'),
   'no-deprecated': require('./lib/rules/no-deprecated'),

--- a/lib/rules/no-component-will-receive-props.js
+++ b/lib/rules/no-component-will-receive-props.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Flag componentWillReceiveProps as deprecated
+ */
+'use strict';
+
+const Components = require('../util/Components');
+const astUtil = require('../util/ast');
+const docsUrl = require('../util/docsUrl');
+
+function errorMessage(node) {
+  return `${node} should not use deprecated lifecycle method componentWillReceiveProps.`;
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Flag deprecated componentWillReceiveProps',
+      category: 'Possible Errors',
+      recommended: false,
+      url: docsUrl('no-redundant-should-component-update')
+    },
+    schema: []
+  },
+
+  create: Components.detect(context => {
+    /**
+     * Checks for componentWillReceiveProps property
+     * @param {ASTNode} node The AST node being checked.
+     * @returns {Boolean} Whether or not the property exists.
+     */
+    function hasComponentWillReceiveProps(node) {
+      const properties = astUtil.getComponentProperties(node);
+      return properties.some(property => {
+        const name = astUtil.getPropertyName(property);
+        return name === 'componentWillReceiveProps';
+      });
+    }
+
+    /**
+     * Get name of node if available
+     * @param {ASTNode} node The AST node being checked.
+     * @return {String} The name of the node
+     */
+    function getNodeName(node) {
+      if (node.id) {
+        return node.id.name;
+      } else if (node.parent && node.parent.id) {
+        return node.parent.id.name;
+      }
+      return '';
+    }
+
+    /**
+     * Checks for violation of rule
+     * @param {ASTNode} node The AST node being checked.
+     */
+    function checkForViolation(node) {
+      if (hasComponentWillReceiveProps(node)) {
+        const className = getNodeName(node);
+        context.report({
+          node: node,
+          message: errorMessage(className)
+        });
+      }
+    }
+
+    return {
+      ClassDeclaration: checkForViolation,
+      ClassExpression: checkForViolation
+    };
+  })
+};

--- a/tests/lib/rules/no-component-will-receive-props.js
+++ b/tests/lib/rules/no-component-will-receive-props.js
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview Tests for no-component-will-receive-props
+ */
+
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/no-component-will-receive-props');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+function errorMessage(node) {
+  return `${node} should not use deprecated lifecycle method componentWillReceiveProps.`;
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+ruleTester.run('no-component-will-receive-props', rule, {
+  valid: [
+    {
+      code: `
+        class Foo extends React.Component {
+        }
+      `,
+      parserOptions: parserOptions
+    },
+    {
+      code: `
+        class Foo extends React.Component {
+          componentWillUpdate = () => {
+            return true;
+          }
+        }
+      `,
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    },
+    {
+      code: `
+        function Foo() {
+          return class Bar extends React.Component {
+            componentWillUpdate() {
+            }
+          };
+        }
+      `,
+      parserOptions: parserOptions
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          componentWillReceiveProps() {
+
+          }
+        }
+      `,
+      errors: [{message: errorMessage('Foo')}],
+      parserOptions: parserOptions
+    },
+    {
+      code: `
+        class Foo extends PureComponent {
+          async componentWillReceiveProps() {
+          }
+        }
+      `,
+      errors: [{message: errorMessage('Foo')}],
+      parserOptions: parserOptions
+    },
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          componentWillReceiveProps = () => {
+          }
+        }
+      `,
+      errors: [{message: errorMessage('Foo')}],
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    },
+    {
+      code: `
+        class Foo extends React.PureComponent {
+          componentWillReceiveProps = async () => {
+          }
+        }
+      `,
+      errors: [{message: errorMessage('Foo')}],
+      parser: 'babel-eslint',
+      parserOptions: parserOptions
+    },
+    {
+      code: `
+        function Foo() {
+          return class Bar extends React.PureComponent {
+            componentWillReceiveProps() {
+            }
+          };
+        }
+      `,
+      errors: [{message: errorMessage('Bar')}],
+      parserOptions: parserOptions
+    },
+    {
+      code: `
+        var Foo = class extends PureComponent {
+          componentWillReceiveProps() {
+          }
+        }
+      `,
+      errors: [{message: errorMessage('Foo')}],
+      parserOptions: parserOptions
+    }
+  ]
+});


### PR DESCRIPTION
I thought I would add some rules to help for the migration of react components to the new lifecycle methods.
This is the first step: forbid using componentWillReceiveProps
let me know what you guys think

opened an issue about this #1864 