### PR TITLE
[Tests] make tests pass in eslint@6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   global:
     - TEST=true
   matrix:
-    - ESLINT=next
+    - ESLINT=^6.0.0-0
     - ESLINT=5
     - ESLINT=4
 after_success:
@@ -32,9 +32,8 @@ matrix:
     - node_js: '4'
       env: ESLINT=5
     - node_js: '4'
-      env: ESLINT=next
+      env: ESLINT=^6.0.0-0
     - node_js: '6'
-      env: ESLINT=next
+      env: ESLINT=^6.0.0-0
   allow_failures:
     - node_js: '11'
-    - env: ESLINT=next

--- a/tests/lib/rules/jsx-child-element-spacing.js
+++ b/tests/lib/rules/jsx-child-element-spacing.js
@@ -7,6 +7,7 @@ const parsers = require('../../helpers/parsers');
 
 const parserOptions = {
   sourceType: 'module',
+  ecmaVersion: 2015,
   ecmaFeatures: {
     jsx: true
   }

--- a/tests/lib/rules/jsx-closing-tag-location.js
+++ b/tests/lib/rules/jsx-closing-tag-location.js
@@ -16,6 +16,7 @@ const parsers = require('../../helpers/parsers');
 
 const parserOptions = {
   sourceType: 'module',
+  ecmaVersion: 2015,
   ecmaFeatures: {
     jsx: true
   }

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -18,6 +18,7 @@ const parsers = require('../../helpers/parsers');
 
 const parserOptions = {
   sourceType: 'module',
+  ecmaVersion: 2015,
   ecmaFeatures: {
     jsx: true
   }

--- a/tests/lib/rules/jsx-max-depth.js
+++ b/tests/lib/rules/jsx-max-depth.js
@@ -16,6 +16,7 @@ const parsers = require('../../helpers/parsers');
 
 const parserOptions = {
   sourceType: 'module',
+  ecmaVersion: 2015,
   ecmaFeatures: {
     jsx: true
   }

--- a/tests/lib/rules/no-did-mount-set-state.js
+++ b/tests/lib/rules/no-did-mount-set-state.js
@@ -117,7 +117,7 @@ ruleTester.run('no-did-mount-set-state', rule, {
         }
       }
     `,
-    parser: 'babel-eslint',
+    parser: parsers.BABEL_ESLINT,
     errors: [{
       message: 'Do not use setState in componentDidMount'
     }]

--- a/tests/lib/rules/no-did-update-set-state.js
+++ b/tests/lib/rules/no-did-update-set-state.js
@@ -117,7 +117,7 @@ ruleTester.run('no-did-update-set-state', rule, {
         }
       }
     `,
-    parser: 'babel-eslint',
+    parser: parsers.BABEL_ESLINT,
     errors: [{
       message: 'Do not use setState in componentDidUpdate'
     }]

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -4376,7 +4376,8 @@ ruleTester.run('no-unused-prop-types', rule, {
         line: 11,
         column: 8
       }]
-    }, { // None of the props are used issue #1162
+    }, {
+      // None of the props are used issue #1162
       code: [
         'import React from "react"; ',
         'var Hello = React.createReactClass({',

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -447,7 +447,7 @@ ruleTester.run('sort-prop-types', rule, {
     options: [{
       sortShapeProp: true
     }],
-    parser: 'babel-eslint'
+    parser: parsers.BABEL_ESLINT
   }, {
     code: `
       const shape = {
@@ -1674,7 +1674,7 @@ ruleTester.run('sort-prop-types', rule, {
     options: [{
       sortShapeProp: true
     }],
-    parser: 'babel-eslint',
+    parser: parsers.BABEL_ESLINT,
     errors: [{
       message: ERROR_MESSAGE,
       line: 4,


### PR DESCRIPTION
Eslint 6.0.0-rc.0 is released 10 hours ago. This pr mostly fixes these two kinds of errors:

> A fatal parsing error occurred: Parsing error: sourceType 'module' is not supported when ecmaVersion < 2015. Consider adding `{ ecmaVersion: 2015 }` to the parser options.

> Parsers provided as strings to RuleTester must be absolute paths.
