### PR TITLE
[New]: `jsx-no-literals`: add `ignoreProps` option to ignore props validation

### DIFF
--- a/docs/rules/jsx-no-literals.md
+++ b/docs/rules/jsx-no-literals.md
@@ -28,13 +28,14 @@ var Hello = <div>
 
 There are two options:
 
-* `noStrings` - Enforces no string literals used as children, wrapped or unwrapped.
+* `noStrings` (default: `false`) - Enforces no string literals used as children, wrapped or unwrapped.
 * `allowedStrings` - An array of unique string values that would otherwise warn, but will be ignored.
+* `ignoreProps` (default: `false`) - When `true` the rule ignores literals used in props, wrapped or unwrapped.
 
 To use, you can specify as follows:
 
 ```js
-"react/jsx-no-literals": [<enabled>, {"noStrings": true, "allowedStrings": ["allowed"]}]
+"react/jsx-no-literals": [<enabled>, {"noStrings": true, "allowedStrings": ["allowed"], "ignoreProps": false}]
 ```
 
 In this configuration, the following are considered warnings:
@@ -52,6 +53,19 @@ var Hello = <div>
   {'test'}
 </div>;
 ```
+
+```jsx
+var Hello = <div class='xx' />;
+```
+
+```jsx
+var Hello = <div class={'xx'} />;
+```
+
+```jsx
+var Hello = <div class={`xx`} />;
+```
+
 
 The following are **not** considered warnings:
 
@@ -75,6 +89,33 @@ var Hello = <div>allowed</div>
 var Hello = <div>
   allowed
 </div>;
+```
+
+```jsx
+// spread props object
+var Hello = <Text {...props} />
+```
+
+```jsx
+// use variable for prop values
+var Hello = <div class={xx} />
+```
+
+```jsx
+// cache
+class Comp1 extends Component {
+  asdf() {}
+
+  render() {
+    return (
+      <div onClick={this.asdf}>
+        {'asdjfl'}
+        test
+        {'foo'}
+      </div>
+    );
+  }
+}
 ```
 
 ## When Not To Use It

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -12,6 +12,10 @@ const docsUrl = require('../util/docsUrl');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+function trimIfString(val) {
+  return typeof val === 'string' ? val.trim() : val;
+}
+
 module.exports = {
   meta: {
     docs: {
@@ -33,6 +37,9 @@ module.exports = {
           items: {
             type: 'string'
           }
+        },
+        ignoreProps: {
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -40,11 +47,7 @@ module.exports = {
   },
 
   create(context) {
-    function trimIfString(val) {
-      return typeof val === 'string' ? val.trim() : val;
-    }
-
-    const defaults = {noStrings: false, allowedStrings: []};
+    const defaults = {noStrings: false, allowedStrings: [], ignoreProps: false};
     const config = Object.assign({}, defaults, context.options[0] || {});
     config.allowedStrings = new Set(config.allowedStrings.map(trimIfString));
 
@@ -52,10 +55,12 @@ module.exports = {
       'Strings not allowed in JSX files' :
       'Missing JSX expression container around literal string';
 
-    function reportLiteralNode(node) {
+    function reportLiteralNode(node, customMessage) {
+      const errorMessage = customMessage || message;
+
       context.report({
         node,
-        message: `${message}: “${context.getSourceCode().getText(node).trim()}”`
+        message: `${errorMessage}: “${context.getSourceCode().getText(node).trim()}”`
       });
     }
 
@@ -82,15 +87,44 @@ module.exports = {
       return standard && parent.type !== 'JSXExpressionContainer';
     }
 
+    function getParentAndGrandParentType(node) {
+      const parent = getParentIgnoringBinaryExpressions(node);
+      const parentType = parent.type;
+      const grandParentType = parent.parent.type;
+
+      return {
+        parent,
+        parentType,
+        grandParentType,
+        grandParent: parent.parent
+      };
+    }
+
+    function hasJSXElementParentOrGrandParent(node) {
+      const parents = getParentAndGrandParentType(node);
+      const parentType = parents.parentType;
+      const grandParentType = parents.grandParentType;
+
+      return parentType === 'JSXFragment' || parentType === 'JSXElement' || grandParentType === 'JSXElement';
+    }
+
     // --------------------------------------------------------------------------
     // Public
     // --------------------------------------------------------------------------
 
     return {
-
       Literal(node) {
-        if (getValidation(node)) {
+        if (getValidation(node) && (hasJSXElementParentOrGrandParent(node) || !config.ignoreProps)) {
           reportLiteralNode(node);
+        }
+      },
+
+      JSXAttribute(node) {
+        const isNodeValueString = node.value && node.value && node.value.type === 'Literal' && typeof node.value.value === 'string';
+
+        if (config.noStrings && !config.ignoreProps && isNodeValueString) {
+          const customMessage = 'Invalid prop value';
+          reportLiteralNode(node, customMessage);
         }
       },
 
@@ -101,12 +135,16 @@ module.exports = {
       },
 
       TemplateLiteral(node) {
-        const parent = getParentIgnoringBinaryExpressions(node);
-        if (config.noStrings && parent.type === 'JSXExpressionContainer') {
+        const parents = getParentAndGrandParentType(node);
+        const parentType = parents.parentType;
+        const grandParentType = parents.grandParentType;
+        const isParentJSXExpressionCont = parentType === 'JSXExpressionContainer';
+        const isParentJSXElement = parentType === 'JSXElement' || grandParentType === 'JSXElement';
+
+        if (isParentJSXExpressionCont && config.noStrings && (isParentJSXElement || !config.ignoreProps)) {
           reportLiteralNode(node);
         }
       }
-
     };
   }
 };


### PR DESCRIPTION
- Update Tests Accordingly
- Update Rule Readme file
- Rule shouldn't allow strings in empty tags