### PR TITLE
jsx-wrap-multilines now catches single missing newlines

### DIFF
--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -98,9 +98,19 @@ module.exports = {
       const previousToken = sourceCode.getTokenBefore(node);
       const nextToken = sourceCode.getTokenAfter(node);
 
-      return isParenthesised(node) &&
-        previousToken.loc.end.line === node.loc.start.line &&
-        node.loc.end.line === nextToken.loc.end.line;
+      if (!isParenthesised(node)) {
+        return false;
+      }
+
+      if (previousToken.loc.end.line === node.loc.start.line) {
+        return true;
+      }
+
+      if (node.loc.end.line === nextToken.loc.end.line) {
+        return true;
+      }
+
+      return false;
     }
 
     function isMultilines(node) {
@@ -151,7 +161,11 @@ module.exports = {
             report(node, MISSING_PARENS, fixer => fixer.replaceText(node, `(\n${sourceCode.getText(node)}\n)`));
           }
         } else if (needsNewLines(node)) {
-          report(node, PARENS_NEW_LINES, fixer => fixer.replaceText(node, `\n${sourceCode.getText(node)}\n`));
+          report(node, PARENS_NEW_LINES, fixer => {
+            const text = sourceCode.getText(node);
+            const fixed = text.replace(/^\n?((.|\n)*?)\n?$/, '\n$1\n');
+            return fixer.replaceText(node, fixed);
+          });
         }
       }
     }

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -94,9 +94,8 @@ module.exports = {
         nextToken.value === ')' && nextToken.range[0] >= node.range[1];
     }
 
