### PR TITLE
Fix propType detection inside class bodies

### DIFF
--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -68,15 +68,15 @@ function iterateProperties(context, properties, fn) {
 }
 
 /**
- * Checks if a node is inside a class property.
+ * Checks if a node is inside a class body.
  *
  * @param {ASTNode} node  the AST node being checked.
- * @returns {Boolean} True if the node has a ClassProperty ancestor, false if not.
+ * @returns {Boolean} True if the node has a ClassBody ancestor, false if not.
  */
-function isInsideClassProperty(node) {
+function isInsideClassBody(node) {
   let parent = node.parent;
   while (parent) {
-    if (parent.type === 'ClassProperty') {
+    if (parent.type === 'ClassBody') {
       return true;
     }
     parent = parent.parent;
@@ -572,7 +572,7 @@ module.exports = function propTypesInstructions(context, components, utils) {
       return;
     }
 
-    if (isInsideClassProperty(node)) {
+    if (isInsideClassBody(node)) {
       return;
     }
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2935,11 +2935,42 @@ ruleTester.run('no-unused-prop-types', rule, {
           used: string,
         }
         class Hello extends React.Component<Props> {
-          renderHelper = ({unused}: {unused: string}) => {
+          renderHelper = ({notAProp}: {notAProp: string}) => {
             return <div />;
           }
           render() {
             return <div>{this.props.used}</div>;
+          }
+        }
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        type Props = {
+          used: string,
+        }
+        class Hello extends React.Component<Props> {
+          componentDidMount() {
+            foo(
+              ({notAProp}: {notAProp: string}) => (<div />)
+            );
+          }
+          render() {
+            return <div>{this.props.used}</div>;
+          }
+        }
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        type Props = {
+          used: string,
+        }
+        class Hello extends React.Component<Props> {
+          render() {
+            return <QueryRenderer
+              render={({notAProp}: {notAProp: string}) => <div>{this.props.used}</div>}
+            />;
           }
         }
       `,


### PR DESCRIPTION
I investigated it a bit more and it turns out #2111 has more instances than just `ClassProperties`. A legit example is JSX render props:

```jsx
type Props = {
  used: string,
}
class Hello extends React.Component<Props> {
  render() {
    return <QueryRenderer
      render={
        ({notAProp}: {notAProp: string}) => <div>{this.props.used}</div>
      }
    />;
  }
}
```

The `no-unused-prop-types` rule gives a warning that `notAProp` is not used, because it thinks `notAProp` is a prop of `Hello`.

I added two more tests. The problem seems to occur in many cases involving functions being declared inside class bodies. The nice thing is that all of them have a `ClassBody` node as an ancestor so I changed the previous fix to look for `ClassBody` instead, which actually feels more like a proper fix.