### PR TITLE
fix(jsx-key): handle shorthand fragment syntax

### DIFF
--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -31,6 +31,11 @@ module.exports = {
           node,
           message: 'Missing "key" prop for element in iterator'
         });
+      } else if (node.type === 'JSXFragment') {
+        context.report({
+          node,
+          message: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does support providing keys'
+        });
       }
     }
 
@@ -52,6 +57,15 @@ module.exports = {
         }
       },
 
+      JSXFragment(node) {
+        if (node.parent.type === 'ArrayExpression') {
+          context.report({
+            node,
+            message: 'Missing "key" prop for element in array. Shorthand fragment syntax does support providing keys'
+          });
+        }
+      },
+
       // Array.prototype.map
       CallExpression(node) {
         if (node.callee && node.callee.type !== 'MemberExpression') {
@@ -66,7 +80,7 @@ module.exports = {
         const isFn = fn && fn.type === 'FunctionExpression';
         const isArrFn = fn && fn.type === 'ArrowFunctionExpression';
 
-        if (isArrFn && fn.body.type === 'JSXElement') {
+        if (isArrFn && (fn.body.type === 'JSXElement' || fn.body.type === 'JSXFragment')) {
           checkIteratorElement(fn.body);
         }
 

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -13,6 +13,10 @@ const docsUrl = require('../util/docsUrl');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const defaultOptions = {
+  checkFragmentShorthand: false
+}
+
 module.exports = {
   meta: {
     docs: {
@@ -21,17 +25,29 @@ module.exports = {
       recommended: true,
       url: docsUrl('jsx-key')
     },
-    schema: []
+    schema: [{
+      type: 'object',
+      properties: {
+        checkFragmentShorthand: {
+          type: 'boolean',
+          default: defaultOptions.checkFragmentShorthand
+        }
+      },
+      additionalProperties: false
+    }]
   },
 
   create(context) {
+    const options = Object.assign({}, defaultOptions, context.options[0])
+    const checkFragmentShorthand = options.checkFragmentShorthand
+
     function checkIteratorElement(node) {
       if (node.type === 'JSXElement' && !hasProp(node.openingElement.attributes, 'key')) {
         context.report({
           node,
           message: 'Missing "key" prop for element in iterator'
         });
-      } else if (node.type === 'JSXFragment') {
+      } else if (checkFragmentShorthand && node.type === 'JSXFragment') {
         context.report({
           node,
           message: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does support providing keys'
@@ -58,6 +74,10 @@ module.exports = {
       },
 
       JSXFragment(node) {
+        if (!checkFragmentShorthand) {
+          return;
+        }
+        
         if (node.parent.type === 'ArrayExpression') {
           context.report({
             node,

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -15,7 +15,7 @@ const docsUrl = require('../util/docsUrl');
 
 const defaultOptions = {
   checkFragmentShorthand: false
-}
+};
 
 module.exports = {
   meta: {
@@ -38,8 +38,8 @@ module.exports = {
   },
 
   create(context) {
-    const options = Object.assign({}, defaultOptions, context.options[0])
-    const checkFragmentShorthand = options.checkFragmentShorthand
+    const options = Object.assign({}, defaultOptions, context.options[0]);
+    const checkFragmentShorthand = options.checkFragmentShorthand;
 
     function checkIteratorElement(node) {
       if (node.type === 'JSXElement' && !hasProp(node.openingElement.attributes, 'key')) {
@@ -77,7 +77,7 @@ module.exports = {
         if (!checkFragmentShorthand) {
           return;
         }
-        
+
         if (node.parent.type === 'ArrayExpression') {
           context.report({
             node,

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -12,6 +12,8 @@
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/jsx-key');
 
+const parsers = require('../../helpers/parsers');
+
 const parserOptions = {
   ecmaVersion: 2018,
   sourceType: 'module',
@@ -38,8 +40,8 @@ ruleTester.run('jsx-key', rule, {
     {code: 'var App = () => <div />;'},
     {code: '[1, 2, 3].map(function(x) { return; });'},
     {code: 'foo(() => <div />);'},
-    {code: 'foo(() => <></>);'},
-    {code: '<></>;'}
+    {code: 'foo(() => <></>);', parser: parsers.BABEL_ESLINT},
+    {code: '<></>;', parser: parsers.BABEL_ESLINT}
   ],
   invalid: [{
     code: '[<App />];',
@@ -61,9 +63,11 @@ ruleTester.run('jsx-key', rule, {
     errors: [{message: 'Missing "key" prop for element in iterator'}]
   }, {
     code: '[1, 2, 3].map(x => <>{x}</>);',
+    parser: parsers.BABEL_ESLINT,
     errors: [{message: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does support providing keys'}]
   }, {
     code: '[<></>];',
+    parser: parsers.BABEL_ESLINT,
     errors: [{message: 'Missing "key" prop for element in array. Shorthand fragment syntax does support providing keys'}]
   }]
 });

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -64,10 +64,12 @@ ruleTester.run('jsx-key', rule, {
   }, {
     code: '[1, 2, 3].map(x => <>{x}</>);',
     parser: parsers.BABEL_ESLINT,
+    options: [{checkFragmentShorthand: true}],
     errors: [{message: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does support providing keys'}]
   }, {
     code: '[<></>];',
     parser: parsers.BABEL_ESLINT,
+    options: [{checkFragmentShorthand: true}],
     errors: [{message: 'Missing "key" prop for element in array. Shorthand fragment syntax does support providing keys'}]
   }]
 });

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -37,7 +37,9 @@ ruleTester.run('jsx-key', rule, {
     {code: '[1, 2, 3].foo(x => <App />);'},
     {code: 'var App = () => <div />;'},
     {code: '[1, 2, 3].map(function(x) { return; });'},
-    {code: 'foo(() => <div />);'}
+    {code: 'foo(() => <div />);'},
+    {code: 'foo(() => <></>);'},
+    {code: '<></>;'}
   ],
   invalid: [{
     code: '[<App />];',
@@ -57,5 +59,11 @@ ruleTester.run('jsx-key', rule, {
   }, {
     code: '[1, 2 ,3].map(x => { return <App /> });',
     errors: [{message: 'Missing "key" prop for element in iterator'}]
+  }, {
+    code: '[1, 2, 3].map(x => <>{x}</>);',
+    errors: [{message: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does support providing keys'}]
+  }, {
+    code: '[<></>];',
+    errors: [{message: 'Missing "key" prop for element in array. Shorthand fragment syntax does support providing keys'}]
   }]
 });


### PR DESCRIPTION
In eslint/eslint#9664 eslint added support for the shorthand fragment syntax (`<></>`) as a new node type: `JSXFragment`. The jsx-key rule hasn't been updated to handle it correctly so in some cases where it should report errors it doesn't. Here is an example

```js
[1, 2, 3].map(x => <>{x}</>);
```

This PR fixes this and adds some tests. The error messages could probably be improved and maybe we should add an example to the docs?