### PR TITLE
[New] add `jsx-quoted-string-props` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Enable the rules that you would like to use.
 * [react/jsx-pascal-case](docs/rules/jsx-pascal-case.md): Enforce PascalCase for user-defined JSX components
 * [react/jsx-props-no-multi-spaces](docs/rules/jsx-props-no-multi-spaces.md): Disallow multiple spaces between inline JSX props (fixable)
 * [react/jsx-props-no-spreading](docs/rules/jsx-props-no-spreading.md): Disallow JSX props spreading
+* [react/jsx-quoted-string-props](docs/rules/jsx-quoted-string-props.md): Disallow JSX props using string only property expressions
 * [react/jsx-sort-default-props](docs/rules/jsx-sort-default-props.md): Enforce default props alphabetical sorting
 * [react/jsx-sort-props](docs/rules/jsx-sort-props.md): Enforce props alphabetical sorting (fixable)
 * [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md): Validate spacing before closing bracket in JSX (fixable)

--- a/docs/rules/jsx-quoted-string-props.md
+++ b/docs/rules/jsx-quoted-string-props.md
@@ -1,0 +1,23 @@
+# Prevent using string only property expressions in JSX (react/jsx-quoted-string-props)
+
+This rule enforces consistent usage of JSX properties with string values.
+
+## Rule Details
+
+In JSX, you can use quotes to specify attributes with string values, or curly braces with expressions that may return any data type. That is, there are two ways of specifying string values, either `name="value"` or `name={'value'}`. This rule requires the usage of quotes for attributes with string values.
+
+The following patterns is considered a warnings:
+
+```jsx
+<div id={'foobar'} />
+```
+
+The following pattern is **not** considered a warning:
+
+```jsx
+<div id="foobar" />
+```
+
+## When Not To Use It
+
+This rule is a formatting preference. If consistent string attribute values are not part of your coding standards, then you can leave this rule off.

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ const allRules = {
   'jsx-fragments': require('./lib/rules/jsx-fragments'),
   'jsx-props-no-multi-spaces': require('./lib/rules/jsx-props-no-multi-spaces'),
   'jsx-props-no-spreading': require('./lib/rules/jsx-props-no-spreading'),
+  'jsx-quoted-string-props': require('./lib/rules/jsx-quoted-string-props'),
   'jsx-sort-default-props': require('./lib/rules/jsx-sort-default-props'),
   'jsx-sort-props': require('./lib/rules/jsx-sort-props'),
   'jsx-space-before-closing': require('./lib/rules/jsx-space-before-closing'),

--- a/lib/rules/jsx-quoted-string-props.js
+++ b/lib/rules/jsx-quoted-string-props.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Prevent using string only property expressions
+ */
+'use strict';
+
+const docsUrl = require('../util/docsUrl');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Prevent using string only property expressions',
+      category: 'Stylistic Issues',
+      recommended: false,
+      url: docsUrl('jsx-quoted-string-props')
+    },
+    schema: []
+  },
+
+  create: function(context) {
+    // --------------------------------------------------------------------------
+    // Public
+    // --------------------------------------------------------------------------
+
+    return {
+      JSXOpeningElement: function (node) {
+        node.attributes.forEach(decl => {
+          if (decl.type === 'JSXSpreadAttribute') {
+            return;
+          }
+
+          if (!decl.value || decl.value.type !== 'JSXExpressionContainer') {
+            return;
+          }
+
+          if (decl.value.expression.type === 'Literal' && typeof decl.value.expression.value === 'string') {
+            context.report({
+              node: decl,
+              message: `String literal value for property '${decl.name.name}' shouldn't be wrapped as an expression`
+            });
+          }
+        });
+      }
+    };
+  }
+};

--- a/tests/lib/rules/jsx-quoted-string-props.js
+++ b/tests/lib/rules/jsx-quoted-string-props.js
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Tests for jsx-quoted-string-props
+ */
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const rule = require('../../../lib/rules/jsx-quoted-string-props');
+const RuleTester = require('eslint').RuleTester;
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+function errMessage(propName) {
+  return `String literal value for property '${propName}' shouldn't be wrapped as an expression`;
+}
+
+const ruleTester = new RuleTester({parserOptions});
+ruleTester.run('jsx-quoted-string-props', rule, {
+  valid: [
+    {
+      code: `
+        <div id="foobar" />
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        <div>{'foobar'}</div>
+       `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        <div prop={0} />
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        <div prop={true} />
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        <div prop={['foobar']} />
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        <div prop={'foobar'.toString()} />
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        <div prop={'foobar' + ''} />
+      `,
+      parser: 'babel-eslint'
+    }, {
+      code: `
+        <div prop />
+      `,
+      parser: 'babel-eslint'
+    }
+  ],
+
+  invalid: [
+    {
+      code: `
+        <div id={'foobar'} />
+      `,
+      parser: 'babel-eslint',
+      errors: [{message: errMessage('id')}]
+    }
+  ]
+});


### PR DESCRIPTION
Implements #529. Enforce quoted props for string-typed property values.

Bad:

```jsx
<div id={'foobar'} />
```

Good:

```jsx
<div id="foobar" />
```

Since this is the first ESLint rule I've ever implemented, feel free to be picky, feedback is highly welcome!