### PR TITLE
Support detecting React.forwardRef/React.memo

### DIFF
--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -99,7 +99,7 @@ module.exports = {
         return;
       }
 
-      if (!utils.isReactCreateElement(node)) {
+      if (!utils.isCreateElement(node)) {
         return;
       }
 

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -255,33 +255,33 @@ function componentRule(rule, context) {
     },
 
     /**
-     * Check if variable is destructured from React import
+     * Check if variable is destructured from pragma import
      *
      * @param {variable} String The variable name to check
-     * @returns {Boolean} True if createElement is destructured from React
+     * @returns {Boolean} True if createElement is destructured from the pragma
      */
-    isDestructuredFromReactImport: function(variable) {
+    isDestructuredFromPragmaImport: function(variable) {
       const variables = variableUtil.variablesInScope(context);
       const variableInScope = variableUtil.getVariable(variables, variable);
       if (variableInScope) {
         const map = variableInScope.scope.set;
-        return map.has('React');
+        return map.has(pragma);
       }
       return false;
     },
 
     /**
-     * Checks to see if node is called within React.createElement
+     * Checks to see if node is called within createElement from pragma
      *
      * @param {ASTNode} node The AST node being checked.
-     * @returns {Boolean} True if React.createElement called
+     * @returns {Boolean} True if createElement called from pragma
      */
-    isReactCreateElement: function(node) {
-      const calledOnReact = (
+    isCreateElement: function(node) {
+      const calledOnPragma = (
         node &&
         node.callee &&
         node.callee.object &&
-        node.callee.object.name === 'React' &&
+        node.callee.object.name === pragma &&
         node.callee.property &&
         node.callee.property.name === 'createElement'
       );
@@ -292,10 +292,10 @@ function componentRule(rule, context) {
         node.callee.name === 'createElement'
       );
 
-      if (this.isDestructuredFromReactImport('createElement')) {
-        return calledDirectly || calledOnReact;
+      if (this.isDestructuredFromPragmaImport('createElement')) {
+        return calledDirectly || calledOnPragma;
       }
-      return calledOnReact;
+      return calledOnPragma;
     },
 
     getReturnPropertyAndNode(ASTnode) {
@@ -357,12 +357,12 @@ function componentRule(rule, context) {
         node[property] &&
         jsxUtil.isJSX(node[property])
       ;
-      const returnsReactCreateElement = this.isReactCreateElement(node[property]);
+      const returnsPragmaCreateElement = this.isCreateElement(node[property]);
 
       return Boolean(
         returnsConditionalJSX ||
         returnsJSX ||
-        returnsReactCreateElement
+        returnsPragmaCreateElement
       );
     },
 
@@ -395,16 +395,16 @@ function componentRule(rule, context) {
       return utils.isReturningJSX(ASTNode, strict) || utils.isReturningNull(ASTNode);
     },
 
-    isReactComponentWrapper(node) {
+    isPragmaComponentWrapper(node) {
       if (node.type !== 'CallExpression') {
         return false;
       }
       const propertyNames = ['forwardRef', 'memo'];
       const calleeObject = node.callee.object;
       if (calleeObject) {
-        return arrayIncludes(propertyNames, node.callee.property.name) && node.callee.object.name === 'React';
+        return arrayIncludes(propertyNames, node.callee.property.name) && node.callee.object.name === pragma;
       }
-      return arrayIncludes(propertyNames, node.callee.name) && this.isDestructuredFromReactImport(node.callee.name);
+      return arrayIncludes(propertyNames, node.callee.name) && this.isDestructuredFromPragmaImport(node.callee.name);
     },
 
     /**
@@ -476,9 +476,12 @@ function componentRule(rule, context) {
         const enclosingScopeParent = enclosingScope && enclosingScope.block.parent;
         const isClass = enclosingScope && astUtil.isClass(enclosingScope.block);
         const isMethod = enclosingScopeParent && enclosingScopeParent.type === 'MethodDefinition'; // Classes methods
-        const isArgument = node.parent && node.parent.type === 'CallExpression' && !this.isReactComponentWrapper(node.parent); // Arguments (callback, etc.)
+        const isArgument = node.parent && node.parent.type === 'CallExpression'; // Arguments (callback, etc.)
         // Attribute Expressions inside JSX Elements (<button onClick={() => props.handleClick()}></button>)
         const isJSXExpressionContainer = node.parent && node.parent.type === 'JSXExpressionContainer';
+        if (node.parent && this.isPragmaComponentWrapper(node.parent)) {
+          return node.parent;
+        }
         // Stop moving up if we reach a class or an argument (like a callback)
         if (isClass || isArgument) {
           return null;
@@ -613,6 +616,13 @@ function componentRule(rule, context) {
 
   // Component detection instructions
   const detectionInstructions = {
+    CallExpression: function(node) {
+      if (!utils.isPragmaComponentWrapper(node)) {
+        return;
+      }
+      components.add(node, 2);
+    },
+
     ClassExpression: function(node) {
       if (!utils.isES6Component(node)) {
         return;

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -6,6 +6,8 @@
 
 const util = require('util');
 const doctrine = require('doctrine');
+const arrayIncludes = require('array-includes');
+
 const variableUtil = require('./variable');
 const pragmaUtil = require('./pragma');
 const astUtil = require('./ast');
@@ -253,18 +255,17 @@ function componentRule(rule, context) {
     },
 
     /**
-     * Check if createElement is destructured from React import
+     * Check if variable is destructured from React import
      *
+     * @param {variable} String The variable name to check
      * @returns {Boolean} True if createElement is destructured from React
      */
-    hasDestructuredReactCreateElement: function() {
+    isDestructuredFromReactImport: function(variable) {
       const variables = variableUtil.variablesInScope(context);
-      const variable = variableUtil.getVariable(variables, 'createElement');
-      if (variable) {
-        const map = variable.scope.set;
-        if (map.has('React')) {
-          return true;
-        }
+      const variableInScope = variableUtil.getVariable(variables, variable);
+      if (variableInScope) {
+        const map = variableInScope.scope.set;
+        return map.has('React');
       }
       return false;
     },
@@ -291,7 +292,7 @@ function componentRule(rule, context) {
         node.callee.name === 'createElement'
       );
 
-      if (this.hasDestructuredReactCreateElement()) {
+      if (this.isDestructuredFromReactImport('createElement')) {
         return calledDirectly || calledOnReact;
       }
       return calledOnReact;
@@ -394,6 +395,18 @@ function componentRule(rule, context) {
       return utils.isReturningJSX(ASTNode, strict) || utils.isReturningNull(ASTNode);
     },
 
+    isReactComponentWrapper(node) {
+      if (node.type !== 'CallExpression') {
+        return false;
+      }
+      const propertyNames = ['forwardRef', 'memo'];
+      const calleeObject = node.callee.object;
+      if (calleeObject) {
+        return arrayIncludes(propertyNames, node.callee.property.name) && node.callee.object.name === 'React';
+      }
+      return arrayIncludes(propertyNames, node.callee.name) && this.isDestructuredFromReactImport(node.callee.name);
+    },
+
     /**
      * Find a return statment in the current node
      *
@@ -463,7 +476,7 @@ function componentRule(rule, context) {
         const enclosingScopeParent = enclosingScope && enclosingScope.block.parent;
         const isClass = enclosingScope && astUtil.isClass(enclosingScope.block);
         const isMethod = enclosingScopeParent && enclosingScopeParent.type === 'MethodDefinition'; // Classes methods
-        const isArgument = node.parent && node.parent.type === 'CallExpression'; // Arguments (callback, etc.)
+        const isArgument = node.parent && node.parent.type === 'CallExpression' && !this.isReactComponentWrapper(node.parent); // Arguments (callback, etc.)
         // Attribute Expressions inside JSX Elements (<button onClick={() => props.handleClick()}></button>)
         const isJSXExpressionContainer = node.parent && node.parent.type === 'JSXExpressionContainer';
         // Stop moving up if we reach a class or an argument (like a callback)

--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -429,7 +429,7 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
    */
   function markDestructuredFunctionArgumentsAsUsed(node) {
     const destructuring = node.params && node.params[0] && node.params[0].type === 'ObjectPattern';
-    if (destructuring && components.get(node)) {
+    if (destructuring && (components.get(node) || components.get(node.parent))) {
       markPropTypesAsUsed(node);
     }
   }

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3947,6 +3947,58 @@ ruleTester.run('prop-types', rule, {
       errors: [{
         message: '\'page\' is missing in props validation'
       }]
+    },
+    {
+      code: `
+        const HeaderBalance = React.memo(({ cryptoCurrency }) => (
+          <div className="header-balance">
+            <div className="header-balance__balance">
+              BTC
+              {cryptoCurrency}
+            </div>
+          </div>
+        ));
+      `,
+      errors: [{
+        message: '\'cryptoCurrency\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
+        import React, { memo } from 'react';
+        const HeaderBalance = memo(({ cryptoCurrency }) => (
+          <div className="header-balance">
+            <div className="header-balance__balance">
+              BTC
+              {cryptoCurrency}
+            </div>
+          </div>
+        ));
+      `,
+      errors: [{
+        message: '\'cryptoCurrency\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
+        const Label = React.forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        });
+      `,
+      errors: [{
+        message: '\'text\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
+        import React, { forwardRef } from 'react';
+        const Label = forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        });
+      `,
+      errors: [{
+        message: '\'text\' is missing in props validation'
+      }]
     }
   ]
 });

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -2066,6 +2066,110 @@ ruleTester.run('prop-types', rule, {
         };
       `,
       settings: {react: {version: '16.3.0'}}
+    },
+    {
+      code: `
+        const HeaderBalance = React.memo(({ cryptoCurrency }) => (
+          <div className="header-balance">
+            <div className="header-balance__balance">
+              BTC
+              {cryptoCurrency}
+            </div>
+          </div>
+        ));
+        HeaderBalance.propTypes = {
+          cryptoCurrency: PropTypes.string
+        };
+      `
+    },
+    {
+      code: `
+        import React, { memo } from 'react';
+        const HeaderBalance = memo(({ cryptoCurrency }) => (
+          <div className="header-balance">
+            <div className="header-balance__balance">
+              BTC
+              {cryptoCurrency}
+            </div>
+          </div>
+        ));
+        HeaderBalance.propTypes = {
+          cryptoCurrency: PropTypes.string
+        };
+      `
+    },
+    {
+      code: `
+        import Foo, { memo } from 'foo';
+        const HeaderBalance = memo(({ cryptoCurrency }) => (
+          <div className="header-balance">
+            <div className="header-balance__balance">
+              BTC
+              {cryptoCurrency}
+            </div>
+          </div>
+        ));
+        HeaderBalance.propTypes = {
+          cryptoCurrency: PropTypes.string
+        };
+      `,
+      settings: {
+        react: {
+          pragma: 'Foo'
+        }
+      }
+    },
+    {
+      code: `
+        const Label = React.forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        });
+        Label.propTypes = {
+          text: PropTypes.string,
+        };
+      `
+    },
+    {
+      code: `
+        const Label = Foo.forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        });
+        Label.propTypes = {
+          text: PropTypes.string,
+        };
+      `,
+      settings: {
+        react: {
+          pragma: 'Foo'
+        }
+      }
+    },
+    {
+      code: `
+        import React, { forwardRef } from 'react';
+        const Label = forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        });
+        Label.propTypes = {
+          text: PropTypes.string,
+        };
+      `
+    },
+    {
+      code: `
+        import Foo, { forwardRef } from 'foo';
+        const Label = forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        });
+        Label.propTypes = {
+          text: PropTypes.string,
+        };
+      `,
+      settings: {
+        react: {
+          pragma: 'Foo'
+        }
+      }
     }
   ],
 
@@ -3981,6 +4085,47 @@ ruleTester.run('prop-types', rule, {
     },
     {
       code: `
+        const HeaderBalance = Foo.memo(({ cryptoCurrency }) => (
+          <div className="header-balance">
+            <div className="header-balance__balance">
+              BTC
+              {cryptoCurrency}
+            </div>
+          </div>
+        ));
+      `,
+      settings: {
+        react: {
+          pragma: 'Foo'
+        }
+      },
+      errors: [{
+        message: '\'cryptoCurrency\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
+        import Foo, { memo } from 'foo';
+        const HeaderBalance = memo(({ cryptoCurrency }) => (
+          <div className="header-balance">
+            <div className="header-balance__balance">
+              BTC
+              {cryptoCurrency}
+            </div>
+          </div>
+        ));
+      `,
+      settings: {
+        react: {
+          pragma: 'Foo'
+        }
+      },
+      errors: [{
+        message: '\'cryptoCurrency\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
         const Label = React.forwardRef(({ text }, ref) => {
           return <div ref={ref}>{text}</div>;
         });
@@ -3996,6 +4141,37 @@ ruleTester.run('prop-types', rule, {
           return <div ref={ref}>{text}</div>;
         });
       `,
+      errors: [{
+        message: '\'text\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
+        const Label = Foo.forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        });
+      `,
+      settings: {
+        react: {
+          pragma: 'Foo'
+        }
+      },
+      errors: [{
+        message: '\'text\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
+        import Foo, { forwardRef } from 'foo';
+        const Label = forwardRef(({ text }, ref) => {
+          return <div ref={ref}>{text}</div>;
+        });
+      `,
+      settings: {
+        react: {
+          pragma: 'Foo'
+        }
+      },
       errors: [{
         message: '\'text\' is missing in props validation'
       }]


### PR DESCRIPTION
This updates the component detection to allow for considering components
wrapped in either React.forwardRef or React.memo.

Resolves #1841. Resolves #2059