### PR TITLE
[Update]`require-render-return`: more accurate report location

### DIFF
--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -35,19 +35,15 @@ module.exports = {
     }
 
     /**
-     * Check if a given AST node has a render method
-     * @param {ASTNode} node The AST node being checked.
-     * @returns {Boolean} True if there is a render method, false if not
+     * Find render method in a given AST node
+     * @param {ASTNode} node The component to find render method.
+     * @returns {ASTNode} Method node if found, undefined if not.
      */
-    function hasRenderMethod(node) {
+    function findRenderMethod(node) {
       const properties = astUtil.getComponentProperties(node);
-      for (let i = 0, j = properties.length; i < j; i++) {
-        if (astUtil.getPropertyName(properties[i]) !== 'render' || !properties[i].value) {
-          continue;
-        }
-        return astUtil.isFunctionLikeExpression(properties[i].value);
-      }
-      return false;
+      return properties
+        .filter(property => astUtil.getPropertyName(property) === 'render' && property.value)
+        .find(property => astUtil.isFunctionLikeExpression(property.value));
     }
 
     return {
@@ -80,14 +76,14 @@ module.exports = {
         const list = components.list();
         Object.keys(list).forEach(component => {
           if (
-            !hasRenderMethod(list[component].node) ||
+            !findRenderMethod(list[component].node) ||
             list[component].hasReturnStatement ||
             (!utils.isES5Component(list[component].node) && !utils.isES6Component(list[component].node))
           ) {
             return;
           }
           context.report({
-            node: list[component].node,
+            node: findRenderMethod(list[component].node),
             message: 'Your render method should have return statement'
           });
         });

--- a/tests/lib/rules/require-render-return.js
+++ b/tests/lib/rules/require-render-return.js
@@ -147,7 +147,8 @@ ruleTester.run('require-render-return', rule, {
       });
     `,
     errors: [{
-      message: 'Your render method should have return statement'
+      message: 'Your render method should have return statement',
+      line: 4
     }]
   }, {
     // Missing return in ES6 class
@@ -171,7 +172,8 @@ ruleTester.run('require-render-return', rule, {
       }
     `,
     errors: [{
-      message: 'Your render method should have return statement'
+      message: 'Your render method should have return statement',
+      line: 3
     }]
   }, {
     // Missing return ES6 class render property
@@ -184,7 +186,8 @@ ruleTester.run('require-render-return', rule, {
     `,
     parser: 'babel-eslint',
     errors: [{
-      message: 'Your render method should have return statement'
+      message: 'Your render method should have return statement',
+      type: 'ClassProperty'
     }]
   }]
 });


### PR DESCRIPTION
Previously the reported node is the whole component.
Now the reported node is the render method.