### PR TITLE
react/prop-types: allow ignoring by glob

### DIFF
--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -56,11 +56,14 @@ module.exports = {
 
     /**
      * Checks if the prop is ignored
-     * @param {String} name Name of the prop to check.
-     * @returns {Boolean} True if the prop is ignored, false if not.
+     * @param {String} name Name of the prop to check. Might be a regexp e.g. "/_path$/"
+     * @returns {Boolean} true if the prop is ignored, false otherwise.
      */
     function isIgnored(name) {
-      return ignored.indexOf(name) !== -1;
+      return ignored.reduce((res, pattern) => {
+        if (pattern[0] === '/') return res || new RegExp(pattern).test(name);
+        return res || pattern.indexOf(name) !== -1;
+      }, false);
     }
 
     /**


### PR DESCRIPTION
example
```js
{
  'react/prop-types': ['warn', { ignore: ["/_path$/", "className"] },
}
```

# todo
- [ ] add test
