### PR TITLE
[Feat]: jsx-pascal-case allowAllCaps allows underscore

### DIFF
--- a/docs/rules/jsx-pascal-case.md
+++ b/docs/rules/jsx-pascal-case.md
@@ -46,7 +46,16 @@ The following patterns are **not** considered warnings:
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
 * `allowAllCaps`: optional boolean set to `true` to allow components name in all caps (default to `false`).
-* `ignore`: optional array of components name to ignore during validation.
+* `ignore`: optional string-array of component names to ignore during validation.
+
+### `allowAllCaps`
+
+The following patterns are **not** considered warnings when `allowAllCaps` is `true`:
+
+```jsx
+<ALLOWED />
+<TEST_COMPONENT />
+```
 
 ## When Not To Use It
 

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -14,7 +14,7 @@ const jsxUtil = require('../util/jsx');
 // ------------------------------------------------------------------------------
 
 const PASCAL_CASE_REGEX = /^([A-Z0-9]|[A-Z0-9]+[a-z0-9]+(?:[A-Z0-9]+[a-z0-9]*)*)$/;
-const ALL_CAPS_TAG_REGEX = /^[A-Z0-9]+$/;
+const ALL_CAPS_TAG_REGEX = /^[A-Z0-9]+([A-Z0-9_]*[A-Z0-9]+)?$/;
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -65,10 +65,13 @@ module.exports = {
         const isIgnored = ignore.indexOf(name) !== -1;
 
         if (!isPascalCase && !isCompatTag && !isAllowedAllCaps && !isIgnored) {
-          context.report({
-            node,
-            message: `Imported JSX component ${name} must be in PascalCase`
-          });
+          let message = `Imported JSX component ${name} must be in PascalCase`;
+
+          if (allowAllCaps) {
+            message += ' or SCREAMING_SNAKE_CASE';
+          }
+
+          context.report({node, message});
         }
       }
     };

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -50,6 +50,9 @@ ruleTester.run('jsx-pascal-case', rule, {
     code: '<YMCA />',
     options: [{allowAllCaps: true}]
   }, {
+    code: '<TEST_COMPONENT />',
+    options: [{allowAllCaps: true}]
+  }, {
     code: '<Modal.Header />'
   }, {
     code: '<Modal:Header />'
@@ -67,5 +70,17 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<YMCA />',
     errors: [{message: 'Imported JSX component YMCA must be in PascalCase'}]
+  }, {
+    code: '<_TEST_COMPONENT />',
+    options: [{allowAllCaps: true}],
+    errors: [{message: 'Imported JSX component _TEST_COMPONENT must be in PascalCase or SCREAMING_SNAKE_CASE'}]
+  }, {
+    code: '<TEST_COMPONENT_ />',
+    options: [{allowAllCaps: true}],
+    errors: [{message: 'Imported JSX component TEST_COMPONENT_ must be in PascalCase or SCREAMING_SNAKE_CASE'}]
+  }, {
+    code: '<__ />',
+    options: [{allowAllCaps: true}],
+    errors: [{message: 'Imported JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE'}]
   }]
 });


### PR DESCRIPTION
Hello, I hope this finds you well.

My team uses a custom tool for Localization and by convention we've adopted an all-caps snake case for "Translatable Strings" like `<TS_USER_INPUT />` or `<TS_ADD_BUTTON />` to facilitate that.

Our ESLint configs fell out of date as we moved to adopt TypeScript, during which we've written hundreds of these new components. Now that I'm trying to refresh and re-enable them, the `jsx-pascal-case` rule is throwing tons of errors. I like what it's trying to do, though, so I don't want to turn it off. If I had more time I'd try to make `ignore` accept Regex patterns like `/^TS_[A-Z0-9]+$/` but I figure enabling Snake Case with the `allowAllCaps` rule is a simple enough change for most people as it doesn't seem like a breaking change to me.

I hope it meets with your approval! Thanks for your time.