### PR TITLE
[Fix]`self-closing-comp`: stop reporting single-line spaces

### DIFF
--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -44,15 +44,19 @@ module.exports = {
       return node.name && node.name.type === 'JSXIdentifier' && !jsxUtil.isDOMComponent(node);
     }
 
-    function hasChildren(node) {
+    function childrenIsEmpty(node) {
+      return node.parent.children.length === 0;
+    }
+
+    function childrenIsMultilineSpaces(node) {
       const childrens = node.parent.children;
-      if (
-        !childrens.length ||
-        (childrens.length === 1 && (childrens[0].type === 'Literal' || childrens[0].type === 'JSXText') && !childrens[0].value.replace(/(?!\xA0)\s/g, ''))
-      ) {
-        return false;
-      }
-      return true;
+
+      return (
+        childrens.length === 1 &&
+        (childrens[0].type === 'Literal' || childrens[0].type === 'JSXText') &&
+        childrens[0].value.indexOf('\n') !== -1 &&
+        childrens[0].value.replace(/(?!\xA0)\s/g, '') === ''
+      );
     }
 
     function isShouldBeSelfClosed(node) {
@@ -60,7 +64,7 @@ module.exports = {
       return (
         configuration.component && isComponent(node) ||
         configuration.html && jsxUtil.isDOMComponent(node)
-      ) && !node.selfClosing && !hasChildren(node);
+      ) && !node.selfClosing && (childrenIsEmpty(node) || childrenIsMultilineSpaces(node));
     }
 
     // --------------------------------------------------------------------------

--- a/tests/lib/rules/self-closing-comp.js
+++ b/tests/lib/rules/self-closing-comp.js
@@ -38,6 +38,10 @@ ruleTester.run('self-closing-comp', rule, {
         </Hello>
       `
     }, {
+      code: 'var HelloJohn = <Hello name="John"> </Hello>;'
+    }, {
+      code: 'var HelloJohn = <Hello name="John">        </Hello>;'
+    }, {
       code: 'var HelloJohn = <div>&nbsp;</div>;'
     }, {
       code: 'var HelloJohn = <div>{\' \'}</div>;'
@@ -55,6 +59,12 @@ ruleTester.run('self-closing-comp', rule, {
           <Hello name="John" />
         </Hello>
       `,
+      options: []
+    }, {
+      code: 'var HelloJohn = <div> </div>;',
+      options: []
+    }, {
+      code: 'var HelloJohn = <div>        </div>;',
       options: []
     }, {
       code: 'var HelloJohn = <div>&nbsp;</div>;',
@@ -117,13 +127,6 @@ ruleTester.run('self-closing-comp', rule, {
         message: 'Empty components are self-closing'
       }]
     }, {
-      code: 'var HelloJohn = <Hello name="John"> </Hello>;',
-      output: 'var HelloJohn = <Hello name="John" />;',
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    },
-    {
       code: 'var HelloJohn = <Hello name="John"></Hello>;',
       output: 'var HelloJohn = <Hello name="John" />;',
       options: [],
@@ -138,13 +141,6 @@ ruleTester.run('self-closing-comp', rule, {
         message: 'Empty components are self-closing'
       }]
     }, {
-      code: 'var HelloJohn = <Hello name="John"> </Hello>;',
-      output: 'var HelloJohn = <Hello name="John" />;',
-      options: [],
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    }, {
       code: 'var contentContainer = <div className="content"></div>;',
       output: 'var contentContainer = <div className="content" />;',
       options: [{html: true}],
@@ -153,13 +149,6 @@ ruleTester.run('self-closing-comp', rule, {
       }]
     }, {
       code: 'var contentContainer = <div className="content">\n</div>;',
-      output: 'var contentContainer = <div className="content" />;',
-      options: [{html: true}],
-      errors: [{
-        message: 'Empty components are self-closing'
-      }]
-    }, {
-      code: 'var contentContainer = <div className="content"> </div>;',
       output: 'var contentContainer = <div className="content" />;',
       options: [{html: true}],
       errors: [{


### PR DESCRIPTION
Closes #1717

React does not trim JSXText if it is single-line spaces.
In case like `<span>    </span>`, the spaces are left as is.