### PR TITLE
[Fix] `no-unused-prop-types`: false positive when nested destructuring

### DIFF
--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -362,19 +362,20 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
           }
           const propName = ast.getKeyValue(context, properties[k]);
 
-          if (
-            propName &&
-            properties[k].type === 'Property' &&
-            properties[k].value.type === 'ObjectPattern'
-          ) {
+          if (!propName || properties[k].type !== 'Property') {
+            break;
+          }
+
+          usedPropTypes.push({
+            allNames: parentNames.concat([propName]),
+            name: propName,
+            node: properties[k]
+          });
+
+          if (properties[k].value.type === 'ObjectPattern') {
             markPropTypesAsUsed(properties[k].value, parentNames.concat([propName]));
-          } else if (propName) {
+          } else if (properties[k].value.type === 'Identifier') {
             propVariables.set(propName, parentNames.concat(propName));
-            usedPropTypes.push({
-              allNames: parentNames.concat([propName]),
-              name: propName,
-              node: properties[k]
-            });
           }
         }
         break;

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -1826,6 +1826,18 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n')
     }, {
+      // Nested destructuring; issue 2424
+      code: `
+        function SomeComponent(props) {
+          const {aaa: {bbb}} = props;
+          return <p>{bbb}</p>;
+        }
+
+        SomeComponent.propTypes = {
+          aaa: somePropType,
+        };
+      `
+    }, {
       // `no-unused-prop-types` in jsx expressions - [Issue #885]
       code: [
         'const PagingBlock = function(props) {',
@@ -1864,7 +1876,7 @@ ruleTester.run('no-unused-prop-types', rule, {
             const { a } = props;
             document.title = a;
           });
-          
+
           return <p/>;
         }
 

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -2498,6 +2498,7 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [
+        {message: "'foo' is missing in props validation"},
         {message: "'foo.bar' is missing in props validation"}
       ]
     }, {
@@ -2525,6 +2526,7 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [
+        {message: "'foo' is missing in props validation"},
         {message: "'foo.bar' is missing in props validation"}
       ]
     },


### PR DESCRIPTION
fixes #2424

Mark `foo` as used when `const {foo: {bar}} = props`.
