### PR TITLE
[Refactor] `no-render-return-value`: reuse version test result

### DIFF
--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -27,6 +27,15 @@ module.exports = {
     // Public
     // --------------------------------------------------------------------------
 
+    let calleeObjectName = /^ReactDOM$/;
+    if (versionUtil.testReactVersion(context, '15.0.0')) {
+      calleeObjectName = /^ReactDOM$/;
+    } else if (versionUtil.testReactVersion(context, '0.14.0')) {
+      calleeObjectName = /^React(DOM)?$/;
+    } else if (versionUtil.testReactVersion(context, '0.13.0')) {
+      calleeObjectName = /^React$/;
+    }
+
     return {
 
       CallExpression: function(node) {
@@ -34,15 +43,6 @@ module.exports = {
         const parent = node.parent;
         if (callee.type !== 'MemberExpression') {
           return;
-        }
-
-        let calleeObjectName = /^ReactDOM$/;
-        if (versionUtil.testReactVersion(context, '15.0.0')) {
-          calleeObjectName = /^ReactDOM$/;
-        } else if (versionUtil.testReactVersion(context, '0.14.0')) {
-          calleeObjectName = /^React(DOM)?$/;
-        } else if (versionUtil.testReactVersion(context, '0.13.0')) {
-          calleeObjectName = /^React$/;
         }
 
         if (

--- a/tests/lib/rules/no-render-return-value.js
+++ b/tests/lib/rules/no-render-return-value.js
@@ -54,6 +54,17 @@ ruleTester.run('no-render-return-value', rule, {
         version: '0.13.0'
       }
     }
+  }, {
+    code: 'var foo = React.render(<div />, root);',
+    settings: {
+      react: {
+        version: '0.0.1'
+      }
+    }
+  }, {
+    code: 'var foo = render(<div />, root)'
+  }, {
+    code: 'var foo = ReactDom.renderder(<div />, root)'
   }],
 
   invalid: [{


### PR DESCRIPTION
This commit likely fixes the performace issue noted in #2259.
