### PR TITLE
Added check for template literals in no-string-refs rule

### DIFF
--- a/docs/rules/no-string-refs.md
+++ b/docs/rules/no-string-refs.md
@@ -26,6 +26,30 @@ var Hello = createReactClass({
 });
 ```
 
+The following patterns are **not** considered warnings:
+
+```jsx
+var Hello = createReactClass({
+  componentDidMount: function() {
+    var component = this.hello;
+    // ...do something with component
+  },
+  render() {
+    return <div ref={(c) => { this.hello = c; }}>Hello, world.</div>;
+  }
+});
+```
+
+## Rule Options
+
+```js
+"react/no-string-refs": [<enabled>, {"noTemplateLiterals": <boolean>}]
+```
+### `noTemplateLiterals`
+
+When set to `true`, it will give warning when using template literals for refs.
+The following patterns will be considered warnings:
+
 ```jsx
 var Hello = createReactClass({
  render: function() {
@@ -39,19 +63,5 @@ var Hello = createReactClass({
  render: function() {
   return <div ref={`hello${index}`}>Hello, world.</div>;
  }
-});
-```
-
-The following patterns are **not** considered warnings:
-
-```jsx
-var Hello = createReactClass({
-  componentDidMount: function() {
-    var component = this.hello;
-    // ...do something with component
-  },
-  render() {
-    return <div ref={(c) => { this.hello = c; }}>Hello, world.</div>;
-  }
 });
 ```

--- a/docs/rules/no-string-refs.md
+++ b/docs/rules/no-string-refs.md
@@ -26,6 +26,22 @@ var Hello = createReactClass({
 });
 ```
 
+```jsx
+var Hello = createReactClass({
+ render: function() {
+  return <div ref={`hello`}>Hello, world.</div>;
+ }
+});
+```
+
+```jsx
+var Hello = createReactClass({
+ render: function() {
+  return <div ref={`hello${index}`}>Hello, world.</div>;
+ }
+});
+```
+
 The following patterns are **not** considered warnings:
 
 ```jsx

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -75,8 +75,8 @@ module.exports = {
         node.value &&
         node.value.type === 'JSXExpressionContainer' &&
         node.value.expression &&
-        node.value.expression.type === 'Literal' &&
-        typeof node.value.expression.value === 'string'
+		((node.value.expression.type === 'Literal' && typeof node.value.expression.value === 'string') ||
+		node.value.expression.type === 'TemplateLiteral')
       );
     }
 

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -19,10 +19,19 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-string-refs')
     },
-    schema: []
+    schema: [{
+      type: 'object',
+      properties: {
+        noTemplateLiterals: {
+          type: 'boolean'
+        }
+      },
+      additionalProperties: false
+    }]
   },
 
   create: Components.detect((context, components, utils) => {
+    const detectTemplateLiterals = context.options[0] ? context.options[0].noTemplateLiterals : false;
     /**
      * Checks if we are using refs
      * @param {ASTNode} node The AST node being checked.
@@ -76,7 +85,7 @@ module.exports = {
         node.value.type === 'JSXExpressionContainer' &&
         node.value.expression &&
 		((node.value.expression.type === 'Literal' && typeof node.value.expression.value === 'string') ||
-		node.value.expression.type === 'TemplateLiteral')
+		(node.value.expression.type === 'TemplateLiteral' && detectTemplateLiterals))
       );
     }
 

--- a/tests/lib/rules/no-string-refs.js
+++ b/tests/lib/rules/no-string-refs.js
@@ -97,5 +97,41 @@ ruleTester.run('no-refs', rule, {
     }, {
       message: 'Using string literals in ref attributes is deprecated.'
     }]
+  },
+  {
+    code: [
+      'var Hello = createReactClass({',
+      '  componentDidMount: function() {',
+      '  var component = this.refs.hello;',
+      '  },',
+      '  render: function() {',
+      '    return <div ref={`hello`}>Hello {this.props.name}</div>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Using this.refs is deprecated.'
+    }, {
+      message: 'Using string literals in ref attributes is deprecated.'
+    }]
+  },
+  {
+    code: [
+      'var Hello = createReactClass({',
+      '  componentDidMount: function() {',
+      '  var component = this.refs.hello;',
+      '  },',
+      '  render: function() {',
+      '    return <div ref={`hello${index}`}>Hello {this.props.name}</div>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parser: 'babel-eslint',
+    errors: [{
+      message: 'Using this.refs is deprecated.'
+    }, {
+      message: 'Using string literals in ref attributes is deprecated.'
+    }]
   }]
 });

--- a/tests/lib/rules/no-string-refs.js
+++ b/tests/lib/rules/no-string-refs.js
@@ -38,6 +38,26 @@ ruleTester.run('no-refs', rule, {
       });
     `,
     parser: 'babel-eslint'
+  },
+  {
+    code: [
+      'var Hello = createReactClass({',
+      '  render: function() {',
+      '    return <div ref={`hello`}>Hello {this.props.name}</div>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parser: 'babel-eslint'
+  },
+  {
+    code: [
+      'var Hello = createReactClass({',
+      '  render: function() {',
+      '    return <div ref={`hello${index}`}>Hello {this.props.name}</div>;',
+      '  }',
+      '});'
+    ].join('\n'),
+    parser: 'babel-eslint'
   }
   ],
 
@@ -110,6 +130,7 @@ ruleTester.run('no-refs', rule, {
       '});'
     ].join('\n'),
     parser: 'babel-eslint',
+    options: [{noTemplateLiterals: true}],
     errors: [{
       message: 'Using this.refs is deprecated.'
     }, {
@@ -128,6 +149,7 @@ ruleTester.run('no-refs', rule, {
       '});'
     ].join('\n'),
     parser: 'babel-eslint',
+    options: [{noTemplateLiterals: true}],
     errors: [{
       message: 'Using this.refs is deprecated.'
     }, {


### PR DESCRIPTION
This PR aims to fix https://github.com/yannickcr/eslint-plugin-react/issues/2148.

no-string-ref will throw warning when using template literals in string refs.