### PR TITLE
Fix false positives for display-name

### DIFF
--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -90,13 +90,13 @@ module.exports = {
       const namedClass = (
         (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') &&
         node.id &&
-        node.id.name
+        !!node.id.name
       );
 
       const namedFunctionDeclaration = (
         (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') &&
         node.id &&
-        node.id.name
+        !!node.id.name
       );
 
       const namedFunctionExpression = (
@@ -200,6 +200,31 @@ module.exports = {
           return;
         }
         markDisplayNameAsDeclared(node);
+      },
+
+      CallExpression(node) {
+        if (!utils.isPragmaComponentWrapper(node)) {
+          return;
+        }
+
+        if (node.arguments.length > 0 && astUtil.isFunctionLikeExpression(node.arguments[0])) {
+          // Skip over React.forwardRef declarations that are embeded within
+          // a React.memo i.e. React.memo(React.forwardRef(/* ... */))
+          // This means that we raise a single error for the call to React.memo
+          // instead of one for React.memo and one for React.forwardRef
+          const isWrappedInAnotherPragma = utils.getPragmaComponentWrapper(node);
+
+          if (
+            !isWrappedInAnotherPragma &&
+            (ignoreTranspilerName || !hasTranspilerName(node.arguments[0]))
+          ) {
+            return;
+          }
+
+          if (components.get(node)) {
+            markDisplayNameAsDeclared(node);
+          }
+        }
       },
 
       'Program:exit': function () {

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -457,6 +457,22 @@ ruleTester.run('display-name', rule, {
     `
   }, {
     code: `
+      import React from 'react'
+
+      const ComponentWithMemo = React.memo(function Component({ world }) {
+        return <div>Hello {world}</div>
+      })
+    `
+  }, {
+    code: `
+      import React from 'react'
+
+      const ForwardRefComponentLike = React.forwardRef(function ComponentLike({ world }, ref) {
+        return <div ref={ref}>Hello {world}</div>
+      })
+    `
+  }, {
+    code: `
       function F() {
         let items = [];
         let testData = [{a: "test1", displayName: "test2"}, {a: "test1", displayName: "test2"}];
@@ -681,6 +697,94 @@ ruleTester.run('display-name', rule, {
       };
     `,
     parser: parsers.BABEL_ESLINT,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: `
+      import React from 'react'
+
+      const ComponentWithMemo = React.memo(({ world }) => {
+        return <div>Hello {world}</div>
+      })
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: `
+      import React from 'react'
+
+      const ComponentWithMemo = React.memo(function() {
+        return <div>Hello {world}</div>
+      })
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: `
+      import React from 'react'
+
+      const ForwardRefComponentLike = React.forwardRef(({ world }, ref) => {
+        return <div ref={ref}>Hello {world}</div>
+      })
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    code: `
+      import React from 'react'
+
+      const ForwardRefComponentLike = React.forwardRef(function({ world }, ref) {
+        return <div ref={ref}>Hello {world}</div>
+      })
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    // Only trigger an error for the outer React.memo
+    code: `
+      import React from 'react'
+
+      const MemoizedForwardRefComponentLike = React.memo(
+        React.forwardRef(({ world }, ref) => {
+          return <div ref={ref}>Hello {world}</div>
+        })
+      )
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    // Only trigger an error for the outer React.memo
+    code: `
+      import React from 'react'
+
+      const MemoizedForwardRefComponentLike = React.memo(
+        React.forwardRef(function({ world }, ref) {
+          return <div ref={ref}>Hello {world}</div>
+       })
+      )
+    `,
+    errors: [{
+      message: 'Component definition is missing display name'
+    }]
+  }, {
+    // React does not handle the result of forwardRef being passed into memo
+    // ComponentWithMemoAndForwardRef gets shown as Memo(Anonymous)
+    // See https://github.com/facebook/react/issues/16722
+    code: `
+      import React from 'react'
+
+      const MemoizedForwardRefComponentLike = React.memo(
+        React.forwardRef(function ComponentLike({ world }, ref) {
+          return <div ref={ref}>Hello {world}</div>
+        })
+      )
+    `,
     errors: [{
       message: 'Component definition is missing display name'
     }]


### PR DESCRIPTION
Wrapping a named function declaration with a React.memo or
React.forwardRef will no longer throw false positive errors.

Check how React devtools exposes the displayNames of components wrapped in memo and forwardRef in https://codesandbox.io/s/awesome-paper-hh0wh?module=App.js

The following no longer raise a linting warning (as react can determine displayNames for them):

```jsx
import React from 'react'

export const ComponentWithMemo = React.memo(function Component({ world }) {
 return <div>Hello {world}</div>
})

export const ComponentWithForwardRef = React.forwardRef(function Component({ world }) {
  return <div>Hello {world}</div>
})
```

Using either an unnamed Function declaration (`function() {/*...*/}`) or arrow functions continue to raise a warning, as a displayName can not be inferred.

Nesting memo and forwardref (`const Component = React.memo(React.forwardRef(function Component() { /*...*/}))` is not currently handled by react so continue to raise an error in that case (see facebook/react#16722)

Fixes #2324, Fixes #2269