### PR TITLE
[jsx-pascal-case] Components can with $ or _

### DIFF
--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -51,6 +51,7 @@ module.exports = {
     return {
       JSXOpeningElement(node) {
         let name = elementType(node);
+        if (name.length === 1) return undefined;
 
         // Get namespace if the type is JSXNamespacedName or JSXMemberExpression
         if (name.indexOf(':') > -1) {

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -59,6 +59,12 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<IGNORED />',
     options: [{ignore: ['IGNORED']}]
+  }, {
+    code: '<T />'
+  }, {
+    code: '<$ />'
+  }, {
+    code: '<_ />'
   }],
 
   invalid: [{
@@ -82,5 +88,8 @@ ruleTester.run('jsx-pascal-case', rule, {
     code: '<__ />',
     options: [{allowAllCaps: true}],
     errors: [{message: 'Imported JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE'}]
+  }, {
+    code: '<$a />',
+    errors: [{message: 'Imported JSX component $a must be in PascalCase'}]
   }]
 });


### PR DESCRIPTION
Fixes #2394.

$ and _ are valid names for components that are neither upper nor lower
case. This change ensures the pascal case rule only applies to the rest
of the component name (if any).