### PR TITLE
Apply allowInPropTypes option to class property

### DIFF
--- a/lib/rules/forbid-foreign-prop-types.js
+++ b/lib/rules/forbid-foreign-prop-types.js
@@ -52,6 +52,18 @@ module.exports = {
       return null;
     }
 
+    function findParentClassProperty(node) {
+      let parent = node.parent;
+
+      while (parent && parent.type !== 'Program') {
+        if (parent.type === 'ClassProperty') {
+          return parent;
+        }
+        parent = parent.parent;
+      }
+      return null;
+    }
+
     function isAllowedAssignment(node) {
       if (!allowInPropTypes) {
         return false;
@@ -64,6 +76,16 @@ module.exports = {
         assignmentExpression.left &&
         assignmentExpression.left.property &&
         assignmentExpression.left.property.name === 'propTypes'
+      ) {
+        return true;
+      }
+
+      const classProperty = findParentClassProperty(node);
+
+      if (
+        classProperty &&
+        classProperty.key &&
+        classProperty.key.name === 'propTypes'
       ) {
         return true;
       }

--- a/tests/lib/rules/forbid-foreign-prop-types.js
+++ b/tests/lib/rules/forbid-foreign-prop-types.js
@@ -62,6 +62,19 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
     options: [{
       allowInPropTypes: true
     }]
+  },
+  {
+    code: `
+      class MyComponent extends React.Component {
+        static propTypes = {
+          baz: Qux.propTypes.baz
+        };
+      }
+    `,
+    parser: 'babel-eslint',
+    options: [{
+      allowInPropTypes: true
+    }]
   }],
 
   invalid: [{
@@ -163,6 +176,23 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
         name: Message.propTypes.message
       };
     `,
+    options: [{
+      allowInPropTypes: false
+    }],
+    errors: [{
+      message: ERROR_MESSAGE,
+      type: 'Identifier'
+    }]
+  },
+  {
+    code: `
+      class MyComponent extends React.Component {
+        static propTypes = {
+          baz: Qux.propTypes.baz
+        };
+      }
+    `,
+    parser: 'babel-eslint',
     options: [{
       allowInPropTypes: false
     }],


### PR DESCRIPTION
Fix @csantos1113 problem in #2023 

### Problem
The `allowInPropTypes` option can't apply following definition for `propTypes`.

```
const space = () => {};
space.propTypes = {
    name: PropTypes.string
};

export default class List extends PureComponent {
  static propTypes = {
    ...space.propTypes, // but I'm getting the warning here!
    message: PropTypes.string
  }

  render() {
     return <div>{this.props.message}</div>
  }
}
```

### Reason
Got following node hierarchy when define `propTypes` by each method, `AssignmentExpression` is only contained by the latter.
```
# define by static propTypes = {}
ExperimentalSpreadProperty
	ObjectExpression
		ClassProperty
```
```
# define by Class.propTypes = {}
ExperimentalSpreadProperty
	ObjectExpression
		AssignmentExpression
```