-    function needsNewLines(node) {
+    function needsOpeningNewLine(node) {
       const previousToken = sourceCode.getTokenBefore(node);
-      const nextToken = sourceCode.getTokenAfter(node);
 
       if (!isParenthesised(node)) {
         return false;
@@ -104,6 +103,16 @@ module.exports = {
 
       if (previousToken.loc.end.line === node.loc.start.line) {
         return true;
+      }
+
+      return false;
+    }
+
+    function needsClosingNewLine(node) {
+      const nextToken = sourceCode.getTokenAfter(node);
+
+      if (!isParenthesised(node)) {
+        return false;
       }
 
       if (node.loc.end.line === nextToken.loc.end.line) {
@@ -160,12 +169,22 @@ module.exports = {
           } else {
             report(node, MISSING_PARENS, fixer => fixer.replaceText(node, `(\n${sourceCode.getText(node)}\n)`));
           }
-        } else if (needsNewLines(node)) {
-          report(node, PARENS_NEW_LINES, fixer => {
-            const text = sourceCode.getText(node);
-            const fixed = text.replace(/^\n?((.|\n)*?)\n?$/, '\n$1\n');
-            return fixer.replaceText(node, fixed);
-          });
+        } else {
+          const needsOpening = needsOpeningNewLine(node);
+          const needsClosing = needsClosingNewLine(node);
+          if (needsOpening || needsClosing) {
+            report(node, PARENS_NEW_LINES, fixer => {
+              const text = sourceCode.getText(node);
+              let fixed = text;
+              if (needsOpening) {
+                fixed = `\n${fixed}`;
+              }
+              if (needsClosing) {
+                fixed = `${fixed}\n`;
+              }
+              return fixer.replaceText(node, fixed);
+            });
+          }
         }
       }
     }

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -86,6 +86,30 @@ const RETURN_PAREN_NEW_LINE = `
   });
 `;
 
+const RETURN_PAREN_NEW_LINE_OPENING = `
+  var Hello = createReactClass({
+    render: function() {
+      return (
+
+      <div>
+        <p>Hello {this.props.name}</p>
+      </div>);
+    }
+  });
+`;
+
+const RETURN_PAREN_NEW_LINE_CLOSING = `
+  var Hello = createReactClass({
+    render: function() {
+      return (<div>
+        <p>Hello {this.props.name}</p>
+      </div>
+
+      );
+    }
+  });
+`;
+
 const RETURN_PAREN_NEW_LINE_FRAGMENT = `
   var Hello = createReactClass({
     render: function() {
@@ -501,7 +525,7 @@ const ATTR_PAREN_NEW_LINE_AUTOFIX_FRAGMENT = `
 `;
 
 function addNewLineSymbols(code) {
-  return code.replace(/\(</g, '(\n<').replace(/>\)/g, '>\n)');
+  return code.replace(/\((\s*)</g, '($1\n<').replace(/>(\s*)\)/g, '>\n$1)');
 }
 
 // ------------------------------------------------------------------------------
@@ -910,6 +934,16 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     }, {
       code: RETURN_PAREN,
       output: addNewLineSymbols(RETURN_PAREN),
+      options: [{return: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: RETURN_PAREN_NEW_LINE_OPENING,
+      output: addNewLineSymbols(RETURN_PAREN_NEW_LINE_OPENING),
+      options: [{return: 'parens-new-line'}],
+      errors: [{message: PARENS_NEW_LINES}]
+    }, {
+      code: RETURN_PAREN_NEW_LINE_CLOSING,
+      output: addNewLineSymbols(RETURN_PAREN_NEW_LINE_CLOSING),
       options: [{return: 'parens-new-line'}],
       errors: [{message: PARENS_NEW_LINES}]
     }, {

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -98,10 +98,36 @@ const RETURN_PAREN_NEW_LINE_OPENING = `
   });
 `;
 
+const RETURN_PAREN_NEW_LINE_OPENING_FIXED = `
+  var Hello = createReactClass({
+    render: function() {
+      return (
+
+      <div>
+        <p>Hello {this.props.name}</p>
+      </div>
+);
+    }
+  });
+`;
+
 const RETURN_PAREN_NEW_LINE_CLOSING = `
   var Hello = createReactClass({
     render: function() {
       return (<div>
+        <p>Hello {this.props.name}</p>
+      </div>
+
+      );
+    }
+  });
+`;
+
+const RETURN_PAREN_NEW_LINE_CLOSING_FIXED = `
+  var Hello = createReactClass({
+    render: function() {
+      return (
+<div>
         <p>Hello {this.props.name}</p>
       </div>
 
@@ -525,7 +551,7 @@ const ATTR_PAREN_NEW_LINE_AUTOFIX_FRAGMENT = `
 `;
 
 function addNewLineSymbols(code) {
-  return code.replace(/\((\s*)</g, '($1\n<').replace(/>(\s*)\)/g, '>\n$1)');
+  return code.replace(/\(</g, '(\n<').replace(/>\)/g, '>\n)');
 }
 
 // ------------------------------------------------------------------------------
@@ -938,12 +964,12 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       errors: [{message: PARENS_NEW_LINES}]
     }, {
       code: RETURN_PAREN_NEW_LINE_OPENING,
-      output: addNewLineSymbols(RETURN_PAREN_NEW_LINE_OPENING),
+      output: RETURN_PAREN_NEW_LINE_OPENING_FIXED,
       options: [{return: 'parens-new-line'}],
       errors: [{message: PARENS_NEW_LINES}]
     }, {
       code: RETURN_PAREN_NEW_LINE_CLOSING,
-      output: addNewLineSymbols(RETURN_PAREN_NEW_LINE_CLOSING),
+      output: RETURN_PAREN_NEW_LINE_CLOSING_FIXED,
       options: [{return: 'parens-new-line'}],
       errors: [{message: PARENS_NEW_LINES}]
     }, {


### PR DESCRIPTION
Fixes #1965. The only interesting question is how the fixer should treat the newlines. I chose to make it add a new line if there was exactly zero after or before the parens. This means:

```
  var Hello = createReactClass({
    render: function() {
      return (<div>
        <p>Hello {this.props.name}</p>
      </div>
      );
    }
  });
```

Fixes to:

```
  var Hello = createReactClass({
    render: function() {
      return (
<div>
        <p>Hello {this.props.name}</p>
      </div>
      );
    }
  });
```

----

And:

```
  var Hello = createReactClass({
    render: function() {
      return (<div>
        <p>Hello {this.props.name}</p>
      </div>

      );
    }
  });
```

Fixes to:

```
  var Hello = createReactClass({
    render: function() {
      return (
<div>
        <p>Hello {this.props.name}</p>
      </div>

      );
    }
  });
```

----

The alternative would be to make exactly _one_ newline regardless of how many there were before -- but I assumed such a behavior should be its own rule instead of attached to this rule.