### PR TITLE
Use `loc` version of `end`, to handle parsers that don't fill `name.end`.

### DIFF
--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -45,7 +45,7 @@ module.exports = {
                 node: decl,
                 message: 'Property should be placed on a new line',
                 fix: function(fixer) {
-                  return fixer.replaceTextRange([node.name.end, decl.range[0]], '\n');
+                  return fixer.replaceTextRange([node.name.range[1], decl.range[0]], '\n');
                 }
               });
             }
@@ -58,7 +58,7 @@ module.exports = {
               node: firstNode,
               message: 'Property should be placed on the same line as the component declaration',
               fix: function(fixer) {
-                return fixer.replaceTextRange([node.name.end, firstNode.range[0]], ' ');
+                return fixer.replaceTextRange([node.name.range[1], firstNode.range[0]], ' ');
               }
             });
             return;

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "coveralls": "^3.0.1",
     "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0",
     "istanbul": "^0.4.5",
-    "mocha": "^5.2.0"
+    "mocha": "^5.2.0",
+    "typescript": "^3.1.3",
+    "typescript-eslint-parser": "^20.0.0"
   },
   "peerDependencies": {
     "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0"

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -130,6 +130,17 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       parser: 'babel-eslint'
     },
     {
+      code: [
+        '<Foo ',
+        '  foo={{',
+        '  }}',
+        '  bar',
+        '/>'
+      ].join('\n'),
+      options: ['multiline-multiprop'],
+      parser: 'typescript-eslint-parser'
+    },
+    {
       code: '<Foo />',
       options: ['always'],
       parser: 'babel-eslint'
@@ -168,6 +179,16 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       parser: 'babel-eslint'
     },
     {
+      code: '<Foo propOne="one" propTwo="two" />',
+      output: [
+        '<Foo',
+        'propOne="one" propTwo="two" />'
+      ].join('\n'),
+      options: ['always'],
+      errors: [{message: 'Property should be placed on a new line'}],
+      parser: 'typescript-eslint-parser'
+    },
+    {
       code: [
         '<Foo propOne="one"',
         '  propTwo="two"',
@@ -182,6 +203,22 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       options: ['always'],
       errors: [{message: 'Property should be placed on a new line'}],
       parser: 'babel-eslint'
+    },
+    {
+      code: [
+        '<Foo propOne="one"',
+        '  propTwo="two"',
+        '/>'
+      ].join('\n'),
+      output: [
+        '<Foo',
+        'propOne="one"',
+        '  propTwo="two"',
+        '/>'
+      ].join('\n'),
+      options: ['always'],
+      errors: [{message: 'Property should be placed on a new line'}],
+      parser: 'typescript-eslint-parser'
     },
     {
       code: [
@@ -201,6 +238,22 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
     },
     {
       code: [
+        '<Foo',
+        '  propOne="one"',
+        '  propTwo="two"',
+        '/>'
+      ].join('\n'),
+      output: [
+        '<Foo propOne="one"',
+        '  propTwo="two"',
+        '/>'
+      ].join('\n'),
+      options: ['never'],
+      errors: [{message: 'Property should be placed on the same line as the component declaration'}],
+      parser: 'typescript-eslint-parser'
+    },
+    {
+      code: [
         '<Foo prop={{',
         '}} />'
       ].join('\n'),
@@ -210,6 +263,34 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '}} />'
       ].join('\n'),
       options: ['multiline'],
+      errors: [{message: 'Property should be placed on a new line'}],
+      parser: 'babel-eslint'
+    },
+    {
+      code: [
+        '<Foo prop={{',
+        '}} />'
+      ].join('\n'),
+      output: [
+        '<Foo',
+        'prop={{',
+        '}} />'
+      ].join('\n'),
+      options: ['multiline'],
+      errors: [{message: 'Property should be placed on a new line'}],
+      parser: 'typescript-eslint-parser'
+    },
+    {
+      code: [
+        '<Foo bar={{',
+        '}} baz />'
+      ].join('\n'),
+      output: [
+        '<Foo',
+        'bar={{',
+        '}} baz />'
+      ].join('\n'),
+      options: ['multiline-multiprop'],
       errors: [{message: 'Property should be placed on a new line'}],
       parser: 'babel-eslint'
     },
@@ -225,7 +306,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
       ].join('\n'),
       options: ['multiline-multiprop'],
       errors: [{message: 'Property should be placed on a new line'}],
-      parser: 'babel-eslint'
+      parser: 'typescript-eslint-parser'
     }
   ]
 });


### PR DESCRIPTION
Not all parsers fill the `name.end` field in the AST structure so relying on it is less robust. 
Ref: https://github.com/babel/babel/issues/6681     
But the `range` syntax is widely supported (babel has a flag). 

I ran into this issue using the `typescript-eslint-parser` which does not add `start` and `end` to the nodes, but has range.

Here is an example to see the difference:
https://astexplorer.net/#/gist/c336be172990d7b467d1ed3dbc1882ee/d312c83cd24626d2e82ba791add48fe061b7cdc0