### PR TITLE
Require Optimization breaks when using arrow function Fix

### DIFF
--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -166,6 +166,10 @@ module.exports = {
 
     return {
       ArrowFunctionExpression(node) {
+        // Skip if the function is declared in the class
+        if (isFunctionInClass()) {
+          return;
+        }
         // Stateless Functional Components cannot be optimized (yet)
         markSCUAsDeclared(node);
       },

--- a/tests/lib/rules/require-optimization.js
+++ b/tests/lib/rules/require-optimization.js
@@ -118,6 +118,23 @@ ruleTester.run('react-require-optimization', rule, {
     code: `
       const obj = { prop: [,,,,,] }
     `
+  }, {
+    code: `
+      import React from "react";
+      class YourComponent extends React.Component {
+        handleClick = () => {}
+        shouldComponentUpdate(){
+          return true;
+        }
+        render() {
+          return <div onClick={this.handleClick}>123</div>
+        }
+      }
+    `,
+    parser: parsers.BABEL_ESLINT,
+    errors: [{
+      message: MESSAGE
+    }]
   }],
 
   invalid: [{
@@ -133,6 +150,20 @@ ruleTester.run('react-require-optimization', rule, {
       import React from "react";
       class YourComponent extends React.Component {
         handleClick() {}
+        render() {
+          return <div onClick={this.handleClick}>123</div>
+        }
+      }
+    `,
+    parser: parsers.BABEL_ESLINT,
+    errors: [{
+      message: MESSAGE
+    }]
+  }, {
+    code: `
+      import React from "react";
+      class YourComponent extends React.Component {
+        handleClick = () => {}
         render() {
           return <div onClick={this.handleClick}>123</div>
         }


### PR DESCRIPTION
Fixes https://github.com/yannickcr/eslint-plugin-react/issues/2374

**Issue**
require-optimization breaks when using arrow function in class components.

**What went wrong**
When we encounter `ArrowFunctionExpression` we blindly calls `markSCUAsDeclared`. In case of functional components it works fine, but in case of class based components, calling `markSCUAsDeclared` sets SCU declared for that component as true.

Added a check, if `ArrowFunctionExpression` is part of a class, then ignore it.