### PR TITLE
Allow jsx-pascal-case to ignore using regexps

### DIFF
--- a/docs/rules/jsx-pascal-case.md
+++ b/docs/rules/jsx-pascal-case.md
@@ -46,7 +46,7 @@ The following patterns are **not** considered warnings:
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
 * `allowAllCaps`: optional boolean set to `true` to allow components name in all caps (default to `false`).
-* `ignore`: optional array of components name to ignore during validation.
+* `ignore`: optional array of component names (strings or regexps) to ignore during validation.
 
 ## When Not To Use It
 

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -62,7 +62,12 @@ module.exports = {
         const isPascalCase = PASCAL_CASE_REGEX.test(name);
         const isCompatTag = jsxUtil.isDOMComponent(node);
         const isAllowedAllCaps = allowAllCaps && ALL_CAPS_TAG_REGEX.test(name);
-        const isIgnored = ignore.indexOf(name) !== -1;
+        const isIgnored = ignore.find(stringOrRegexp => {
+          if (stringOrRegexp instanceof RegExp) {
+            return stringOrRegexp.test(name);
+          }
+          return stringOrRegexp === name;
+        });
 
         if (!isPascalCase && !isCompatTag && !isAllowedAllCaps && !isIgnored) {
           context.report({

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -49,6 +49,9 @@ ruleTester.run('jsx-pascal-case', rule, {
     code: '<YMCA />',
     options: [{allowAllCaps: true}]
   }, {
+    code: '<YMCA />',
+    options: [{ignore: [/^[A-Z]+$/]}]
+  }, {
     code: '<Modal.Header />'
   }, {
     code: '<Modal:Header />'


### PR DESCRIPTION
We want to ignore a consistent theme of component naming in our project, where the offending component names match a regexp, without having to individually label each of the components, or
to individually eslint-disable each of the instances.

This should be backwards compatible with existing rule sets, and matches how the `camelcase` rule works in eslint (which also supports regexps).