### PR TITLE
Adjust `no-unsafe` rule to handle all unsafe life-cycle methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Enable the rules that you would like to use.
 * [react/no-this-in-sfc](docs/rules/no-this-in-sfc.md): Prevent using `this` in stateless functional components
 * [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md): Prevent invalid characters from appearing in markup
 * [react/no-unknown-property](docs/rules/no-unknown-property.md): Prevent usage of unknown DOM property (fixable)
-* [react/no-unsafe](docs/rules/no-unsafe.md): Prevent usage of `UNSAFE_` methods
+* [react/no-unsafe](docs/rules/no-unsafe.md): Prevent usage of unsafe lifecycle methods
 * [react/no-unused-prop-types](docs/rules/no-unused-prop-types.md): Prevent definitions of unused prop types
 * [react/no-unused-state](docs/rules/no-unused-state.md): Prevent definitions of unused state properties
 * [react/no-will-update-set-state](docs/rules/no-will-update-set-state.md): Prevent usage of `setState` in `componentWillUpdate`

--- a/docs/rules/no-unsafe.md
+++ b/docs/rules/no-unsafe.md
@@ -17,12 +17,6 @@ The following patterns are considered warnings:
 
 ```jsx
 class Foo extends React.Component {
-  componentWillMount() {}
-  componentWillReceiveProps() {}
-  componentWillUpdate() {}
-}
-// or
-class Foo extends React.Component {
   UNSAFE_componentWillMount() {}
   UNSAFE_componentWillReceiveProps() {}
   UNSAFE_componentWillUpdate() {}
@@ -30,12 +24,6 @@ class Foo extends React.Component {
 ```
 
 ```jsx
-const Foo = createReactClass({
-  componentWillMount: function() {},
-  componentWillReceiveProps: function() {},
-  componentWillUpdate: function() {}
-});
-// or
 const Foo = createReactClass({
   UNSAFE_componentWillMount: function() {},
   UNSAFE_componentWillReceiveProps: function() {},
@@ -47,12 +35,6 @@ The following patterns are **not** considered warnings:
 
 ```jsx
 class Foo extends Bar {
-  componentWillMount() {}
-  componentWillReceiveProps() {}
-  componentWillUpdate() {}
-}
-// or
-class Foo extends Bar {
   UNSAFE_componentWillMount() {}
   UNSAFE_componentWillReceiveProps() {}
   UNSAFE_componentWillUpdate() {}
@@ -61,14 +43,55 @@ class Foo extends Bar {
 
 ```jsx
 const Foo = bar({
+  UNSAFE_componentWillMount: function() {},
+  UNSAFE_componentWillReceiveProps: function() {},
+  UNSAFE_componentWillUpdate: function() {}
+});
+```
+
+## Rule Options
+```json
+...
+"react/no-unsafe": [<enabled>, { "checkAliases": <boolean> }]
+...
+```
+
+### `checkAliases` (default: `false`)
+
+When `true` the rule will also check aliases of unsafe methods: `componentWillMount`, `componentWillReceiveProps`, `componentWillUpdate`.
+
+The following patterns are considered warnings:
+
+```jsx
+class Foo extends React.Component {
+  componentWillMount() {}
+  componentWillReceiveProps() {}
+  componentWillUpdate() {}
+}
+```
+
+```jsx
+const Foo = createReactClass({
   componentWillMount: function() {},
   componentWillReceiveProps: function() {},
   componentWillUpdate: function() {}
 });
-// or
+```
+
+The following patterns are **not** considered warnings:
+
+```jsx
+class Foo extends Bar {
+  componentWillMount() {}
+  componentWillReceiveProps() {}
+  componentWillUpdate() {}
+}
+```
+
+```jsx
 const Foo = bar({
-  UNSAFE_componentWillMount: function() {},
-  UNSAFE_componentWillReceiveProps: function() {},
-  UNSAFE_componentWillUpdate: function() {}
+  componentWillMount: function() {},
+  componentWillReceiveProps: function() {},
+  componentWillUpdate: function() {}
 });
 ```

--- a/docs/rules/no-unsafe.md
+++ b/docs/rules/no-unsafe.md
@@ -1,4 +1,4 @@
-# Prevent usage of `UNSAFE_` methods (react/no-unsafe)
+# Prevent usage of unsafe lifecycle methods (react/no-unsafe)
 
 Certain legacy lifecycle methods are [unsafe for use in async React applications][async_rendering] and cause warnings in [_strict mode_][strict_mode]. These also happen to be the lifecycles that cause the most [confusion within the React community][component_lifecycle_changes].
 
@@ -6,13 +6,22 @@ Certain legacy lifecycle methods are [unsafe for use in async React applications
 [strict_mode]: https://reactjs.org/docs/strict-mode.html#identifying-unsafe-lifecycles
 [component_lifecycle_changes]: https://reactjs.org/blog/2018/03/29/react-v-16-3.html#component-lifecycle-changes
 
-The rule checks the following methods: `UNSAFE_componentWillMount`, `UNSAFE_componentWillReceiveProps`, `UNSAFE_componentWillUpdate`.
+The rule checks the following methods: 
+- `componentWillMount` (and `UNSAFE_componentWillMount` alias)
+- `componentWillReceiveProps` (and `UNSAFE_componentWillReceiveProps` alias)
+- `componentWillUpdate` (and `UNSAFE_componentWillUpdate` alias)
 
 ## Rule Details
 
 The following patterns are considered warnings:
 
 ```jsx
+class Foo extends React.Component {
+  componentWillMount() {}
+  componentWillReceiveProps() {}
+  componentWillUpdate() {}
+}
+// or
 class Foo extends React.Component {
   UNSAFE_componentWillMount() {}
   UNSAFE_componentWillReceiveProps() {}
@@ -21,6 +30,12 @@ class Foo extends React.Component {
 ```
 
 ```jsx
+const Foo = createReactClass({
+  componentWillMount: function() {},
+  componentWillReceiveProps: function() {},
+  componentWillUpdate: function() {}
+});
+// or
 const Foo = createReactClass({
   UNSAFE_componentWillMount: function() {},
   UNSAFE_componentWillReceiveProps: function() {},
@@ -32,6 +47,12 @@ The following patterns are **not** considered warnings:
 
 ```jsx
 class Foo extends Bar {
+  componentWillMount() {}
+  componentWillReceiveProps() {}
+  componentWillUpdate() {}
+}
+// or
+class Foo extends Bar {
   UNSAFE_componentWillMount() {}
   UNSAFE_componentWillReceiveProps() {}
   UNSAFE_componentWillUpdate() {}
@@ -39,6 +60,12 @@ class Foo extends Bar {
 ```
 
 ```jsx
+const Foo = bar({
+  componentWillMount: function() {},
+  componentWillReceiveProps: function() {},
+  componentWillUpdate: function() {}
+});
+// or
 const Foo = bar({
   UNSAFE_componentWillMount: function() {},
   UNSAFE_componentWillReceiveProps: function() {},

--- a/lib/rules/no-unsafe.js
+++ b/lib/rules/no-unsafe.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Prevent usage of UNSAFE_ methods
+ * @fileoverview Prevent usage of unsafe lifecycle methods
  * @author Sergei Startsev
  */
 
@@ -17,7 +17,7 @@ const versionUtil = require('../util/version');
 module.exports = {
   meta: {
     docs: {
-      description: 'Prevent usage of UNSAFE_ methods',
+      description: 'Prevent usage of unsafe lifecycle methods',
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-unsafe')
@@ -31,16 +31,29 @@ module.exports = {
       return {};
     }
 
+    const unsafe = {};
+    unsafe.componentWillMount = unsafe.UNSAFE_componentWillMount = {
+      newMethod: 'componentDidMount',
+      details:
+        'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+    };
+    unsafe.componentWillReceiveProps = unsafe.UNSAFE_componentWillReceiveProps = {
+      newMethod: 'getDerivedStateFromProps',
+      details:
+        'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+    };
+    unsafe.componentWillUpdate = unsafe.UNSAFE_componentWillUpdate = {
+      newMethod: 'componentDidUpdate',
+      details:
+        'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+    };
+
     /**
      * Returns a list of unsafe methods
      * @returns {Array} A list of unsafe methods
      */
     function getUnsafeMethods() {
-      return [
-        'UNSAFE_componentWillMount',
-        'UNSAFE_componentWillReceiveProps',
-        'UNSAFE_componentWillUpdate'
-      ];
+      return Object.keys(unsafe);
     }
 
     /**
@@ -63,9 +76,13 @@ module.exports = {
         return;
       }
 
+      const meta = unsafe[method];
+      const newMethod = meta.newMethod;
+      const details = meta.details;
+
       context.report({
         node: node,
-        message: `${method} is unsafe for use in async rendering, see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html`
+        message: `${method} is unsafe for use in async rendering. Update the component to use ${newMethod} instead. ${details}`
       });
     }
 

--- a/lib/rules/no-unsafe.js
+++ b/lib/rules/no-unsafe.js
@@ -22,31 +22,51 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-unsafe')
     },
-    schema: []
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          checkAliases: {
+            default: false,
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
   },
 
   create: Components.detect((context, components, utils) => {
+    const config = context.options[0] || {};
+    const checkAliases = config.checkAliases || false;
+
     const isApplicable = versionUtil.testReactVersion(context, '16.3.0');
     if (!isApplicable) {
       return {};
     }
 
-    const unsafe = {};
-    unsafe.componentWillMount = unsafe.UNSAFE_componentWillMount = {
-      newMethod: 'componentDidMount',
-      details:
-        'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+    const unsafe = {
+      UNSAFE_componentWillMount: {
+        newMethod: 'componentDidMount',
+        details:
+          'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+      },
+      UNSAFE_componentWillReceiveProps: {
+        newMethod: 'getDerivedStateFromProps',
+        details:
+          'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+      },
+      UNSAFE_componentWillUpdate: {
+        newMethod: 'componentDidUpdate',
+        details:
+          'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+      }
     };
-    unsafe.componentWillReceiveProps = unsafe.UNSAFE_componentWillReceiveProps = {
-      newMethod: 'getDerivedStateFromProps',
-      details:
-        'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-    };
-    unsafe.componentWillUpdate = unsafe.UNSAFE_componentWillUpdate = {
-      newMethod: 'componentDidUpdate',
-      details:
-        'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-    };
+    if (checkAliases) {
+      unsafe.componentWillMount = unsafe.UNSAFE_componentWillMount;
+      unsafe.componentWillReceiveProps = unsafe.UNSAFE_componentWillReceiveProps;
+      unsafe.componentWillUpdate = unsafe.UNSAFE_componentWillUpdate;
+    }
 
     /**
      * Returns a list of unsafe methods

--- a/tests/lib/rules/no-unsafe.js
+++ b/tests/lib/rules/no-unsafe.js
@@ -97,7 +97,7 @@ ruleTester.run('no-unsafe', rule, {
             componentWillUpdate() {}
           }
         `,
-      settings: {react: {version: '16.2.0'}}
+      settings: {react: {version: '16.4.0'}}
     },
     {
       code: `
@@ -118,7 +118,7 @@ ruleTester.run('no-unsafe', rule, {
               componentWillUpdate: function() {},
             });
           `,
-      settings: {react: {version: '16.2.0'}}
+      settings: {react: {version: '16.4.0'}}
     },
     {
       code: `
@@ -142,7 +142,8 @@ ruleTester.run('no-unsafe', rule, {
           componentWillUpdate() {}
         }
       `,
-      settings: {react: {version: '16.3.0'}},
+      options: [{checkAliases: true}],
+      settings: {react: {version: '16.4.0'}},
       errors: [
         {
           message: errorMessage(
@@ -227,6 +228,7 @@ ruleTester.run('no-unsafe', rule, {
             componentWillUpdate: function() {},
           });
         `,
+      options: [{checkAliases: true}],
       settings: {react: {version: '16.3.0'}},
       errors: [
         {

--- a/tests/lib/rules/no-unsafe.js
+++ b/tests/lib/rules/no-unsafe.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Prevent usage of UNSAFE_ methods
+ * @fileoverview Prevent usage of unsafe lifecycle methods
  * @author Sergei Startsev
  */
 'use strict';
@@ -19,8 +19,8 @@ const parserOptions = {
   }
 };
 
-function errorMessage(method) {
-  return `${method} is unsafe for use in async rendering, see https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html`;
+function errorMessage(method, newMethod, details) {
+  return `${method} is unsafe for use in async rendering. Update the component to use ${newMethod} instead. ${details}`;
 }
 
 // ------------------------------------------------------------------------------
@@ -50,12 +50,32 @@ ruleTester.run('no-unsafe', rule, {
     },
     {
       code: `
+          class Foo extends Bar {
+            componentWillMount() {}
+            componentWillReceiveProps() {}
+            componentWillUpdate() {}
+          }
+        `,
+      settings: {react: {version: '16.4.0'}}
+    },
+    {
+      code: `
         class Foo extends Bar {
           UNSAFE_componentWillMount() {}
           UNSAFE_componentWillReceiveProps() {}
           UNSAFE_componentWillUpdate() {}
         }
       `,
+      settings: {react: {version: '16.4.0'}}
+    },
+    {
+      code: `
+          const Foo = bar({
+            componentWillMount: function() {},
+            componentWillReceiveProps: function() {},
+            componentWillUpdate: function() {},
+          });
+        `,
       settings: {react: {version: '16.4.0'}}
     },
     {
@@ -68,6 +88,17 @@ ruleTester.run('no-unsafe', rule, {
       `,
       settings: {react: {version: '16.4.0'}}
     },
+    // React.Component
+    {
+      code: `
+          class Foo extends React.Component {
+            componentWillMount() {}
+            componentWillReceiveProps() {}
+            componentWillUpdate() {}
+          }
+        `,
+      settings: {react: {version: '16.2.0'}}
+    },
     {
       code: `
         class Foo extends React.Component {
@@ -76,6 +107,17 @@ ruleTester.run('no-unsafe', rule, {
           UNSAFE_componentWillUpdate() {}
         }
       `,
+      settings: {react: {version: '16.2.0'}}
+    },
+    // createReactClass
+    {
+      code: `
+            const Foo = createReactClass({
+              componentWillMount: function() {},
+              componentWillReceiveProps: function() {},
+              componentWillUpdate: function() {},
+            });
+          `,
       settings: {react: {version: '16.2.0'}}
     },
     {
@@ -91,6 +133,49 @@ ruleTester.run('no-unsafe', rule, {
   ],
 
   invalid: [
+    // React.Component
+    {
+      code: `
+        class Foo extends React.Component {
+          componentWillMount() {}
+          componentWillReceiveProps() {}
+          componentWillUpdate() {}
+        }
+      `,
+      settings: {react: {version: '16.3.0'}},
+      errors: [
+        {
+          message: errorMessage(
+            'componentWillMount',
+            'componentDidMount',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
+          line: 2,
+          column: 9,
+          type: 'ClassDeclaration'
+        },
+        {
+          message: errorMessage(
+            'componentWillReceiveProps',
+            'getDerivedStateFromProps',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
+          line: 2,
+          column: 9,
+          type: 'ClassDeclaration'
+        },
+        {
+          message: errorMessage(
+            'componentWillUpdate',
+            'componentDidUpdate',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
+          line: 2,
+          column: 9,
+          type: 'ClassDeclaration'
+        }
+      ]
+    },
     {
       code: `
       class Foo extends React.Component {
@@ -102,22 +187,77 @@ ruleTester.run('no-unsafe', rule, {
       settings: {react: {version: '16.3.0'}},
       errors: [
         {
-          message: errorMessage('UNSAFE_componentWillMount'),
+          message: errorMessage(
+            'UNSAFE_componentWillMount',
+            'componentDidMount',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
           line: 2,
           column: 7,
           type: 'ClassDeclaration'
         },
         {
-          message: errorMessage('UNSAFE_componentWillReceiveProps'),
+          message: errorMessage(
+            'UNSAFE_componentWillReceiveProps',
+            'getDerivedStateFromProps',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
           line: 2,
           column: 7,
           type: 'ClassDeclaration'
         },
         {
-          message: errorMessage('UNSAFE_componentWillUpdate'),
+          message: errorMessage(
+            'UNSAFE_componentWillUpdate',
+            'componentDidUpdate',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
           line: 2,
           column: 7,
           type: 'ClassDeclaration'
+        }
+      ]
+    },
+    // createReactClass
+    {
+      code: `
+          const Foo = createReactClass({
+            componentWillMount: function() {},
+            componentWillReceiveProps: function() {},
+            componentWillUpdate: function() {},
+          });
+        `,
+      settings: {react: {version: '16.3.0'}},
+      errors: [
+        {
+          message: errorMessage(
+            'componentWillMount',
+            'componentDidMount',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
+          line: 2,
+          column: 40,
+          type: 'ObjectExpression'
+        },
+        {
+          message: errorMessage(
+            'componentWillReceiveProps',
+            'getDerivedStateFromProps',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
+          line: 2,
+          column: 40,
+          type: 'ObjectExpression'
+        },
+        {
+          message: errorMessage(
+            'componentWillUpdate',
+            'componentDidUpdate',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
+          line: 2,
+          column: 40,
+          type: 'ObjectExpression'
         }
       ]
     },
@@ -132,19 +272,31 @@ ruleTester.run('no-unsafe', rule, {
       settings: {react: {version: '16.3.0'}},
       errors: [
         {
-          message: errorMessage('UNSAFE_componentWillMount'),
+          message: errorMessage(
+            'UNSAFE_componentWillMount',
+            'componentDidMount',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
           line: 2,
           column: 38,
           type: 'ObjectExpression'
         },
         {
-          message: errorMessage('UNSAFE_componentWillReceiveProps'),
+          message: errorMessage(
+            'UNSAFE_componentWillReceiveProps',
+            'getDerivedStateFromProps',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
           line: 2,
           column: 38,
           type: 'ObjectExpression'
         },
         {
-          message: errorMessage('UNSAFE_componentWillUpdate'),
+          message: errorMessage(
+            'UNSAFE_componentWillUpdate',
+            'componentDidUpdate',
+            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          ),
           line: 2,
           column: 38,
           type: 'ObjectExpression'


### PR DESCRIPTION
[The original PR](https://github.com/yannickcr/eslint-plugin-react/pull/2069) has been broken down to 2 parts, the changes related to `no-unsafe` rule have been moved to this PR.

## Summary
- `no-unsafe` rule has been adjusted to handle all unsafe life-cycle methods including their aliases. Developers who want to avoid using of legacy lifecycle methods can enable it today.
- Instructions on updating components have been adjusted in `no-unsafe` rule to be consistent with React runtime warnings.
- Documentation pages have been updated.
- Corresponding unit tests have been updated/added.