### PR TITLE
[Fix] `jsx-curly-brace-presence`: accept multiline template string

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -182,6 +182,7 @@ module.exports = {
       } else if (
         expressionType === 'TemplateLiteral' &&
           expression.expressions.length === 0 &&
+          expression.quasis[0].value.raw.indexOf('\n') === -1 &&
           !needToEscapeCharacterForJSX(expression.quasis[0].value.raw) && (
           jsxUtil.isJSX(JSXExpressionNode.parent) ||
           !containsQuoteCharacters(expression.quasis[0].value.cooked)

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -241,6 +241,44 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
     {
       code: ['<a a={"start\\', '\\', 'end"}/>'].join('/n'),
       options: ['never']
+    },
+    {
+      code: `
+        <App prop={\`
+          a
+          b
+        \`} />
+      `,
+      options: ['never']
+    },
+    {
+      code: `
+        <App prop={\`
+          a
+          b
+        \`} />
+      `,
+      options: ['always']
+    },
+    {
+      code: `
+        <App>
+          {\`
+            a
+            b
+          \`}
+        </App>
+      `,
+      options: ['never']
+    },
+    {
+      code: `
+        <App>{\`
+          a
+          b
+        \`}</App>
+      `,
+      options: ['always']
     }
   ],
 


### PR DESCRIPTION
Fixes #1592

Multi-line template string is no longer considered error.
```javascript
<App prop={`
   a
   b
`} />
```