### PR TITLE
[jsx-sort-default-props] Bug fix for one case with spread

### DIFF
--- a/lib/rules/jsx-sort-default-props.js
+++ b/lib/rules/jsx-sort-default-props.js
@@ -96,7 +96,7 @@ module.exports = {
      */
     function checkSorted(declarations) {
       declarations.reduce((prev, curr, idx, decls) => {
-        if (/SpreadProperty$/.test(curr.type)) {
+        if (/Spread(?:Property|Element)$/.test(curr.type)) {
           return decls[idx + 1];
         }
 

--- a/tests/lib/rules/jsx-sort-default-props.js
+++ b/tests/lib/rules/jsx-sort-default-props.js
@@ -326,6 +326,25 @@ ruleTester.run('jsx-sort-default-props', rule, {
       'First.propTypes = propTypes;',
       'First.defaultProps = defaultProps;'
     ].join('\n')
+  }, {
+    code: [
+      'const defaults = {',
+      '  b: "b"',
+      '};',
+      'const First = (props) => <div />;',
+      'export const propTypes = {',
+      '    a: PropTypes.string,',
+      '    b: PropTypes.string,',
+      '    z: PropTypes.string,',
+      '};',
+      'export const defaultProps = {',
+      '    ...defaults,',
+      '    a: "a",',
+      '    z: "z",',
+      '};',
+      'First.propTypes = propTypes;',
+      'First.defaultProps = defaultProps;'
+    ].join('\n')
   }],
 
   invalid: [{


### PR DESCRIPTION
Closes #2178

I thought an option was needed, but instead it was a bug