### PR TITLE
Make attribute "charset" valid

### DIFF
--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -117,7 +117,7 @@ const SVGDOM_ATTRIBUTE_NAMES = {
 const DOM_PROPERTY_NAMES = [
   // Standard
   'acceptCharset', 'accessKey', 'allowFullScreen', 'allowTransparency', 'autoComplete', 'autoFocus', 'autoPlay',
-  'cellPadding', 'cellSpacing', 'charSet', 'classID', 'className', 'colSpan', 'contentEditable', 'contextMenu',
+  'cellPadding', 'cellSpacing', 'classID', 'className', 'colSpan', 'contentEditable', 'contextMenu',
   'dateTime', 'encType', 'formAction', 'formEncType', 'formMethod', 'formNoValidate', 'formTarget',
   'frameBorder', 'hrefLang', 'htmlFor', 'httpEquiv', 'inputMode', 'keyParams', 'keyType', 'marginHeight', 'marginWidth',
   'maxLength', 'mediaGroup', 'minLength', 'noValidate', 'onAnimationEnd', 'onAnimationIteration', 'onAnimationStart',

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -30,6 +30,8 @@ ruleTester.run('no-unknown-property', rule, {
     {code: '<App class="bar" />;'},
     {code: '<App for="bar" />;'},
     {code: '<App accept-charset="bar" />;'},
+    {code: '<meta charset="utf-8" />;'},
+    {code: '<meta charSet="utf-8" />;'},
     {code: '<App http-equiv="bar" />;'},
     {code: '<App xlink:href="bar" />;'},
     {code: '<App clip-path="bar" />;'},


### PR DESCRIPTION
The attribute `charset` was considered an error in favor of `charSet`, but both of them result in valid HTML because HTML is case-insensitive. In other words, these two lines will be interpreted in the same way:

```jsx
<meta charSet="utf-8" />
<meta charset="utf-8" />
```

They will render different HTML (exactly like this JSX suggests), but browsers won't care. If nothing else, `charset` should be the more "correct" form of this attribute because it doesn't suggest a dash (`fillOpacity` = `fill-opacity`, `charSet` ≠ `char-set`).

https://github.com/facebook/react/issues/11492#issuecomment-342953964