### PR TITLE
ensure jsx-sort-props fixer respects callbacksLast

### DIFF
--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -35,12 +35,20 @@ function propNameCompare(a, b, options) {
   if (options.reservedFirst) {
     const aIsReserved = isReservedPropName(a, options.reservedList);
     const bIsReserved = isReservedPropName(b, options.reservedList);
-    if ((aIsReserved && bIsReserved) || (!aIsReserved && !bIsReserved)) {
-      return a.localeCompare(b);
-    } else if (aIsReserved && !bIsReserved) {
+    if (aIsReserved && !bIsReserved) {
       return -1;
+    } else if (!aIsReserved && bIsReserved) {
+      return 1;
     }
-    return 1;
+  }
+  if (options.callbacksLast) {
+    const aIsCallback = isCallbackPropName(a);
+    const bIsCallback = isCallbackPropName(b);
+    if (!aIsCallback && bIsCallback) {
+      return -1;
+    } else if (aIsCallback && !bIsCallback) {
+      return 1;
+    }
   }
   return a.localeCompare(b);
 }
@@ -80,6 +88,7 @@ const generateFixerFunction = (node, context, reservedList) => {
   const configuration = context.options[0] || {};
   const ignoreCase = configuration.ignoreCase || false;
   const reservedFirst = configuration.reservedFirst || false;
+  const callbacksLast = configuration.reservedFirst || false;
 
   // Sort props according to the context. Only supports ignoreCase.
   // Since we cannot safely move JSXSpreadAttribute (due to potential variable overrides),
@@ -87,7 +96,7 @@ const generateFixerFunction = (node, context, reservedList) => {
   const sortableAttributeGroups = getGroupsOfSortableAttributes(attributes);
   const sortedAttributeGroups = sortableAttributeGroups.slice(0).map(group =>
     group.slice(0).sort((a, b) =>
-      propNameCompare(propName(a), propName(b), {ignoreCase, reservedFirst, reservedList})
+      propNameCompare(propName(a), propName(b), {ignoreCase, reservedFirst, reservedList, callbacksLast})
     )
   );
 
@@ -267,7 +276,8 @@ module.exports = {
               // Encountered a non-callback prop after a callback prop
               context.report({
                 node: memo,
-                message: 'Callbacks must be listed after all other props'
+                message: 'Callbacks must be listed after all other props',
+                fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
             }


### PR DESCRIPTION
The jsx-sort-props fixer would not place all callback props last if the option was enabled. This patch fixes that.

I tested on a React component which previously, when applying the fixer, sorted its props alphabetically and did not place the callbacks last.