### PR TITLE
fix(jsx-curly-brace-presence): allow necessary white-space literal

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -6,6 +6,8 @@
 
 'use strict';
 
+const arrayIncludes = require('array-includes');
+
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
 
@@ -70,7 +72,7 @@ module.exports = {
     }
 
     function containsBackslash(rawStringValue) {
-      return rawStringValue.includes('\\');
+      return arrayIncludes(rawStringValue, '\\');
     }
 
     function containsHTMLEntity(rawStringValue) {
@@ -238,7 +240,12 @@ module.exports = {
 
       return adjSiblings.some(x => x.type && x.type === 'JSXExpressionContainer');
     }
+    function hasAdjacentJsx(node, children) {
+      const childrenExcludingWhitespaceLiteral = children.filter(child => !isWhiteSpaceLiteral(child));
+      const adjSiblings = getAdjacentSiblings(node, childrenExcludingWhitespaceLiteral);
 
+      return adjSiblings.some(x => x.type && arrayIncludes(['JSXExpressionContainer', 'JSXElement'], x.type));
+    }
     function shouldCheckForUnnecessaryCurly(parent, node, config) {
       // Bail out if the parent is a JSXAttribute & its contents aren't
       // StringLiteral or TemplateLiteral since e.g
@@ -259,7 +266,9 @@ module.exports = {
       if (jsxUtil.isJSX(parent) && hasAdjacentJsxExpressionContainers(node, parent.children)) {
         return false;
       }
-
+      if (containsWhitespaceExpression(node) && hasAdjacentJsx(node, parent.children)) {
+        return false;
+      }
       if (
         parent.children &&
         parent.children.length === 1 &&

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -4,6 +4,8 @@
 
 'use strict';
 
+const arrayIncludes = require('array-includes');
+
 const pragmaUtil = require('../util/pragma');
 const jsxUtil = require('../util/jsx');
 const docsUrl = require('../util/docsUrl');
@@ -47,8 +49,8 @@ function trimLikeReact(text) {
   const leadingSpaces = /^\s*/.exec(text)[0];
   const trailingSpaces = /\s*$/.exec(text)[0];
 
-  const start = leadingSpaces.includes('\n') ? leadingSpaces.length : 0;
-  const end = trailingSpaces.includes('\n') ? text.length - trailingSpaces.length : text.length;
+  const start = arrayIncludes(leadingSpaces, '\n') ? leadingSpaces.length : 0;
+  const end = arrayIncludes(trailingSpaces, '\n') ? text.length - trailingSpaces.length : text.length;
 
   return text.slice(start, end);
 }
@@ -92,7 +94,7 @@ module.exports = {
     function isPaddingSpaces(node) {
       return isJSXText(node) &&
         isOnlyWhitespace(node.raw) &&
-        node.raw.includes('\n');
+        arrayIncludes(node.raw, '\n');
     }
 
     /**

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -86,6 +86,25 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       options: [{children: 'never'}]
     },
     {
+      code: `
+      <React.Fragment>
+        foo{' '}
+        <span>bar</span>
+      </React.Fragment>
+    `,
+      options: [{children: 'never'}]
+    },
+    {
+      code: `
+      <>
+        foo{' '}
+        <span>bar</span>
+      </>
+    `,
+      parser: parsers.BABEL_ESLINT,
+      options: [{children: 'never'}]
+    },
+    {
       code: '<App>{`Hello \\n World`}</App>',
       options: [{children: 'never'}]
     },


### PR DESCRIPTION
Checks against use-case where white space literal is used to pad around JSX across newlines.