### PR TITLE
[Tests] `no-access-state-in-setstate`: passing test for “don't error if it's not a React Component"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,12 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 * [`display-name`]: Get rid of false position on component detection ([#2759] @iiison)
 
+### Changed
+* [`no-access-state-in-setstate`]: passing test for “don't error if it's not a React Component” ([#1873] @kentcdodds)
+
 [#2640]: https://github.com/yannickcr/eslint-plugin-react/pull/2640
 [#2759]: https://github.com/yannickcr/eslint-plugin-react/pull/2759
+[#1873]: https://github.com/yannickcr/eslint-plugin-react/pull/1873
 
 ## [7.25.3] - 2021.09.19
 

--- a/tests/lib/rules/no-access-state-in-setstate.js
+++ b/tests/lib/rules/no-access-state-in-setstate.js
@@ -137,6 +137,15 @@ ruleTester.run('no-access-state-in-setstate', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions
+  }, {
+    code: [
+      'class StateContainer extends Container {',
+      '  anything() {',
+      '    return this.setState({value: this.state.value + 1})',
+      '  }',
+      '};'
+    ].join('\n'),
+    parserOptions
   }],
 
   invalid: [{


### PR DESCRIPTION
unstated uses `this.setState` and we're getting false positives when using this rule.

I figured this would be better than an issue. Is this something we could add?