### PR TITLE
Additional cases for prop-types and no-unused-prop-types

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -146,7 +146,7 @@ module.exports = {
     function mustBeValidated(component) {
       return Boolean(
         component &&
-        !component.ignorePropsValidation
+        !component.ignoreUnusedPropTypesValidation
       );
     }
 
@@ -397,7 +397,7 @@ module.exports = {
 
       const component = components.get(utils.getParentComponent());
       const usedPropTypes = component && component.usedPropTypes || [];
-      let ignorePropsValidation = component && component.ignorePropsValidation || false;
+      let ignoreUnusedPropTypesValidation = component && component.ignoreUnusedPropTypesValidation || false;
 
       switch (type) {
         case 'direct':
@@ -414,7 +414,7 @@ module.exports = {
         case 'destructuring':
           for (let k = 0, l = (properties || []).length; k < l; k++) {
             if (hasSpreadOperator(properties[k]) || properties[k].computed) {
-              ignorePropsValidation = true;
+              ignoreUnusedPropTypesValidation = true;
               break;
             }
             const propName = getKeyValue(properties[k]);
@@ -441,7 +441,7 @@ module.exports = {
 
       components.set(component ? component.node : node, {
         usedPropTypes: usedPropTypes,
-        ignorePropsValidation: ignorePropsValidation
+        ignoreUnusedPropTypesValidation: ignoreUnusedPropTypesValidation
       });
     }
 

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -191,7 +191,7 @@ module.exports = {
           return true;
         }
         // Consider every children as declared
-        if (propType.children === true) {
+        if (propType.children === true || propType.containsSpread) {
           return true;
         }
         if (propType.acceptedProperties) {

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -143,10 +143,10 @@ module.exports = function propTypesInstructions(context, components, utils) {
         }
       });
 
-      // nested object type spread means we need to ignore/accept everything in this object
-      if (containsObjectTypeSpread) {
-        return {};
-      }
+      // Mark if this shape has spread. We will know to consider all props from this shape as having propTypes,
+      // but still have the ability to detect unused children of this shape.
+      shapeTypeDefinition.containsSpread = containsObjectTypeSpread;
+
       return shapeTypeDefinition;
     },
 
@@ -669,7 +669,7 @@ module.exports = function propTypesInstructions(context, components, utils) {
     JSXSpreadAttribute: function(node) {
       const component = components.get(utils.getParentComponent());
       components.set(component ? component.node : node, {
-        ignorePropsValidation: true
+        ignoreUnusedPropTypesValidation: true
       });
     },
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1802,34 +1802,6 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n')
     }, {
-      code: [
-        'type Person = {',
-        '  ...data,',
-        '  lastname: string',
-        '};',
-        'class Hello extends React.Component {',
-        '  props: Person;',
-        '  render () {',
-        '    return <div>Hello {this.props.firstname}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint'
-    }, {
-      code: [
-        'type Person = {|',
-        '  ...data,',
-        '  lastname: string',
-        '|};',
-        'class Hello extends React.Component {',
-        '  props: Person;',
-        '  render () {',
-        '    return <div>Hello {this.props.firstname}</div>;',
-        '  }',
-        '}'
-      ].join('\n'),
-      parser: 'babel-eslint'
-    }, {
       // The next two test cases are related to: https://github.com/yannickcr/eslint-plugin-react/issues/1183
       code: [
         'export default function SomeComponent(props) {',
@@ -2471,6 +2443,20 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: 'babel-eslint'
     }, {
+      code: [
+        'const foo = {};',
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    const {firstname, lastname} = this.props.name;',
+        '    return <div>{firstname} {lastname}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  name: PropTypes.shape(foo)',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
       // issue #933
       code: [
         'type Props = {',
@@ -2913,6 +2899,23 @@ ruleTester.run('no-unused-prop-types', rule, {
         }
       `,
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'import type {BasePerson} from \'./types\'',
+        'type Props = {',
+        '  person: {',
+        '   ...$Exact<BasePerson>,',
+        '   lastname: string',
+        '  }',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  render () {',
+        '    return <div>Hello {this.props.person.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
     }
   ],
 
@@ -4476,6 +4479,48 @@ ruleTester.run('no-unused-prop-types', rule, {
         message: '\'lastname\' PropType is defined but prop is never used'
       }]
     }, {
+      code: `
+        type Person = string;
+        class Hello extends React.Component<{ person: Person }> {
+          render () {
+            return <div />;
+          }
+        }
+      `,
+      settings: {react: {flowVersion: '0.53'}},
+      errors: [{
+        message: '\'person\' PropType is defined but prop is never used'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        type Person = string;
+        class Hello extends React.Component<void, { person: Person }, void> {
+          render () {
+            return <div />;
+          }
+        }
+      `,
+      settings: {react: {flowVersion: '0.52'}},
+      errors: [{
+        message: '\'person\' PropType is defined but prop is never used'
+      }],
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        function higherOrderComponent<P: { foo: string }>() {
+          return class extends React.Component<P> {
+            render() {
+              return <div />;
+            }
+          }
+        }
+      `,
+      errors: [{
+        message: '\'foo\' PropType is defined but prop is never used'
+      }],
+      parser: 'babel-eslint'
+    }, {
       // issue #1506
       code: [
         'class MyComponent extends React.Component {',
@@ -4664,6 +4709,163 @@ ruleTester.run('no-unused-prop-types', rule, {
         message: '\'a.b\' PropType is defined but prop is never used'
       }, {
         message: '\'a.b.c\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: `
+        type Props = { foo: string }
+        function higherOrderComponent<Props>() {
+          return class extends React.Component<Props> {
+            render() {
+              return <div />;
+            }
+          }
+        }
+      `,
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'foo\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'type Person = {',
+        '  ...data,',
+        '  lastname: string',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'type Person = {|',
+        '  ...data,',
+        '  lastname: string',
+        '|};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'type Person = {',
+        '  ...$Exact<data>,',
+        '  lastname: string',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'import type {Data} from \'./Data\'',
+        'type Person = {',
+        '  ...Data,',
+        '  lastname: string',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.bar}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'import type {Data} from \'some-libdef-like-flow-typed-provides\'',
+        'type Person = {',
+        '  ...Data,',
+        '  lastname: string',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.bar}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'type Person = {',
+        '  ...data,',
+        '  lastname: string',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'type Person = {|',
+        '  ...data,',
+        '  lastname: string',
+        '|};',
+        'class Hello extends React.Component {',
+        '  props: Person;',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'import type {BasePerson} from \'./types\'',
+        'type Props = {',
+        '  person: {',
+        '   ...$Exact<BasePerson>,',
+        '   lastname: string',
+        '  }',
+        '};',
+        'class Hello extends React.Component {',
+        '  props: Props;',
+        '  render () {',
+        '    return <div>Hello {this.props.person.firstname}</div>;',
+        '  }',
+        '}'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      options: [{skipShapeProps: false}],
+      errors: [{
+        message: '\'person.lastname\' PropType is defined but prop is never used'
       }]
     }
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2916,6 +2916,21 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint'
+    }, {
+      code: [
+        'import BasePerson from \'./types\'',
+        'class Hello extends React.Component {',
+        '  render () {',
+        '    return <div>Hello {this.props.person.firstname}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  person: ProTypes.shape({',
+        '    ...BasePerson,',
+        '    lastname: PropTypes.string',
+        '  })',
+        '};'
+      ].join('\n')
     }
   ],
 
@@ -4848,6 +4863,22 @@ ruleTester.run('no-unused-prop-types', rule, {
       }]
     }, {
       code: [
+        'class Hello extends React.Component {',
+        '  render () {',
+        '    return <div>Hello {this.props.firstname}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  ...BasePerson,',
+        '  lastname: PropTypes.string',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint',
+      errors: [{
+        message: '\'lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
         'import type {BasePerson} from \'./types\'',
         'type Props = {',
         '  person: {',
@@ -4863,6 +4894,25 @@ ruleTester.run('no-unused-prop-types', rule, {
         '}'
       ].join('\n'),
       parser: 'babel-eslint',
+      options: [{skipShapeProps: false}],
+      errors: [{
+        message: '\'person.lastname\' PropType is defined but prop is never used'
+      }]
+    }, {
+      code: [
+        'import BasePerson from \'./types\'',
+        'class Hello extends React.Component {',
+        '  render () {',
+        '    return <div>Hello {this.props.person.firstname}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  person: ProTypes.shape({',
+        '    ...BasePerson,',
+        '    lastname: PropTypes.string',
+        '  })',
+        '};'
+      ].join('\n'),
       options: [{skipShapeProps: false}],
       errors: [{
         message: '\'person.lastname\' PropType is defined but prop is never used'

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2915,7 +2915,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  }',
         '}'
       ].join('\n'),
-      parser: 'babel-eslint',
+      parser: 'babel-eslint'
     }
   ],
 

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -343,6 +343,51 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n')
     }, {
+      code: `
+        class Component extends React.Component {
+          render() {
+            return <div>{this.props.foo.baz}</div>;
+          }
+        }
+        Component.propTypes = {
+          foo: PropTypes.oneOfType([
+            PropTypes.shape({
+              bar: PropTypes.string
+            }),
+            PropTypes.shape({
+              baz: PropTypes.string
+            })
+          ])
+        };
+      `
+    }, {
+      code: `
+        class Component extends React.Component {
+          render() {
+            return <div>{this.props.foo.baz}</div>;
+          }
+        }
+        Component.propTypes = {
+          foo: PropTypes.oneOfType([
+            PropTypes.shape({
+              bar: PropTypes.string
+            }),
+            PropTypes.instanceOf(Baz)
+          ])
+        };
+      `
+    }, {
+      code: `
+        class Component extends React.Component {
+          render() {
+            return <div>{this.props.foo.baz}</div>;
+          }
+        }
+        Component.propTypes = {
+          foo: PropTypes.oneOf(['bar', 'baz'])
+        };
+      `
+    }, {
       code: [
         'class Hello extends React.Component {',
         '  render() {',
@@ -475,6 +520,20 @@ ruleTester.run('prop-types', rule, {
         '    firstname: PropTypes.string,',
         '    lastname: PropTypes.string',
         '  })',
+        '};'
+      ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      code: [
+        'const foo = {};',
+        'class Hello extends React.Component {',
+        '  render() {',
+        '    const {firstname, lastname} = this.props.name;',
+        '    return <div>{firstname} {lastname}</div>;',
+        '  }',
+        '}',
+        'Hello.propTypes = {',
+        '  name: PropTypes.shape(foo)',
         '};'
       ].join('\n'),
       parser: 'babel-eslint'
@@ -1208,6 +1267,20 @@ ruleTester.run('prop-types', rule, {
         '  options: Array<SelectOption>',
         '} & FieldProps'
       ].join('\n'),
+      parser: 'babel-eslint'
+    }, {
+      // Impossible intersection type
+      code: `
+        import React from 'react';
+        type Props = string & {
+          fullname: string
+        };
+        class Test extends React.PureComponent<Props> {
+          render() {
+            return <div>Hello {this.props.fullname}</div>
+          }
+        }
+      `,
       parser: 'babel-eslint'
     }, {
       code: [
@@ -3760,6 +3833,25 @@ ruleTester.run('prop-types', rule, {
         message: '\'bad\' is missing in props validation'
       }],
       parser: 'babel-eslint'
+    },
+    {
+      code: `
+        class Component extends React.Component {
+          render() {
+            return <div>{this.props.foo.baz}</div>;
+          }
+        }
+        Component.propTypes = {
+          foo: PropTypes.oneOfType([
+            PropTypes.shape({
+              bar: PropTypes.string
+            })
+          ])
+        };
+      `,
+      errors: [{
+        message: '\'foo.baz\' is missing in props validation'
+      }]
     }
   ]
 });


### PR DESCRIPTION
So I was adding test cases to both rules to bring them to parity after the refactoring, but a couple of things didn't make sense.
In particular, having just one flag for ignoring props validation doesn't seem to be enough (and that was the case before the refactoring as well). For instance, let's say we encounter a spread in props e.g.
```js
type Props = {
  ...data,
  lastname: string
};
```
That means any `this.props.foo` usage is considered to have a corresponding propType and it's ignored in `prop-types` via `ignorePropsValidation` flag we set in the helper.
However, this shouldn't preclude us from being able to detect whether `lastname` is an unused propType in `no-unused-prop-types` (this would be ignored if we met a `{...props}` spread). But we can't rely on the same flag, because that flag means a different thing. So I'm proposing to split it into two.

Also see comments inline.

Resolves #836