### PR TITLE
Fix typos in prefer-es6-class.md

### DIFF
--- a/docs/rules/prefer-es6-class.md
+++ b/docs/rules/prefer-es6-class.md
@@ -1,6 +1,6 @@
 # Enforce ES5 or ES6 class for React Components (react/prefer-es6-class)
 
-React offers you two way to create traditional components: using the ES5 `create-react-class` module or the new ES6 class system. This rule allow you to enforce one way or another.
+React offers you two ways to create traditional components: using the ES5 `create-react-class` module or the new ES6 class system. This rule allows you to enforce one way or another.
 
 ## Rule Options
 
@@ -36,7 +36,7 @@ class Hello extends React.Component {
 
 ### `never` mode
 
-Will enforce ES5 classes for React Components
+Will enforce ES5 classes for React Components.
 
 The following patterns are considered warnings:
 


### PR DESCRIPTION
I noticed a couple of minor typos while reading through the docs.