### PR TITLE
Fix set state callback destructing & state use inside callback

### DIFF
--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -262,13 +262,19 @@ module.exports = {
         } else if (
           isSetStateCall(node) &&
           node.arguments.length > 0 &&
-          node.arguments[0].type === 'ArrowFunctionExpression' &&
-          node.arguments[0].body.type === 'ObjectExpression'
+          node.arguments[0].type === 'ArrowFunctionExpression'
         ) {
-          if (node.arguments[0].params.length > 0 && classInfo.aliases) {
-            classInfo.aliases.add(getName(node.arguments[0].params[0]));
+          if (node.arguments[0].body.type === 'ObjectExpression') {
+            addStateFields(node.arguments[0].body);
           }
-          addStateFields(node.arguments[0].body);
+          if (node.arguments[0].params.length > 0 && classInfo.aliases) {
+            const firstParam = node.arguments[0].params[0];
+            if (firstParam.type === 'ObjectPattern') {
+              handleStateDestructuring(firstParam);
+            } else {
+              classInfo.aliases.add(getName(firstParam));
+            }
+          }
         }
       },
 

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -671,6 +671,52 @@ eslintTester.run('no-unused-state', rule, {
       });
       `
     }, {
+      code: `
+      class SetStateDestructuringCallback extends Component {
+        state = {
+            used: 1, unused: 2
+        }
+        handleChange = () => {
+          this.setState(({unused}) => ({
+            used: unused * unused,
+          }));
+        }
+        render() {
+          return <div>{this.state.used}</div>
+        }
+      }
+      `,
+      parser: 'babel-eslint'
+    },
+    {
+      code: `
+      class SetStateCallbackStateCondition extends Component {
+        state = {
+            isUsed: true,
+            foo: 'foo'
+        }
+        handleChange = () => {
+          this.setState((prevState) => (prevState.isUsed ? {foo: 'bar', isUsed: false} : {}));
+        }
+        render() {
+          return <SomeComponent foo={this.state.foo} />;
+        }
+      }
+      `,
+      parser: 'babel-eslint'
+    }, {
+      // Don't error out
+      code: `
+      class Foo extends Component {
+        handleChange = function() {
+          this.setState(() => ({ foo: value }));
+        }
+        render() {
+          return <SomeComponent foo={this.state.foo} />;
+        }
+      }`,
+      parser: 'babel-eslint'
+    }, {
       // Don't error out
       code: `
       class Foo extends Component {


### PR DESCRIPTION
Fix no-unused-state rule:
1. When using destruction in `setState` callback.
2. When using state inside `setState` callback.

Fixes #1697

This is my first PR to open source :)