### PR TITLE
Supporting async/await in `no-did-mount-setstate` rule

### DIFF
--- a/docs/rules/no-did-mount-set-state.md
+++ b/docs/rules/no-did-mount-set-state.md
@@ -49,6 +49,20 @@ var Hello = createReactClass({
 });
 ```
 
+```jsx
+var Hello = createReactClass({
+  componentDidMount: async function() {
+    const newName = await getName();
+    this.setState({
+      name: newName
+    });
+  },
+  render: function() {
+    return <div>Hello {this.state.name}</div>;
+  }
+});
+```
+
 ## Rule Options
 
 ```js

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -40,6 +40,11 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
         return false;
       }
 
+      function hasAsyncBefore(ancestor, callee) {
+        return context.getTokensBetween(context.getFirstToken(ancestor), callee)
+          .filter(token => token.value === 'await').length;
+      }
+
       // --------------------------------------------------------------------------
       // Public
       // --------------------------------------------------------------------------
@@ -67,6 +72,9 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
               !nameMatches(ancestor.key.name) ||
               (mode !== 'disallow-in-func' && depth > 1)
             ) {
+              continue;
+            }
+            if (ancestor.value.async && hasAsyncBefore(ancestor, callee)) {
               continue;
             }
             context.report({

--- a/tests/lib/rules/no-did-mount-set-state.js
+++ b/tests/lib/rules/no-did-mount-set-state.js
@@ -77,6 +77,18 @@ ruleTester.run('no-did-mount-set-state', rule, {
       });
     `,
     parser: 'babel-eslint'
+  }, {
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: async function() {
+          const data = await getFromServer(this.props);
+          this.setState({
+            data: data
+          });
+        }
+      });
+    `,
+    parser: 'babel-eslint'
   }],
 
   invalid: [{
@@ -222,6 +234,24 @@ ruleTester.run('no-did-mount-set-state', rule, {
     `,
     parser: 'babel-eslint',
     options: ['disallow-in-func'],
+    errors: [{
+      message: 'Do not use setState in componentDidMount'
+    }]
+  }, {
+    code: `
+      var Hello = createReactClass({
+        componentDidMount: async function() {
+          this.setState({
+            loading: true
+          });
+          const data = await getFromServer(this.props);
+          this.setState({
+            loading: false,
+            data: data
+          });
+        }
+      });
+    `,
     errors: [{
       message: 'Do not use setState in componentDidMount'
     }]


### PR DESCRIPTION
Pretty naive approach: checking if the call is in an `async` method and if an `await` is found before `setState` (going over tokens).

Fixes #1110.