### PR TITLE
fix[jsx-handler-name]: add option to disable property

### DIFF
--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -21,26 +21,59 @@ module.exports = {
     },
 
     schema: [{
-      type: 'object',
-      properties: {
-        eventHandlerPrefix: {
-          type: 'string'
-        },
-        eventHandlerPropPrefix: {
-          type: 'string'
+      oneOf: [
+        {
+          type: 'object',
+          properties: {
+            eventHandlerPrefix: {type: 'string'},
+            eventHandlerPropPrefix: {type: 'string'}
+          },
+          additionalProperties: false
+        }, {
+          type: 'object',
+          properties: {
+            eventHandlerPrefix: {type: 'string'},
+            eventHandlerPropPrefix: {
+              type: 'boolean',
+              enum: [false]
+            }
+          },
+          additionalProperties: false
+        }, {
+          type: 'object',
+          properties: {
+            eventHandlerPrefix: {
+              type: 'boolean',
+              enum: [false]
+            },
+            eventHandlerPropPrefix: {type: 'string'}
+          },
+          additionalProperties: false
         }
-      },
-      additionalProperties: false
+      ]
     }]
   },
 
   create(context) {
-    const configuration = context.options[0] || {};
-    const eventHandlerPrefix = configuration.eventHandlerPrefix || 'handle';
-    const eventHandlerPropPrefix = configuration.eventHandlerPropPrefix || 'on';
+    function isPrefixDisabled(prefix) {
+      return prefix === false;
+    }
 
-    const EVENT_HANDLER_REGEX = new RegExp(`^((props\\.${eventHandlerPropPrefix})|((.*\\.)?${eventHandlerPrefix}))[A-Z].*$`);
-    const PROP_EVENT_HANDLER_REGEX = new RegExp(`^(${eventHandlerPropPrefix}[A-Z].*|ref)$`);
+    const configuration = context.options[0] || {};
+
+    const eventHandlerPrefix = isPrefixDisabled(configuration.eventHandlerPrefix) ?
+      null :
+      configuration.eventHandlerPrefix || 'handle';
+    const eventHandlerPropPrefix = isPrefixDisabled(configuration.eventHandlerPropPrefix) ?
+      null :
+      configuration.eventHandlerPropPrefix || 'on';
+
+    const EVENT_HANDLER_REGEX = !eventHandlerPrefix ?
+      null :
+      new RegExp(`^((props\\.${eventHandlerPropPrefix || ''})|((.*\\.)?${eventHandlerPrefix}))[A-Z].*$`);
+    const PROP_EVENT_HANDLER_REGEX = !eventHandlerPropPrefix ?
+      null :
+      new RegExp(`^(${eventHandlerPropPrefix}[A-Z].*|ref)$`);
 
     return {
       JSXAttribute(node) {
@@ -55,15 +88,23 @@ module.exports = {
           return;
         }
 
-        const propIsEventHandler = PROP_EVENT_HANDLER_REGEX.test(propKey);
-        const propFnIsNamedCorrectly = EVENT_HANDLER_REGEX.test(propValue);
+        const propIsEventHandler = PROP_EVENT_HANDLER_REGEX && PROP_EVENT_HANDLER_REGEX.test(propKey);
+        const propFnIsNamedCorrectly = EVENT_HANDLER_REGEX && EVENT_HANDLER_REGEX.test(propValue);
 
-        if (propIsEventHandler && !propFnIsNamedCorrectly) {
+        if (
+          propIsEventHandler &&
+          propFnIsNamedCorrectly !== null &&
+          !propFnIsNamedCorrectly
+        ) {
           context.report({
             node,
             message: `Handler function for ${propKey} prop key must begin with '${eventHandlerPrefix}'`
           });
-        } else if (propFnIsNamedCorrectly && !propIsEventHandler) {
+        } else if (
+          propFnIsNamedCorrectly &&
+          propIsEventHandler !== null &&
+          !propIsEventHandler
+        ) {
           context.report({
             node,
             message: `Prop key for ${propValue} must begin with '${eventHandlerPropPrefix}'`

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -63,6 +63,34 @@ ruleTester.run('jsx-handler-names', rule, {
     parser: parsers.BABEL_ESLINT
   }, {
     code: '<TestComponent only={this.only} />'
+  }, {
+    code: '<TestComponent onChange={this.someChange} />',
+    options: [{
+      eventHandlerPrefix: false,
+      eventHandlerPropPrefix: 'on'
+    }]
+  }, {
+    code: '<TestComponent somePrefixChange={this.someChange} />',
+    options: [{
+      eventHandlerPrefix: false,
+      eventHandlerPropPrefix: 'somePrefix'
+    }]
+  }, {
+    code: '<TestComponent someProp={this.handleChange} />',
+    options: [{
+      eventHandlerPropPrefix: false
+    }]
+  }, {
+    code: '<TestComponent someProp={this.somePrefixChange} />',
+    options: [{
+      eventHandlerPrefix: 'somePrefix',
+      eventHandlerPropPrefix: false
+    }]
+  }, {
+    code: '<TestComponent someProp={props.onChange} />',
+    options: [{
+      eventHandlerPropPrefix: false
+    }]
   }],
 
   invalid: [{


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #2400 
- [x] enhancement
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
```javascript
    schema: [{
      oneOf: [
        {
          type: 'object',
          properties: {
            eventHandlerPrefix: {type: 'string'},
            eventHandlerPropPrefix: {type: 'string'}
          },
          additionalProperties: false
        }, {
          type: 'object',
          properties: {
            eventHandlerPrefix: {type: 'string'},
            eventHandlerPropPrefix: {
              type: 'boolean',
              enum: [false]
            }
          },
          additionalProperties: false
        }, {
          type: 'object',
          properties: {
            eventHandlerPrefix: {
              type: 'boolean',
              enum: [false]
            },
            eventHandlerPropPrefix: {type: 'string'}
          },
          additionalProperties: false
        }
      ]
    }]
```