### PR TITLE
[jsx curly brace presence]: fix jsx tags in braces

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -128,6 +128,10 @@ module.exports = {
               expression.quasis[0].value.raw :
               expression.raw.substring(1, expression.raw.length - 1)
             }"`;
+          } else if (jsxUtil.isJSX(expression)) {
+            const sourceCode = context.getSourceCode();
+
+            textToReplace = sourceCode.getText(expression);
           } else {
             textToReplace = expressionType === 'TemplateLiteral' ?
               expression.quasis[0].value.cooked : expression.value;
@@ -189,6 +193,8 @@ module.exports = {
           !containsQuoteCharacters(expression.quasis[0].value.cooked)
         )
       ) {
+        reportUnnecessaryCurly(JSXExpressionNode);
+      } else if (jsxUtil.isJSX(expression)) {
         reportUnnecessaryCurly(JSXExpressionNode);
       }
     }

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -96,7 +96,8 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       options: [{props: 'never'}]
     },
     {
-      code: '<App>{<myApp></myApp>}</App>'
+      code: '<App>{<myApp></myApp>}</App>',
+      options: [{children: 'always'}]
     },
     {
       code: '<App>{[]}</App>'
@@ -311,6 +312,17 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       code: '<App prop={`foo`} />',
       output: '<App prop="foo" />',
       options: [{props: 'never'}],
+      errors: [{message: unnecessaryCurlyMessage}]
+    },
+    {
+      code: '<App>{<myApp></myApp>}</App>',
+      output: '<App><myApp></myApp></App>',
+      options: [{children: 'never'}],
+      errors: [{message: unnecessaryCurlyMessage}]
+    },
+    {
+      code: '<App>{<myApp></myApp>}</App>',
+      output: '<App><myApp></myApp></App>',
       errors: [{message: unnecessaryCurlyMessage}]
     },
     {


### PR DESCRIPTION
#### PR checklist

- [x] Addresses an existing issue: fixes #2416 
- [x] bug
- [x] Includes tests
- [ ] Documentation update

#### Overview of change:
Check for single `JSXElement` in child.
