### PR TITLE
Fix `no-this-in-sfc` for class properties

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -457,14 +457,13 @@ function componentRule(rule, context) {
       while (scope) {
         const node = scope.block;
         const isFunction = /Function/.test(node.type); // Functions
-        const isArrowFunction = node.type === 'ArrowFunctionExpression';
+        const isArrowFunction = astUtil.isArrowFunction(node);
         let enclosingScope = scope;
         if (isArrowFunction) {
           enclosingScope = utils.getArrowFunctionScope(scope);
         }
-        const enclosingScopeType = enclosingScope && enclosingScope.block.type;
         const enclosingScopeParent = enclosingScope && enclosingScope.block.parent;
-        const isClass = enclosingScopeType === 'ClassDeclaration' || enclosingScopeType === 'ClassExpression';
+        const isClass = enclosingScope && astUtil.isClass(enclosingScope.block);
         const isMethod = enclosingScopeParent && enclosingScopeParent.type === 'MethodDefinition'; // Classes methods
         const isArgument = node.parent && node.parent.type === 'CallExpression'; // Arguments (callback, etc.)
         // Attribute Expressions inside JSX Elements (<button onClick={() => props.handleClick()}></button>)
@@ -490,9 +489,7 @@ function componentRule(rule, context) {
     getArrowFunctionScope(scope) {
       scope = scope.upper;
       while (scope) {
-        const type = scope.block.type;
-        if (type === 'FunctionExpression' || type === 'FunctionDeclaration'
-            || type === 'ClassDeclaration' || type === 'ClassExpression') {
+        if (astUtil.isFunction(scope.block) || astUtil.isClass(scope.block)) {
           return scope;
         }
         scope = scope.upper;

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -458,10 +458,7 @@ function componentRule(rule, context) {
         const node = scope.block;
         const isFunction = /Function/.test(node.type); // Functions
         const isArrowFunction = astUtil.isArrowFunction(node);
-        let enclosingScope = scope;
-        if (isArrowFunction) {
-          enclosingScope = utils.getArrowFunctionScope(scope);
-        }
+        const enclosingScope = isArrowFunction ? utils.getArrowFunctionScope(scope) : scope;
         const enclosingScopeParent = enclosingScope && enclosingScope.block.parent;
         const isClass = enclosingScope && astUtil.isClass(enclosingScope.block);
         const isMethod = enclosingScopeParent && enclosingScopeParent.type === 'MethodDefinition'; // Classes methods

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -456,15 +456,16 @@ function componentRule(rule, context) {
       let scope = context.getScope();
       while (scope) {
         const node = scope.block;
-        const isClass = node.type === 'ClassExpression';
         const isFunction = /Function/.test(node.type); // Functions
         const isArrowFunction = node.type === 'ArrowFunctionExpression';
-        let functionScope = scope;
+        let enclosingScope = scope;
         if (isArrowFunction) {
-          functionScope = utils.getParentFunctionScope(scope);
+          enclosingScope = utils.getArrowFunctionScope(scope);
         }
-        const methodNode = functionScope && functionScope.block.parent;
-        const isMethod = methodNode && methodNode.type === 'MethodDefinition'; // Classes methods
+        const enclosingScopeType = enclosingScope && enclosingScope.block.type;
+        const enclosingScopeParent = enclosingScope && enclosingScope.block.parent;
+        const isClass = enclosingScopeType === 'ClassDeclaration' || enclosingScopeType === 'ClassExpression';
+        const isMethod = enclosingScopeParent && enclosingScopeParent.type === 'MethodDefinition'; // Classes methods
         const isArgument = node.parent && node.parent.type === 'CallExpression'; // Arguments (callback, etc.)
         // Attribute Expressions inside JSX Elements (<button onClick={() => props.handleClick()}></button>)
         const isJSXExpressionContainer = node.parent && node.parent.type === 'JSXExpressionContainer';
@@ -482,15 +483,16 @@ function componentRule(rule, context) {
     },
 
     /**
-     * Get a parent scope created by a FunctionExpression or FunctionDeclaration
-     * @param {Scope} scope The child scope
-     * @returns {Scope} A parent function scope
+     * Get an enclosing scope used to find `this` value by an arrow function
+     * @param {Scope} scope Current scope
+     * @returns {Scope} An enclosing scope used by an arrow function
      */
-    getParentFunctionScope(scope) {
+    getArrowFunctionScope(scope) {
       scope = scope.upper;
       while (scope) {
         const type = scope.block.type;
-        if (type === 'FunctionExpression' || type === 'FunctionDeclaration') {
+        if (type === 'FunctionExpression' || type === 'FunctionDeclaration'
+            || type === 'ClassDeclaration' || type === 'ClassExpression') {
           return scope;
         }
         scope = scope.upper;

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -102,11 +102,41 @@ function isFunctionLikeExpression(node) {
   return node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression';
 }
 
+/**
+ * Checks if the node is a function.
+ * @param {Object} context The node to check
+ * @return {Boolean} true if it's a function
+ */
+function isFunction(node) {
+  return node.type === 'FunctionExpression' || node.type === 'FunctionDeclaration';
+}
+
+/**
+ * Checks if the node is an arrow function.
+ * @param {Object} context The node to check
+ * @return {Boolean} true if it's an arrow function
+ */
+function isArrowFunction(node) {
+  return node.type === 'ArrowFunctionExpression';
+}
+
+/**
+ * Checks if the node is a class.
+ * @param {Object} context The node to check
+ * @return {Boolean} true if it's a class
+ */
+function isClass(node) {
+  return node.type === 'ClassDeclaration' || node.type === 'ClassExpression';
+}
+
 module.exports = {
   findReturnStatement: findReturnStatement,
   getPropertyName: getPropertyName,
   getPropertyNameNode: getPropertyNameNode,
   getComponentProperties: getComponentProperties,
-  isNodeFirstInLine: isNodeFirstInLine,
-  isFunctionLikeExpression: isFunctionLikeExpression
+  isArrowFunction: isArrowFunction,
+  isClass: isClass,
+  isFunction: isFunction,
+  isFunctionLikeExpression: isFunctionLikeExpression,
+  isNodeFirstInLine: isNodeFirstInLine
 };

--- a/tests/lib/rules/no-this-in-sfc.js
+++ b/tests/lib/rules/no-this-in-sfc.js
@@ -16,8 +16,6 @@ const ERROR_MESSAGE = 'Stateless functional components should not use this';
 const rule = require('../../../lib/rules/no-this-in-sfc');
 const RuleTester = require('eslint').RuleTester;
 
-require('babel-eslint');
-
 const parserOptions = {
   ecmaVersion: 2018,
   sourceType: 'module',

--- a/tests/lib/rules/no-this-in-sfc.js
+++ b/tests/lib/rules/no-this-in-sfc.js
@@ -16,6 +16,8 @@ const ERROR_MESSAGE = 'Stateless functional components should not use this';
 const rule = require('../../../lib/rules/no-this-in-sfc');
 const RuleTester = require('eslint').RuleTester;
 
+require('babel-eslint');
+
 const parserOptions = {
   ecmaVersion: 2018,
   sourceType: 'module',
@@ -119,6 +121,24 @@ ruleTester.run('no-this-in-sfc', rule, {
         };
       }
     }`
+  }, {
+    code: `
+    class Foo {
+      bar = () => {
+        this.something();
+        return null;
+      };
+    }`,
+    parser: 'babel-eslint'
+  }, {
+    code: `
+    class Foo {
+      bar = () => () => {
+        this.something();
+        return null;
+      };
+    }`,
+    parser: 'babel-eslint'
   }],
   invalid: [{
     code: `


### PR DESCRIPTION
The PR fixes #1960 - `no-this-in-sfc` rule for class properties.

Class properties example:
```js
class Foo {
  bar = () => {
    this.something();
    return null;
  };
}
```

The corresponding AST: [link](https://astexplorer.net/#/gist/01be31cd9af1884c028099be843c3bab/ade0ae41ec5b2a03737618519741454bdaa0dc33).

