### PR TITLE
Minor speedup - Replace regexp usage with property comparison

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -196,10 +196,10 @@ function componentRule(rule, context) {
      * @returns {Boolean} True if the node is a React ES5 component, false if not
      */
     isES5Component(node) {
-      if (!node.parent) {
+      if (!node.parent || !node.parent.callee || node.parent.callee.type !== 'MemberExpression') {
         return false;
       }
-      return new RegExp(`^(${pragma}\\.)?${createClass}$`).test(sourceCode.getText(node.parent.callee));
+      return node.parent.callee.object.name === pragma && node.parent.callee.property.name === createClass;
     },
 
     /**
@@ -213,10 +213,13 @@ function componentRule(rule, context) {
         return true;
       }
 
-      if (!node.superClass) {
+      if (!node.superClass || node.superClass.type !== 'MemberExpression') {
         return false;
       }
-      return new RegExp(`^(${pragma}\\.)?(Pure)?Component$`).test(sourceCode.getText(node.superClass));
+      return (
+        node.superClass.object.name === pragma &&
+        (node.superClass.property.name === 'Component' || node.superClass.property.name === 'PureComponent')
+      );
     },
 
     /**
@@ -258,8 +261,11 @@ function componentRule(rule, context) {
      * @returns {Boolean} True if node extends React.PureComponent, false if not
      */
     isPureComponent(node) {
-      if (node.superClass) {
-        return new RegExp(`^(${pragma}\\.)?PureComponent$`).test(sourceCode.getText(node.superClass));
+      if (node.superClass && node.superClass.type === 'MemberExpression') {
+        return (
+          node.superClass.object.name === pragma &&
+          (node.superClass.property.name === 'Component' || node.superClass.property.name === 'PureComponent')
+        );
       }
       return false;
     },


### PR DESCRIPTION
Getting source code and then creating a regexp and testing against it seems excessive when we already have access to AST. This minor change saves 500ms in a big project, your milage may vary