### PR TITLE
[Fix] Ignoring pure components without props and context usage

### DIFF
--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -66,7 +66,7 @@ class Foo extends React.Component {
 
 When `true` the rule will ignore Components extending from `React.PureComponent` that use `this.props` or `this.context`.
 
-The following pattern is considered okay and does **not** cause warnings:
+The following patterns are considered okay and does **not** cause warnings:
 
 ```jsx
 class Foo extends React.PureComponent {
@@ -74,14 +74,10 @@ class Foo extends React.PureComponent {
     return <div>{this.props.foo}</div>;
   }
 }
-```
 
-The following pattern is considered a warning because it's not using props or context:
-
-```jsx
-class Foo extends React.PureComponent {
+class Bar extends React.PureComponent {
   render() {
-    return <div>Bar</div>;
+    return <div>Baz</div>;
   }
 }
 ```

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -369,7 +369,7 @@ module.exports = {
             return;
           }
 
-          if (list[component].hasSCU && list[component].usePropsOrContext) {
+          if (list[component].hasSCU) {
             return;
           }
           context.report({

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -304,6 +304,18 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       parser: 'babel-eslint'
+    },
+    {
+      code: `
+        class Child extends PureComponent {
+          render() {
+            return <h1>I don't</h1>;
+          }
+        }
+      `,
+      options: [{
+        ignorePureComponents: true
+      }]
     }
   ],
 
@@ -339,9 +351,6 @@ ruleTester.run('prefer-stateless-function', rule, {
           }
         }
       `,
-      options: [{
-        ignorePureComponents: true
-      }],
       errors: [{
         message: 'Component should be written as a pure function'
       }]


### PR DESCRIPTION
Pure components without props are still valid, since they prevent rerendering of component even if parent component is being rerendered.