### PR TITLE
[Fix]`no-unknown-property`: fix case like `<Foo.bar>`

### DIFF
--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -168,6 +168,20 @@ function getTagName(node) {
 }
 
 /**
+ * Test wether the tag name for the JSXAttribute is
+ * something like <Foo.bar />
+ * @param {JSXAttribute} node - JSXAttribute being tested.
+ * @returns {Boolean} result
+ */
+function tagNameHasDot(node) {
+  return !!(
+    node.parent &&
+    node.parent.name &&
+    node.parent.name.type === 'JSXMemberExpression'
+  );
+}
+
+/**
  * Get the standard name of the attribute.
  * @param {String} name - Name of the attribute.
  * @returns {String} The standard name of the attribute.
@@ -228,6 +242,11 @@ module.exports = {
         const ignoreNames = getIgnoreConfig();
         const name = sourceCode.getText(node.name);
         if (ignoreNames.indexOf(name) >= 0) {
+          return;
+        }
+
+        // Ignore tags like <Foo.bar />
+        if (tagNameHasDot(node)) {
           return;
         }
 

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -29,6 +29,7 @@ ruleTester.run('no-unknown-property', rule, {
   valid: [
     {code: '<App class="bar" />;'},
     {code: '<App for="bar" />;'},
+    {code: '<Foo.bar for="bar" />;'},
     {code: '<App accept-charset="bar" />;'},
     {code: '<meta charset="utf-8" />;'},
     {code: '<meta charSet="utf-8" />;'},


### PR DESCRIPTION
Fixes #2204