### PR TITLE
[New]: `prop-types`: handle nested destructuring

### DIFF
--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -313,20 +313,20 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
           }
           const propName = ast.getKeyValue(context, properties[k]);
 
-          // Get parent names in the right hand side of `const {foo} = props.a.b`
-          let currentNode = (node.parent && node.parent.init) || {};
-          allNames = [];
-          while (currentNode.property && currentNode.property.name !== 'props') {
-            allNames.unshift(currentNode.property.name);
-            currentNode = currentNode.object;
-          }
-          allNames.push(propName);
           if (propName) {
             usedPropTypes.push({
-              allNames,
+              allNames: parentNames.concat([propName]),
               name: propName,
               node: properties[k]
             });
+          }
+
+          if (
+            propName &&
+            properties[k].type === 'Property' &&
+            properties[k].value.type === 'ObjectPattern'
+          ) {
+            markPropTypesAsUsed(properties[k].value, parentNames.concat([propName]));
           }
         }
         break;

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -2458,6 +2458,21 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT
     }, {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            const {foo: {bar}} = this.props;
+            return <div>{bar}</div>;
+          }
+        }
+        Hello.propTypes = {
+          foo: PropTypes.shape({
+            bar: PropTypes.string,
+          })
+        };
+      `,
+      options: [{skipShapeProps: false}]
+    }, {
       // issue #933
       code: [
         'type Props = {',

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -2413,6 +2413,47 @@ ruleTester.run('prop-types', rule, {
         type: 'Identifier'
       }]
     }, {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            const { foo: { bar } } = this.props;
+            return <p>{bar}</p>
+          }
+        }
+      `,
+      errors: [
+        {message: "'foo' is missing in props validation"},
+        {message: "'foo.bar' is missing in props validation"}
+      ]
+    }, {
+      code: `
+        class Hello extends React.Component {
+          render() {
+            const { foo: { bar } } = this.props;
+            return <p>{bar}</p>
+          }
+        }
+
+        Hello.propTypes = {
+          foo: PropTypes.shape({
+            _: PropTypes.string,
+          })
+        }
+      `,
+      errors: [
+        {message: "'foo.bar' is missing in props validation"}
+      ]
+    }, {
+      code: `
+        function Foo({ foo: { bar } }) {
+          return <p>{bar}</p>
+        }
+      `,
+      errors: [
+        {message: "'foo' is missing in props validation"},
+        {message: "'foo.bar' is missing in props validation"}
+      ]
+    }, {
       code: [
         'class Hello extends React.Component {',
         '  render() {',


### PR DESCRIPTION
Fixes #1422. Fixes #296.

This commit fixes cases like `const {a: {b}} = this.props;`. Nested destructuring are now marked as used **recursively**. 