### PR TITLE
Fix no-unused-state crash

### DIFF
--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -265,7 +265,7 @@ module.exports = {
           node.arguments[0].type === 'ArrowFunctionExpression' &&
           node.arguments[0].body.type === 'ObjectExpression'
         ) {
-          if (node.arguments[0].params.length > 0) {
+          if (node.arguments[0].params.length > 0 && classInfo.aliases) {
             classInfo.aliases.add(getName(node.arguments[0].params[0]));
           }
           addStateFields(node.arguments[0].body);

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -636,6 +636,64 @@ eslintTester.run('no-unused-state', rule, {
       }
       `,
       parser: 'babel-eslint'
+    }, {
+      code: `
+      var Foo = createReactClass({
+        getInitialState: function() {
+          return { initial: 'foo' };
+        },
+        handleChange: function() {
+          this.setState(state => ({
+            current: state.initial
+          }));
+        },
+        render() {
+          const { current } = this.state;
+          return <div>{current}</div>
+        }
+      });
+      `
+    }, {
+      code: `
+      var Foo = createReactClass({
+        getInitialState: function() {
+          return { initial: 'foo' };
+        },
+        handleChange: function() {
+          this.setState((state, props) => ({
+            current: state.initial
+          }));
+        },
+        render() {
+          const { current } = this.state;
+          return <div>{current}</div>
+        }
+      });
+      `
+    }, {
+      // Don't error out
+      code: `
+      class Foo extends Component {
+        handleChange = function() {
+          this.setState(state => ({ foo: value }));
+        }
+        render() {
+          return <SomeComponent foo={this.state.foo} />;
+        }
+      }`,
+      parser: 'babel-eslint'
+    }, {
+      // Don't error out
+      code: `
+      class Foo extends Component {
+        static handleChange = () => {
+          this.setState(state => ({ foo: value }));
+        }
+        render() {
+          return <SomeComponent foo={this.state.foo} />;
+        }
+      }`,
+      parser: 'babel-eslint'
     }
   ],
 


### PR DESCRIPTION
Don't assume `classInfo.aliases` is a set since there are some cases where
it is `null` for a `ClassProperty`.

Fixes #2096 