### PR TITLE
Fix issue with propTypes misclassifying props

### DIFF
--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -67,6 +67,24 @@ function iterateProperties(context, properties, fn) {
   }
 }
 
+/**
+ * Checks if a node is inside a class property.
+ *
+ * @param {ASTNode} node  the AST node being checked.
+ * @returns {Boolean} True if the node has a ClassProperty ancestor, false if not.
+ */
+function isInsideClassProperty(node) {
+  let parent = node.parent;
+  while (parent) {
+    if (parent.type === 'ClassProperty') {
+      return true;
+    }
+    parent = parent.parent;
+  }
+
+  return false;
+}
+
 module.exports = function propTypesInstructions(context, components, utils) {
   // Used to track the type annotations in scope.
   // Necessary because babel's scopes do not track type annotations.
@@ -551,6 +569,10 @@ module.exports = function propTypesInstructions(context, components, utils) {
    */
   function markAnnotatedFunctionArgumentsAsDeclared(node) {
     if (!node.params || !node.params.length || !annotations.isAnnotatedFunctionPropsDeclaration(node, context)) {
+      return;
+    }
+
+    if (isInsideClassProperty(node)) {
       return;
     }
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2929,6 +2929,21 @@ ruleTester.run('no-unused-prop-types', rule, {
         '  })',
         '};'
       ].join('\n')
+    }, {
+      code: `
+        type Props = {
+          used: string,
+        }
+        class Hello extends React.Component<Props> {
+          renderHelper = ({unused}: {unused: string}) => {
+            return <div />;
+          }
+          render() {
+            return <div>{this.props.used}</div>;
+          }
+        }
+      `,
+      parser: 'babel-eslint'
     }
   ],
 


### PR DESCRIPTION
While testing #2110, I found a bug with `declaredPropTypes` and the `no-unused-prop-types` rule.

The `propTypes` module incorrectly detects function parameters inside a class property as props of the class component, which results in this code being considered a warning:

```jsx
type Props = {
  used: string,
}

class Hello extends React.Component<Props> {
  renderHelper = ({unused}: {unused: string}) => {
    return <div />;
  }
  render() {
    return <div>{this.props.used}</div>;
  }
}
```

It thinks that `unused` is an unused prop of `Hello`.

I'm not a 100% if the fix is the correct fix, but I made `markAnnotatedFunctionArgumentsAsDeclared` check if the `node` has a `ClassProperty` ancestor, and if so, bail. I also added a test to `no-unused-prop-types` to check for this.

Having these kinds of class properties is arguably an anti-pattern, but it came up as an issue when I was testing legacy code. Worse yet, because `declaredPropTypes` is an object, those helper properties can overwrite actual props.
