### PR TITLE
[Fix] - Fix sorting props with numeric keys

### DIFF
--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -85,6 +85,10 @@ module.exports = {
       return node.arguments && node.arguments[0] && node.arguments[0].properties;
     }
 
+    function toLowerCase(item) {
+      return String(item).toLowerCase();
+    }
+
     function sorter(a, b) {
       let aKey = getKey(a);
       let bKey = getKey(b);
@@ -107,8 +111,8 @@ module.exports = {
       }
 
       if (ignoreCase) {
-        aKey = aKey.toLowerCase();
-        bKey = bKey.toLowerCase();
+        aKey = toLowerCase(aKey);
+        bKey = toLowerCase(bKey);
       }
 
       if (aKey < bKey) {
@@ -188,8 +192,8 @@ module.exports = {
         const currentIsCallback = isCallbackPropName(currentPropName);
 
         if (ignoreCase) {
-          prevPropName = prevPropName.toLowerCase();
-          currentPropName = currentPropName.toLowerCase();
+          prevPropName = toLowerCase(prevPropName);
+          currentPropName = toLowerCase(currentPropName);
         }
 
         if (requiredFirst) {

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -410,6 +410,21 @@ ruleTester.run('sort-prop-types', rule, {
     options: [{
       noSortAlphabetically: true
     }]
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        0: PropTypes.any,
+        1: PropTypes.any,
+      };
+    `,
+    options: [{
+      ignoreCase: true
+    }]
   }],
 
   invalid: [{
@@ -1565,5 +1580,37 @@ ruleTester.run('sort-prop-types', rule, {
       '  }',
       '});'
     ].join('\n')
+  }, {
+    code: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        1: PropTypes.any,
+        0: PropTypes.any,
+      };
+    `,
+    options: [{
+      ignoreCase: true
+    }],
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 9,
+      column: 9,
+      type: 'Property'
+    }],
+    output: `
+      class Component extends React.Component {
+        render() {
+          return <div />;
+        }
+      }
+      Component.propTypes = {
+        0: PropTypes.any,
+        1: PropTypes.any,
+      };
+    `
   }]
 });


### PR DESCRIPTION
Error occurs when some of props has keys declared as numbers. Object keys shouldn't be declared as numbers. Nevertheless, error should not occur.

Fixes #2212.