### PR TITLE
Remove debatable statement on perf in jsx-no-bind

### DIFF
--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -1,6 +1,6 @@
 # No `.bind()` or Arrow Functions in JSX Props (react/jsx-no-bind)
 
-A `bind` call or [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) in a JSX prop will create a brand new function on every single render. This is bad for performance, as it will result in the garbage collector being invoked way more than is necessary. It may also cause unnecessary re-renders if a brand new function is passed as a prop to a component that uses reference equality check on the prop to determine if it should update.
+A `bind` call or [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) in a JSX prop will create a brand new function on every single render. This is bad for performance, as it may cause unnecessary re-renders if a brand new function is passed as a prop to a component that uses reference equality check on the prop to determine if it should update.
 
 ## Rule Details
 


### PR DESCRIPTION
## Overview

The PR removes a controversial and debatable line that is the source of much confusion

See: 
- https://twitter.com/sophiebits/status/1069150849467731968
- https://cdb.reacttraining.com/react-inline-functions-and-performance-bdff784f5578?gi=cfceda6d7a59

