### PR TITLE
Guard against 0 length specifiers for proptypes

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -155,7 +155,9 @@ module.exports = {
     return {
       ImportDeclaration(node) {
         if (node.source && node.source.value === 'prop-types') { // import PropType from "prop-types"
-          propTypesPackageName = node.specifiers[0].local.name;
+          if (node.specifiers.length > 0) {
+            propTypesPackageName = node.specifiers[0].local.name;
+           }
         } else if (node.source && node.source.value === 'react') { // import { PropTypes } from "react"
           if (node.specifiers.length > 0) {
             reactPackageName = node.specifiers[0].local.name; // guard against accidental anonymous `import "react"`


### PR DESCRIPTION
My co-worker was entered `import {} from "prop-types` in preparation to declare the prop types for his component. 
Upon doing this, eslint crashed as it could not find `local` on undefined.