### PR TITLE
2390 - fix incorrect formatting in jsx-wrap-multilines

### DIFF
--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -163,8 +163,8 @@ module.exports = {
               node,
               MISSING_PARENS,
               fixer => fixer.replaceTextRange(
-                [tokenBefore.range[0], tokenAfter ? tokenAfter.range[0] : node.range[1]],
-                `${trimTokenBeforeNewline(node, tokenBefore)}(\n${sourceCode.getText(node)}\n)`
+                [tokenBefore.range[0], tokenAfter && (tokenAfter.value === ';' || tokenAfter.value === '}') ? tokenAfter.range[0] : node.range[1]],
+                `${trimTokenBeforeNewline(node, tokenBefore)}(\n${' '.repeat(node.loc.start.column)}${sourceCode.getText(node)}\n${' '.repeat(node.loc.start.column - 2)})`
               )
             );
           } else {
@@ -229,7 +229,7 @@ module.exports = {
         }
       },
 
-      'ArrowFunctionExpression:exit': function (node) {
+      'ArrowFunctionExpression:exit': (node) => {
         const arrowBody = node.body;
         const type = 'arrow';
 

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -464,20 +464,20 @@ const LOGICAL_NO_PAREN_FRAGMENT = `
 const LOGICAL_PAREN_NEW_LINE_AUTOFIX = `
   <div>
     {foo && (
-<div>
+      <div>
         <p>Hello World</p>
       </div>
-)}
+    )}
   </div>
 `;
 
 const LOGICAL_PAREN_NEW_LINE_AUTOFIX_FRAGMENT = `
   <div>
     {foo && (
-<>
+      <>
         <p>Hello World</p>
       </>
-)}
+    )}
   </div>
 `;
 
@@ -545,20 +545,20 @@ const ATTR_PAREN_NEW_LINE = `
 
 const ATTR_PAREN_NEW_LINE_AUTOFIX = `
   <div prop={(
-<div>
+    <div>
       <p>Hello</p>
     </div>
-)}>
+  )}>
     <p>Hello</p>
   </div>
 `;
 
 const ATTR_PAREN_NEW_LINE_AUTOFIX_FRAGMENT = `
   <div prop={(
-<>
+    <>
       <p>Hello</p>
     </>
-)}>
+  )}>
     <p>Hello</p>
   </div>
 `;
@@ -571,10 +571,53 @@ export default () =>
 
 const SFC_NO_PARENS_AUTOFIX = `
 export default () => (
-<div>
+    <div>
         with newline without parentheses eslint crashes
     </div>
-)`;
+  )`;
+
+const ARROW_WITH_EXPORT = `
+  const Component = () =>
+    <div>
+      <p>Some text</p>
+    </div>
+
+  export { Component as default }
+`;
+
+const ARROW_WITH_EXPORT_AUTOFIX = `
+  const Component = () => (
+    <div>
+      <p>Some text</p>
+    </div>
+  )
+
+  export { Component as default }
+`;
+
+const ARROW_WITH_LOGICAL = `
+const Component = props => (
+  <div>
+    {true &&
+      <div>
+        <p>Some text</p>
+      </div>
+    }
+  </div>
+)
+`;
+
+const ARROW_WITH_LOGICAL_AUTOFIX = `
+const Component = props => (
+  <div>
+    {true && (
+      <div>
+        <p>Some text</p>
+      </div>
+    )}
+  </div>
+)
+`;
 
 function addNewLineSymbols(code) {
   return code.replace(/\(</g, '(\n<').replace(/>\)/g, '>\n)');
@@ -1188,6 +1231,24 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       code: SFC_NO_PARENS_NO_NEWLINE,
       output: SFC_NO_PARENS_AUTOFIX,
       options: [OPTIONS_ALL_NEW_LINES],
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: ARROW_WITH_EXPORT,
+      output: ARROW_WITH_EXPORT_AUTOFIX,
+      options: [{
+        declaration: 'parens-new-line',
+        assignment: 'parens-new-line',
+        return: 'parens-new-line',
+        arrow: 'parens-new-line',
+        condition: 'parens-new-line',
+        logical: 'ignore',
+        prop: 'ignore'
+      }],
+      errors: [{message: MISSING_PARENS}]
+    }, {
+      code: ARROW_WITH_LOGICAL,
+      output: ARROW_WITH_LOGICAL_AUTOFIX,
+      options: [{logical: 'parens-new-line'}],
       errors: [{message: MISSING_PARENS}]
     }]
 });


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #2390 
- [x] bugfix
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
check for `tokenAfter` values to be `;` or `}`
And add spacing for indent after adding `(` or `)`