### PR TITLE
[eslint] disable some options and manually fix `valid-jsdoc`

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -31,7 +31,11 @@
         "no-param-reassign": 1,
         "no-mixed-operators": 1,
         "no-restricted-syntax": 1,
-        "valid-jsdoc": 1,
+        "valid-jsdoc": [2, {
+          "requireReturn": false,
+          "requireParamDescription": false,
+          "requireReturnDescription": false,
+        }],
     },
     "overrides": [
       {

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -69,6 +69,7 @@ module.exports = {
      *   required: PropTypes.bool.isRequired
      * }
      * @param {Object} node The node we're getting the name of
+     * @returns {string | null}
      */
     function getPropKey(node) {
       // Check for `ExperimentalSpreadProperty` (ESLint 3/4) and `SpreadElement` (ESLint 5)
@@ -96,6 +97,7 @@ module.exports = {
     /**
      * Returns the name of the given node (prop)
      * @param {Object} node The node we're getting the name of
+     * @returns {string}
      */
     function getPropName(node) {
       // Due to this bug https://github.com/babel/babel-eslint/issues/307

--- a/lib/rules/no-danger-with-children.js
+++ b/lib/rules/no-danger-with-children.js
@@ -30,6 +30,7 @@ module.exports = {
      * @param {object} node - ObjectExpression node
      * @param {string} propName - name of the prop to look for
      * @param {string[]} seenProps
+     * @returns {object | boolean}
      */
     function findObjectProp(node, propName, seenProps) {
       if (!node.properties) {
@@ -57,6 +58,7 @@ module.exports = {
      * Takes a JSXElement and returns the value of the prop if it has it
      * @param {object} node - JSXElement node
      * @param {string} propName - name of the prop to look for
+     * @returns {object | boolean}
      */
     function findJsxProp(node, propName) {
       const attributes = node.openingElement.attributes;

--- a/lib/rules/style-prop-object.js
+++ b/lib/rules/style-prop-object.js
@@ -26,6 +26,7 @@ module.exports = {
   create(context) {
     /**
      * @param {ASTNode} expression An Identifier node
+     * @returns {boolean}
      */
     function isNonNullaryLiteral(expression) {
       return expression.type === 'Literal' && expression.value !== null;

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -415,7 +415,7 @@ function componentRule(rule, context) {
     /**
      * Check if the node is returning JSX or null
      *
-     * @param {ASTNode} ASTnode The AST node being checked
+     * @param {ASTNode} ASTNode The AST node being checked
      * @param {Boolean} [strict] If true, in a ternary condition the node must return JSX in both cases
      * @returns {Boolean} True if the node is returning JSX or null, false if not
      */
@@ -449,9 +449,9 @@ function componentRule(rule, context) {
     },
 
     /**
-     *
-     * @param {object} node
      * Getting the first JSX element's name.
+     * @param {object} node
+     * @returns {string | null}
      */
     getNameOfWrappedComponent(node) {
       if (node.length < 1) {
@@ -473,6 +473,7 @@ function componentRule(rule, context) {
 
     /**
      * Get the list of names of components created till now
+     * @returns {string | boolean}
      */
     getDetectedComponents() {
       const list = components.list();
@@ -496,15 +497,15 @@ function componentRule(rule, context) {
     },
 
     /**
-     *
-     * @param {object} node
      * It will check wheater memo/forwardRef is wrapping existing component or
      * creating a new one.
+     * @param {object} node
+     * @returns {boolean}
      */
     nodeWrapsComponent(node) {
       const childComponent = this.getNameOfWrappedComponent(node.arguments);
       const componentList = this.getDetectedComponents();
-      return childComponent && arrayIncludes(componentList, childComponent);
+      return !!childComponent && arrayIncludes(componentList, childComponent);
     },
 
     isPragmaComponentWrapper(node) {

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -8,6 +8,7 @@
  * Find a return statment in the current node
  *
  * @param {ASTNode} node The AST node being checked
+ * @returns {ASTNode | false}
  */
 function findReturnStatement(node) {
   if (
@@ -153,6 +154,7 @@ function isClass(node) {
 /**
  * Removes quotes from around an identifier.
  * @param {string} string the identifier to strip
+ * @returns {string}
  */
 function stripQuotes(string) {
   return string.replace(/^'|'$/g, '');

--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -34,6 +34,7 @@ function createPropVariables() {
      * Add a variable name to the current scope
      * @param {string} name
      * @param {string[]} allNames Example: `props.a.b` should be formatted as `['a', 'b']`
+     * @returns {Map<string, string[]>}
      */
     set(name, allNames) {
       if (!hasBeenWritten) {
@@ -75,6 +76,8 @@ function mustBeValidated(component) {
 
 /**
  * Check if we are in a lifecycle method
+ * @param {object} context
+ * @param {boolean} checkAsyncSafeLifeCycles
  * @return {boolean} true if we are in a class constructor, false if not
  */
 function inLifeCycleMethod(context, checkAsyncSafeLifeCycles) {
@@ -98,6 +101,7 @@ function inLifeCycleMethod(context, checkAsyncSafeLifeCycles) {
 /**
  * Returns true if the given node is a React Component lifecycle method
  * @param {ASTNode} node The AST node being checked.
+ * @param {boolean} checkAsyncSafeLifeCycles
  * @return {Boolean} True if the node is a lifecycle method
  */
 function isNodeALifeCycleMethod(node, checkAsyncSafeLifeCycles) {
@@ -120,6 +124,7 @@ function isNodeALifeCycleMethod(node, checkAsyncSafeLifeCycles) {
  * Returns true if the given node is inside a React Component lifecycle
  * method.
  * @param {ASTNode} node The AST node being checked.
+ * @param {boolean} checkAsyncSafeLifeCycles
  * @return {Boolean} True if the node is inside a lifecycle method
  */
 function isInLifeCycleMethod(node, checkAsyncSafeLifeCycles) {
@@ -188,6 +193,7 @@ function isThisDotProps(node) {
 
 /**
  * Checks if the prop has spread operator.
+ * @param {object} context
  * @param {ASTNode} node The AST node being marked.
  * @returns {Boolean} True if the prop has spread operator, false if not.
  */


### PR DESCRIPTION
* Disable options `requireParamDescription` and `requireReturnDescription`: Personally I find it harmful to add meaningless descriptions to self descriptive params.
* `"requireReturn": false`: This option is a misnomer, actually it means "require `@returns` tag except for void functions". This helps avoid adding lots of `@returns {void}`.