### PR TITLE
2381-fix camelCase error in jsx-sort-props

### DIFF
--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -342,7 +342,7 @@ module.exports = {
             }
           }
 
-          if (!noSortAlphabetically && currentPropName < previousPropName) {
+          if (!noSortAlphabetically && previousPropName.localeCompare(currentPropName) > 0) {
             context.report({
               node: decl.name,
               message: 'Props should be sorted alphabetically',

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -109,7 +109,11 @@ ruleTester.run('jsx-sort-props', rule, {
     {code: '<App a="c" b="b" c="a" />;'},
     {code: '<App {...this.props} a="c" b="b" c="a" />;'},
     {code: '<App c="a" {...this.props} a="c" b="b" />;'},
-    {code: '<App A a />;'},
+    {code: '<App a A />;'},
+    {code: '<App aa aB />;'},
+    {code: '<App aA aB />;'},
+    {code: '<App aaa aB />;'},
+    {code: '<App a aa aB />;'},
     // Ignoring case
     {code: '<App a A />;', options: ignoreCaseArgs},
     {code: '<App a B c />;', options: ignoreCaseArgs},
@@ -166,6 +170,31 @@ ruleTester.run('jsx-sort-props', rule, {
       output: '<App a b />;'
     },
     {
+      code: '<App aB a />;',
+      errors: [expectedError],
+      output: '<App a aB />;'
+    },
+    {
+      code: '<App A a />;',
+      errors: [expectedError],
+      output: '<App a A />;'
+    },
+    {
+      code: '<App aB aA />;',
+      errors: [expectedError],
+      output: '<App aA aB />;'
+    },
+    {
+      code: '<App aaB aA />;',
+      errors: [expectedError],
+      output: '<App aA aaB />;'
+    },
+    {
+      code: '<App aaB aaa aA a />;',
+      errors: [expectedError, expectedError, expectedError],
+      output: '<App a aA aaa aaB />;'
+    },
+    {
       code: '<App {...this.props} b a />;',
       errors: [expectedError],
       output: '<App {...this.props} a b />;'
@@ -174,11 +203,6 @@ ruleTester.run('jsx-sort-props', rule, {
       code: '<App c {...this.props} b a />;',
       errors: [expectedError],
       output: '<App c {...this.props} a b />;'
-    },
-    {
-      code: '<App a A />;',
-      errors: [expectedError],
-      output: '<App a A />;'
     },
     {
       code: '<App B a />;',


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #2381 
- [x] bugfix
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
use `localCompare` rather than `comparison operator`