### PR TITLE
Added old context to no-deprecated rule

### DIFF
--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -76,6 +76,22 @@ module.exports = {
       deprecated[`${pragma}.PropTypes`] = ['15.5.0', 'the npm module prop-types'];
       // 15.6.0
       deprecated[`${pragma}.DOM`] = ['15.6.0', 'the npm module react-dom-factories'];
+      // 16.6.0
+      deprecated.getChildContext = [
+        '16.6.0',
+        'https://reactjs.org/docs/legacy-context.html ' +
+        'Use new context api https://reactjs.org/docs/context.html'
+      ];
+      deprecated.childContextTypes = [
+        '16.6.0',
+        'https://reactjs.org/docs/legacy-context.html ' +
+        'Use new context api https://reactjs.org/docs/context.html'
+      ];
+      deprecated.contextTypes = [
+        '16.6.0',
+        'https://reactjs.org/docs/legacy-context.html ' +
+        'Use new context api https://reactjs.org/docs/context.html'
+      ];
       // 16.9.0
       // For now the following life-cycle methods are just legacy, not deprecated:
       // `componentWillMount`, `componentWillReceiveProps`, `componentWillUpdate`

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -493,6 +493,42 @@ ruleTester.run('no-deprecated', rule, {
           column: 11
         }
       ]
+    },
+    {
+      code: `
+        class MessageList extends React.Component {
+          static childContextTypes = {};
+          static contextTypes = {};
+          getChildContext() {
+            return {color: "purple"};
+          }
+        
+          render() {
+            return <div>1</div>;
+          }
+        }
+      `,
+      parser: parsers.BABEL_ESLINT,
+      errors: [
+        {
+          message: errorMessage('childContextTypes', '16.6.0', 'https://reactjs.org/docs/legacy-context.html Use new context api https://reactjs.org/docs/context.html'),
+          type: 'Identifier',
+          line: 3,
+          column: 18
+        },
+        {
+          message: errorMessage('contextTypes', '16.6.0', 'https://reactjs.org/docs/legacy-context.html Use new context api https://reactjs.org/docs/context.html'),
+          type: 'Identifier',
+          line: 4,
+          column: 18
+        },
+        {
+          message: errorMessage('getChildContext', '16.6.0', 'https://reactjs.org/docs/legacy-context.html Use new context api https://reactjs.org/docs/context.html'),
+          type: 'Identifier',
+          line: 5,
+          column: 11
+        }
+      ]
     }
   ]
 });


### PR DESCRIPTION
In the 16.6.0 react did be deprecation old context https://reactjs.org/blog/2018/10/23/react-v-16-6.html#deprecations-in-strictmode and remove to next major release
fixes #2382 