### PR TITLE
[Fix] `display-name`: fix false negative around nested functions

### DIFF
--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -160,21 +160,27 @@ module.exports = {
         if (ignoreTranspilerName || !hasTranspilerName(node)) {
           return;
         }
-        markDisplayNameAsDeclared(node);
+        if (components.get(node)) {
+          markDisplayNameAsDeclared(node);
+        }
       },
 
       FunctionDeclaration: function(node) {
         if (ignoreTranspilerName || !hasTranspilerName(node)) {
           return;
         }
-        markDisplayNameAsDeclared(node);
+        if (components.get(node)) {
+          markDisplayNameAsDeclared(node);
+        }
       },
 
       ArrowFunctionExpression: function(node) {
         if (ignoreTranspilerName || !hasTranspilerName(node)) {
           return;
         }
-        markDisplayNameAsDeclared(node);
+        if (components.get(node)) {
+          markDisplayNameAsDeclared(node);
+        }
       },
 
       MethodDefinition: function(node) {

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -693,5 +693,65 @@ ruleTester.run('display-name', rule, {
     errors: [{
       message: 'Component definition is missing display name'
     }]
+  }, {
+    code: `
+      module.exports = function () {
+        function a () {}
+        const b = function b () {}
+        const c = function () {}
+        const d = () => {}
+        const obj = {
+          a: function a () {},
+          b: function b () {},
+          c () {},
+          d: () => {},
+        }
+        return React.createElement("div", {}, "text content");
+      }
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: `
+      module.exports = () => {
+        function a () {}
+        const b = function b () {}
+        const c = function () {}
+        const d = () => {}
+        const obj = {
+          a: function a () {},
+          b: function b () {},
+          c () {},
+          d: () => {},
+        }
+
+        return React.createElement("div", {}, "text content");
+      }
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: `
+      export default class extends React.Component {
+        render() {
+          function a () {}
+          const b = function b () {}
+          const c = function () {}
+          const d = () => {}
+          const obj = {
+            a: function a () {},
+            b: function b () {},
+            c () {},
+            d: () => {},
+          }
+          return <div>Hello {this.props.name}</div>;
+        }
+      }
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
   }]
 });


### PR DESCRIPTION
Fixes https://github.com/yannickcr/eslint-plugin-react/issues/2221

RFC --- this is most likely not a good solution.

I've made sure that the component is marked only if the function node is the component itself.
