### PR TITLE
Group static lifecycle methods under lifecycle

### DIFF
--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -47,7 +47,8 @@ const defaultConfig = {
       'componentDidCatch',
       'componentWillUnmount'
     ]
-  }
+  },
+  preferLifecycle: false
 };
 
 /**
@@ -56,8 +57,6 @@ const defaultConfig = {
  * @returns {Array} Methods order
  */
 function getMethodsOrder(userConfig) {
-  userConfig = userConfig || {};
-
   const groups = util._extend(defaultConfig.groups, userConfig.groups);
   const order = userConfig.order || defaultConfig.order;
 
@@ -81,7 +80,6 @@ function getMethodsOrder(userConfig) {
  * @returns {Function} isLifecycle
  */
 function makeIsLifecycle(userConfig) {
-  userConfig = userConfig || {};
   const groups = util._extend(defaultConfig.groups, userConfig.groups);
   const lifecycleGroup = groups.lifecycle || [];
   return function isLifecycle(methodName) {
@@ -121,6 +119,10 @@ module.exports = {
               }
             }
           }
+        },
+        preferLifecycle: {
+          type: 'boolean',
+          default: defaultConfig.default
         }
       },
       additionalProperties: false
@@ -132,8 +134,10 @@ module.exports = {
 
     const MISPOSITION_MESSAGE = '{{propA}} should be placed {{position}} {{propB}}';
 
-    const methodsOrder = getMethodsOrder(context.options[0]);
-    const isLifecycle = makeIsLifecycle(context.options[0]);
+    const userConfig = context.options[0] || {};
+    const methodsOrder = getMethodsOrder(userConfig);
+    const isLifecycle = makeIsLifecycle(userConfig);
+    const preferLifecycle = userConfig.preferLifecycle || defaultConfig.preferLifecycle;
 
     // --------------------------------------------------------------------------
     // Public
@@ -163,8 +167,10 @@ module.exports = {
             methodGroupIndexes.push(groupIndex);
           }
         } else if (currentGroup === 'static-methods') {
-          if (method.static && !isLifecycle(method.name)) {
-            methodGroupIndexes.push(groupIndex);
+          if (method.static) {
+            if (!(preferLifecycle && isLifecycle(method.name))) {
+              methodGroupIndexes.push(groupIndex);
+            }
           }
         } else if (currentGroup === 'instance-variables') {
           if (method.instanceVariable) {

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -75,6 +75,20 @@ function getMethodsOrder(userConfig) {
   return config;
 }
 
+/**
+ * Returns a function that check if the method name is a lifecycle method
+ * @param {Object} userConfig The user configuration.
+ * @returns {Function} isLifecycle
+ */
+function makeIsLifecycle(userConfig) {
+  userConfig = userConfig || {};
+  const groups = util._extend(defaultConfig.groups, userConfig.groups);
+  const lifecycleGroup = groups.lifecycle || [];
+  return function isLifecycle(methodName) {
+    return arrayIncludes(lifecycleGroup, methodName);
+  };
+}
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -119,6 +133,7 @@ module.exports = {
     const MISPOSITION_MESSAGE = '{{propA}} should be placed {{position}} {{propB}}';
 
     const methodsOrder = getMethodsOrder(context.options[0]);
+    const isLifecycle = makeIsLifecycle(context.options[0]);
 
     // --------------------------------------------------------------------------
     // Public
@@ -148,7 +163,7 @@ module.exports = {
             methodGroupIndexes.push(groupIndex);
           }
         } else if (currentGroup === 'static-methods') {
-          if (method.static) {
+          if (method.static && !isLifecycle(method.name)) {
             methodGroupIndexes.push(groupIndex);
           }
         } else if (currentGroup === 'instance-variables') {
@@ -159,34 +174,7 @@ module.exports = {
           if (method.instanceMethod) {
             methodGroupIndexes.push(groupIndex);
           }
-        } else if (arrayIncludes([
-          'displayName',
-          'propTypes',
-          'contextTypes',
-          'childContextTypes',
-          'mixins',
-          'statics',
-          'defaultProps',
-          'constructor',
-          'getDefaultProps',
-          'state',
-          'getInitialState',
-          'getChildContext',
-          'getDerivedStateFromProps',
-          'componentWillMount',
-          'UNSAFE_componentWillMount',
-          'componentDidMount',
-          'componentWillReceiveProps',
-          'UNSAFE_componentWillReceiveProps',
-          'shouldComponentUpdate',
-          'componentWillUpdate',
-          'UNSAFE_componentWillUpdate',
-          'getSnapshotBeforeUpdate',
-          'componentDidUpdate',
-          'componentDidCatch',
-          'componentWillUnmount',
-          'render'
-        ], currentGroup)) {
+        } else if (isLifecycle(currentGroup) || currentGroup === 'render') {
           if (currentGroup === method.name) {
             methodGroupIndexes.push(groupIndex);
           }

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -76,7 +76,7 @@ function getMethodsOrder(userConfig) {
 }
 
 /**
- * Returns a function that check if the method name is a lifecycle method
+ * Returns a function that checks if the method name is a lifecycle method
  * @param {Object} userConfig The user configuration.
  * @returns {Function} isLifecycle
  */

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -468,7 +468,7 @@ ruleTester.run('sort-comp', rule, {
     }]
   }, {
     code: [
-      '// static lifecycle methods should be grouped with lifecycle',
+      '// static lifecycle methods should be grouped under lifecycle',
       'class Hello extends React.Component {',
       '  constructor() {}',
       '  static getDerivedStateFromProps() {}',

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -468,15 +468,7 @@ ruleTester.run('sort-comp', rule, {
     }]
   }, {
     code: [
-      '// static lifecycle methods can be grouped (with statics)',
-      'class Hello extends React.Component {',
-      '  static getDerivedStateFromProps() {}',
-      '  constructor() {}',
-      '}'
-    ].join('\n')
-  }, {
-    code: [
-      '// static lifecycle methods can be grouped (with lifecycle)',
+      '// static lifecycle methods should be grouped with lifecycle',
       'class Hello extends React.Component {',
       '  constructor() {}',
       '  static getDerivedStateFromProps() {}',

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -468,12 +468,21 @@ ruleTester.run('sort-comp', rule, {
     }]
   }, {
     code: [
-      '// static lifecycle methods should be grouped under lifecycle',
+      '// by default static lifecycle methods can be grouped with static',
+      'class Hello extends React.Component {',
+      '  static getDerivedStateFromProps() {}',
+      '  constructor() {}',
+      '}'
+    ].join('\n')
+  }, {
+    code: [
+      '// static lifecycle methods should be grouped under lifecycle with the preferLifecycle set to true',
       'class Hello extends React.Component {',
       '  constructor() {}',
       '  static getDerivedStateFromProps() {}',
       '}'
-    ].join('\n')
+    ].join('\n'),
+    options: [{preferLifecycle: true}]
   }],
 
   invalid: [{
@@ -758,5 +767,15 @@ ruleTester.run('sort-comp', rule, {
         'render'
       ]
     }]
+  }, {
+    code: [
+      '// static lifecycle methods should warn if not grouped under the lifecycle group',
+      'class Hello extends React.Component {',
+      '  static getDerivedStateFromProps() {}',
+      '  constructor() {}',
+      '}'
+    ].join('\n'),
+    errors: [{message: 'getDerivedStateFromProps should be placed after constructor'}],
+    options: [{preferLifecycle: true}]
   }]
 });


### PR DESCRIPTION
Since the lifecycle group is a special group that deals with state/props changes, grouping static lifecycle methods under lifecycle group helps to have this logic together. This looks like a good default behavior that follows the docs.
This PR enforces static lifecycle methods to be grouped under `lifecycle` group as [one of possible solutions suggested](https://github.com/yannickcr/eslint-plugin-react/issues/1839#issuecomment-416658030) by @ljharb .