### PR TITLE
Change the reporting for no-unused-prop-types

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -104,7 +104,7 @@ module.exports = {
 
         if (prop.node && !isPropUsed(component, prop)) {
           context.report({
-            node: prop.node.value || prop.node,
+            node: prop.node.key || prop.node,
             message: UNUSED_MESSAGE,
             data: {
               name: prop.fullName

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -3229,7 +3229,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -3245,7 +3245,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'name\' PropType is defined but prop is never used',
         line: 3,
-        column: 11
+        column: 5
       }]
     }, {
       code: [
@@ -3262,7 +3262,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'name\' PropType is defined but prop is never used',
         line: 3,
-        column: 11
+        column: 5
       }]
     }, {
       code: [
@@ -4061,7 +4061,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4079,7 +4079,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4097,7 +4097,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4114,7 +4114,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4132,7 +4132,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4149,7 +4149,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4167,7 +4167,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4184,7 +4184,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4202,7 +4202,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4219,7 +4219,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'unused\' PropType is defined but prop is never used',
         line: 3,
-        column: 13
+        column: 5
       }]
     }, {
       code: [
@@ -4236,7 +4236,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'something\' PropType is defined but prop is never used',
         line: 3,
-        column: 16
+        column: 5
       }]
     }, {
       code: [
@@ -4252,7 +4252,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'something\' PropType is defined but prop is never used',
         line: 3,
-        column: 16
+        column: 5
       }]
     }, {
       code: [
@@ -4273,7 +4273,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 4,
-        column: 10
+        column: 5
       }]
     }, {
       // Multiple props used inside of an async class property
@@ -4294,7 +4294,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'baz\' PropType is defined but prop is never used',
         line: 5,
-        column: 10
+        column: 5
       }]
     }, {
       code: [
@@ -4313,7 +4313,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 10,
-        column: 8
+        column: 3
       }]
     }, {
       code: [
@@ -4334,7 +4334,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 4,
-        column: 10
+        column: 5
       }]
     }, {
       // Multiple destructured props inside of async class property
@@ -4375,7 +4375,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 4,
-        column: 10
+        column: 5
       }]
     }, {
       code: [
@@ -4394,7 +4394,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 10,
-        column: 8
+        column: 3
       }]
     }, {
       code: [
@@ -4415,7 +4415,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 4,
-        column: 10
+        column: 5
       }]
     }, {
       // Multiple destructured props inside of async class method
@@ -4437,7 +4437,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'baz\' PropType is defined but prop is never used',
         line: 5,
-        column: 10
+        column: 5
       }]
     }, {
       // factory functions that return async functions
@@ -4460,7 +4460,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'baz\' PropType is defined but prop is never used',
         line: 5,
-        column: 10
+        column: 5
       }]
     }, {
       code: [
@@ -4479,7 +4479,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 10,
-        column: 8
+        column: 3
       }]
     }, {
       code: [
@@ -4498,7 +4498,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 10,
-        column: 8
+        column: 3
       }],
       settings: {
         propWrapperFunctions: ['forbidExtraProps']
@@ -4521,7 +4521,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'bar\' PropType is defined but prop is never used',
         line: 4,
-        column: 10
+        column: 5
       }],
       settings: {
         propWrapperFunctions: ['forbidExtraProps']
@@ -4547,7 +4547,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'foo\' PropType is defined but prop is never used',
         line: 3,
-        column: 10
+        column: 5
       }]
     }, {
       // Multiple props used inside of an async function
@@ -4571,7 +4571,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'baz\' PropType is defined but prop is never used',
         line: 13,
-        column: 8
+        column: 3
       }]
     }, {
       // Multiple props used inside of an async arrow function
@@ -4595,7 +4595,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: '\'foo\' PropType is defined but prop is never used',
         line: 11,
-        column: 8
+        column: 3
       }]
     }, {
       // None of the props are used issue #1162
@@ -4739,7 +4739,7 @@ ruleTester.run('no-unused-prop-types', rule, {
       errors: [{
         message: "'unusedProp' PropType is defined but prop is never used",
         line: 7,
-        column: 23
+        column: 11
       }]
     }, {
       code: `


### PR DESCRIPTION
Fixes #2287

This change seems rather trivial, which made me wonder if there was ever a reason why it was not done this way? 🤔 

The code used to report only on `prop.node` value, then it would report like this:

<img width="296" alt="Screen Shot 2019-05-27 at 08 02 12" src="https://user-images.githubusercontent.com/9586897/58398690-26eb2c00-8056-11e9-9827-4daa698fad00.png">

However, this logic was changed in this commit to report only on the `node.value` instead. But this commit doesn't really explain why and seems mostly about another rule instead. I'm thinking that it may have been done by accident?
https://github.com/yannickcr/eslint-plugin-react/commit/2e4f91afdc8a089936a2ff49e6b4c83cccb3432a

So now I question whether we should report back to the full `node` or change it to `node.key`.

Otherwise, I tried it out on a local project and seemed to work fine, all tests also continue to pass once the column context values were adjusted.

Before:
<img width="296" alt="Screen Shot 2019-05-27 at 07 44 58" src="https://user-images.githubusercontent.com/9586897/58398397-3b7af480-8055-11e9-9cc9-8b621909170e.png">

After:
<img width="294" alt="Screen Shot 2019-05-27 at 07 44 42" src="https://user-images.githubusercontent.com/9586897/58398396-3b7af480-8055-11e9-8083-904bc4adf6ca.png">
