### PR TITLE
Remove no-render-return-value from recommended

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,6 @@ The rules enabled in this configuration are:
 * [react/no-direct-mutation-state](docs/rules/no-direct-mutation-state.md)
 * [react/no-find-dom-node](docs/rules/no-find-dom-node.md)
 * [react/no-is-mounted](docs/rules/no-is-mounted.md)
-* [react/no-render-return-value](docs/rules/no-render-return-value.md)
 * [react/no-string-refs](docs/rules/no-string-refs.md)
 * [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md)
 * [react/no-unknown-property](docs/rules/no-unknown-property.md)

--- a/index.js
+++ b/index.js
@@ -141,7 +141,6 @@ module.exports = {
         'react/no-direct-mutation-state': 2,
         'react/no-find-dom-node': 2,
         'react/no-is-mounted': 2,
-        'react/no-render-return-value': 2,
         'react/no-string-refs': 2,
         'react/no-unescaped-entities': 2,
         'react/no-unknown-property': 2,

--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -16,7 +16,7 @@ module.exports = {
     docs: {
       description: 'Prevent usage of the return value of React.render',
       category: 'Best Practices',
-      recommended: true,
+      recommended: false,
       url: docsUrl('no-render-return-value')
     },
     schema: []


### PR DESCRIPTION
This rules is about a potential future change to a ReactDOM interface
not any actual problem, and is the slowest `plugin:react/recommended`
by a factor of about 3.

Timings from one of our projects:

```
Rule                           | Time (ms) | Relative
:------------------------------|----------:|--------:
import/namespace               |  5505.442 |    19.3%
indent                         |  4169.809 |    14.6%
react/no-render-return-value   |  3402.119 |    11.9%
import/named                   |  1252.616 |     4.4%
react/no-deprecated            |  1165.668 |     4.1%
react/display-name             |  1126.994 |     4.0%
react/no-direct-mutation-state |  1109.049 |     3.9%
react/sort-comp                |   691.149 |     2.4%
react/no-string-refs           |   680.091 |     2.4%
import/default                 |   622.367 |     2.2%
```

Removing the rule does save 4s from a 60s run.

