### PR TITLE
Update forbid-prop-types: handle prop-type functions with no args

### DIFF
--- a/docs/rules/forbid-prop-types.md
+++ b/docs/rules/forbid-prop-types.md
@@ -52,6 +52,24 @@ class Component extends React.Component {
 
 An array of strings, with the names of `PropTypes` keys that are forbidden. The default value for this option is `['any', 'array', 'object']`.
 
+You can also specify `empty` to forbid prop types which are functions from being used with no arguments. For example:
+
+```js
+// allowed
+Component.propTypes = {
+  foo: PropTypes.shape({
+    name: PropTypes.string
+  }),
+};
+```
+
+```js
+// forbidden
+Component.propTypes = {
+  foo: PropTypes.shape,
+};
+```
+
 ### `checkContextTypes`
 
 Whether or not to check `contextTypes` for forbidden prop types. The default value is false.

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -13,6 +13,7 @@ const propWrapperUtil = require('../util/propWrapper');
 // Constants
 // ------------------------------------------------------------------------------
 
+const EMPTY_RULE = 'empty';
 const DEFAULTS = ['any', 'array', 'object'];
 
 // ------------------------------------------------------------------------------
@@ -53,9 +54,30 @@ module.exports = {
     const checkContextTypes = configuration.checkContextTypes || false;
     const checkChildContextTypes = configuration.checkChildContextTypes || false;
 
-    function isForbidden(type) {
+    function isEmptyArgument(arg) {
+      const isEmptyArray = arg.type === 'ArrayExpression' && arg.elements.length === 0;
+      const isEmptyObject = arg.type === 'ObjectExpression' && arg.properties.length === 0;
+
+      return isEmptyArray || isEmptyObject;
+    }
+
+    function isMissingArguments(type, value) {
       const forbid = configuration.forbid || DEFAULTS;
-      return forbid.indexOf(type) >= 0;
+      const propIsAFunction = propsUtil.isPropTypeAFunction(type);
+
+      if (forbid.indexOf(EMPTY_RULE) === -1 || !propIsAFunction) {
+        return false;
+      }
+
+      const hasArguments = value.parent && Array.isArray(value.parent.arguments) && value.parent.arguments.length > 0;
+      const noPropertiesInArguments = hasArguments && value.parent.arguments.every(isEmptyArgument);
+
+      return !hasArguments || noPropertiesInArguments;
+    }
+
+    function isForbidden(type, value) {
+      const forbid = configuration.forbid || DEFAULTS;
+      return forbid.indexOf(type) >= 0 || isMissingArguments(type, value);
     }
 
     function shouldCheckContextTypes(node) {
@@ -103,7 +125,7 @@ module.exports = {
         } else if (value.type === 'Identifier') {
           target = value.name;
         }
-        if (isForbidden(target)) {
+        if (isForbidden(target, value)) {
           context.report({
             node: declaration,
             message: `Prop type \`${target}\` is forbidden`

--- a/lib/util/props.js
+++ b/lib/util/props.js
@@ -5,6 +5,8 @@
 
 const astUtil = require('./ast');
 
+const PROP_TYPE_FUNCTIONS = ['object', 'shape', 'instanceOf', 'oneOf', 'oneOfType', 'objectOf', 'arrayOf', 'exact'];
+
 /**
  * Checks if the Identifier node passed in looks like a propTypes declaration.
  * @param {ASTNode} node The node to check. Must be an Identifier node.
@@ -63,10 +65,20 @@ function isRequiredPropType(propTypeExpression) {
   return propTypeExpression.type === 'MemberExpression' && propTypeExpression.property.name === 'isRequired';
 }
 
+/**
+ * Checks if the PropType is a function.
+ * @param {String} propType to check.
+ * @returns {Boolean} `true` if the PropType is a function, `false` if not.
+ */
+function isPropTypeAFunction(propType) {
+  return PROP_TYPE_FUNCTIONS.indexOf(propType) > -1;
+}
+
 module.exports = {
   isPropTypesDeclaration: isPropTypesDeclaration,
   isContextTypesDeclaration: isContextTypesDeclaration,
   isChildContextTypesDeclaration: isChildContextTypesDeclaration,
   isDefaultPropsDeclaration: isDefaultPropsDeclaration,
-  isRequiredPropType: isRequiredPropType
+  isRequiredPropType: isRequiredPropType,
+  isPropTypeAFunction: isPropTypeAFunction
 };

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -201,6 +201,138 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n')
   }, {
     code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.object({',
+      '      foo: PropTypes.string',
+      '    }),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.shape({',
+      '      foo: PropTypes.string',
+      '    }),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.instanceOf(Retailer),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.oneOf([',
+      '      "foo",',
+      '      "bar",',
+      '    ]),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.oneOfType([',
+      '      PropTypes.string,',
+      '      PropTypes.instanceOf(Retailer),',
+      '    ]),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.objectOf(PropTypes.string),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.arrayOf(PropTypes.string),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.exact({',
+      '      foo: PropTypes.string',
+      '    }),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
       'var First = createReactClass({',
       '  childContextTypes: externalPropTypes,',
       '  render: function() {',
@@ -890,6 +1022,231 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{
       forbid: ['object']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.object,',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.object(),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.object({}),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.shape,',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.shape(),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.shape({}),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.instanceOf(),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.oneOf(),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.oneOf([]),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.oneOfType(),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.oneOfType([]),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.objectOf(),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.arrayOf(),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.exact(),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var Hello = createReactClass({',
+      '  propTypes: {',
+      '    retailer: PropTypes.exact({}),',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
+    options: [{
+      forbid: ['empty']
     }],
     errors: 1
   }, {


### PR DESCRIPTION
This PR aims to fix #1673 by adding a new option to the forbid-prop-types rule: `empty`.

This will catch prop types which are functions, such as `shape()` or `arrayOf()`, but are used with either no arguments, or empty arguments (`{}` or `[]`). These prop types don't add a huge amount of value in those scenarios, and should be avoided if possible.

Feedback appreciated 🙂