### PR TITLE
[fix] `jsx-props-no-multi-spaces`: support generic components (ts)

### DIFF
--- a/lib/rules/jsx-props-no-multi-spaces.js
+++ b/lib/rules/jsx-props-no-multi-spaces.js
@@ -55,12 +55,37 @@ module.exports = {
       }
     }
 
+    function containsGenericType(node) {
+      const containsTypeParams = typeof node.typeParameters !== 'undefined';
+      return containsTypeParams && node.typeParameters.type === 'TSTypeParameterInstantiation';
+    }
+
+    function getGenericNode(node) {
+      const name = node.name;
+      if (containsGenericType(node)) {
+        const type = node.typeParameters;
+
+        return Object.assign(
+          {},
+          node,
+          {
+            range: [
+              name.range[0],
+              type.range[1]
+            ]
+          }
+        );
+      }
+
+      return name;
+    }
+
     return {
       JSXOpeningElement: function (node) {
         node.attributes.reduce((prev, prop) => {
           checkSpacing(prev, prop);
           return prop;
-        }, node.name);
+        }, getGenericNode(node));
       }
     };
   }

--- a/tests/lib/rules/jsx-props-no-multi-spaces.js
+++ b/tests/lib/rules/jsx-props-no-multi-spaces.js
@@ -11,6 +11,8 @@
 const rule = require('../../../lib/rules/jsx-props-no-multi-spaces');
 const RuleTester = require('eslint').RuleTester;
 
+const parsers = require('../../helpers/parsers');
+
 const parserOptions = {
   ecmaVersion: 2018,
   sourceType: 'module',
@@ -58,6 +60,9 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
       '  foo {...test}',
       '  bar />'
     ].join('\n')
+  }, {
+    code: '<App<T> foo bar />',
+    parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: '<Foo.Bar baz="quux" />'
   }, {


### PR DESCRIPTION
```typescript
<Foo<T> bar />
```
**Error:**
Expected only one space between "Foo" and "bar"

Fixes https://github.com/yannickcr/eslint-plugin-react/issues/2181