### PR TITLE
Fix display-name false positive for React.memo

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -479,7 +479,7 @@ function componentRule(rule, context) {
         const isArgument = node.parent && node.parent.type === 'CallExpression'; // Arguments (callback, etc.)
         // Attribute Expressions inside JSX Elements (<button onClick={() => props.handleClick()}></button>)
         const isJSXExpressionContainer = node.parent && node.parent.type === 'JSXExpressionContainer';
-        if (node.parent && this.isPragmaComponentWrapper(node.parent)) {
+        if (isFunction && node.parent && this.isPragmaComponentWrapper(node.parent)) {
           return node.parent;
         }
         // Stop moving up if we reach a class or an argument (like a callback)
@@ -620,7 +620,9 @@ function componentRule(rule, context) {
       if (!utils.isPragmaComponentWrapper(node)) {
         return;
       }
-      components.add(node, 2);
+      if (node.arguments.length > 0 && astUtil.isFunctionLikeExpression(node.arguments[0])) {
+        components.add(node, 2);
+      }
     },
 
     ClassExpression: function(node) {

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -437,6 +437,21 @@ ruleTester.run('display-name', rule, {
       createElement("a");
     `,
     parser: 'babel-eslint'
+  }, {
+    code: `
+      import React from 'react'
+      import { string } from 'prop-types'
+
+      function Component({ world }) {
+        return <div>Hello {world}</div>
+      }
+
+      Component.propTypes = {
+        world: string,
+      }
+
+      export default React.memo(Component)
+    `
   }],
 
   invalid: [{


### PR DESCRIPTION
This will only consider the React `memo`/`forwardRef` wrappers to be components themselves if they are wrapping a `FunctionExpression`/`ArrowFunctionExpression` directly. In the issue code sample, the normal function component will be picked up as a component as usual.

Resolves #2105 