### PR TITLE
check used state when using ternary assignment

### DIFF
--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -170,6 +170,11 @@ module.exports = {
     // Used to record used state fields and new aliases for both
     // AssignmentExpressions and VariableDeclarators.
     function handleAssignment(left, right) {
+      if (right.type === 'ConditionalExpression') {
+        handleAssignment(left, right.consequent);
+        handleAssignment(left, right.alternate);
+        return;
+      }
       switch (left.type) {
         case 'Identifier':
           if (isStateReference(right) && classInfo.aliases) {

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -257,6 +257,15 @@ eslintTester.run('no-unused-state', rule, {
           return <SomeComponent foo={foo} />;
         }
       }`,
+    `class ShorthandDestructuringWithTernaryOperatorTest extends React.Component {
+            constructor() {
+              this.state = { foo: 0 };
+            }
+            render() {
+              const {foo} = true ? this.state : {};
+              return <SomeComponent bar={foo} />;
+            }
+          }`,
     `class AliasDeclarationTest extends React.Component {
         constructor() {
           this.state = { foo: 0 };


### PR DESCRIPTION
fixes ternary assignment with destructuring
```javascript
render() {
    const {foo} = true ? this.state : {};
    return <SomeComponent bar={foo} />;
}
```
would result in `unused state field foo`, although the field is used.