### PR TITLE
[Refactor]: remove unused codes in util/propTypes

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -23,9 +23,8 @@ declare global {
     [k in string]: TypeDeclarationBuilder;
   };
 
-  type UnionTypeDefinitionChildren = unknown[];
   type UnionTypeDefinition = {
     type: 'union' | 'shape';
-    children: UnionTypeDefinitionChildren | true;
+    children: unknown[];
   };
 }

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -170,22 +170,9 @@ module.exports = function propTypesInstructions(context, components, utils) {
       /** @type {UnionTypeDefinition} */
       const unionTypeDefinition = {
         type: 'union',
-        children: []
+        children: annotation.types.map(type => buildTypeAnnotationDeclarationTypes(type, parentName, seen))
       };
-      for (let i = 0, j = annotation.types.length; i < j; i++) {
-        const type = buildTypeAnnotationDeclarationTypes(annotation.types[i], parentName, seen);
-        // keep only complex type
-        if (type.type) {
-          if (type.children === true) {
-            // every child is accepted for one type, abort type analysis
-            unionTypeDefinition.children = true;
-            return unionTypeDefinition;
-          }
-        }
-
-        /** @type {UnionTypeDefinitionChildren} */(unionTypeDefinition.children).push(type);
-      }
-      if (/** @type {UnionTypeDefinitionChildren} */(unionTypeDefinition.children).length === 0) {
+      if (unionTypeDefinition.children.length === 0) {
         // no complex type found, simply accept everything
         return {};
       }
@@ -419,34 +406,14 @@ module.exports = function propTypesInstructions(context, components, utils) {
           /** @type {UnionTypeDefinition} */
           const unionTypeDefinition = {
             type: 'union',
-            children: []
+            children: argument.elements.map(element => buildReactDeclarationTypes(element, parentName))
           };
-          for (let i = 0, j = argument.elements.length; i < j; i++) {
-            const type = buildReactDeclarationTypes(argument.elements[i], parentName);
-            // keep only complex type
-            if (type.type) {
-              if (type.children === true) {
-                // every child is accepted for one type, abort type analysis
-                unionTypeDefinition.children = true;
-                return unionTypeDefinition;
-              }
-            }
-
-            /** @type {UnionTypeDefinitionChildren} */(unionTypeDefinition.children).push(type);
-          }
-          if (/** @type {UnionTypeDefinitionChildren} */(unionTypeDefinition.children).length === 0) {
+          if (unionTypeDefinition.children.length === 0) {
             // no complex type found, simply accept everything
             return {};
           }
           return unionTypeDefinition;
         }
-        case 'instanceOf':
-          return {
-            type: 'instance',
-            // Accept all children because we can't know what type they are
-            children: true
-          };
-        case 'oneOf':
         default:
           return {};
       }


### PR DESCRIPTION
`UnionTypeDefinition.children` had a inconvenient type `unknown[]|true`. It turned out `children === true` never happens, so the related codes can be removed.