### PR TITLE
[fix] `jsx-curly-brace-presence`: allow trailing spaces in literal

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -174,6 +174,10 @@ module.exports = {
       return node.type && node.type === 'Literal' && node.value && jsxUtil.isWhiteSpaces(node.value);
     }
 
+    function isLiteralWithTrailingWhiteSpaces(node) {
+      return node.type && node.type === 'Literal' && node.value && /^\s|\s$/.test(node.value);
+    }
+
     // Bail out if there is any character that needs to be escaped in JSX
     // because escaping decreases readiblity and the original code may be more
     // readible anyway or intentional for other specific reasons
@@ -184,7 +188,10 @@ module.exports = {
       if (
         (expressionType === 'Literal' || expressionType === 'JSXText') &&
           typeof expression.value === 'string' &&
-          !isWhiteSpaceLiteral(expression) &&
+          (
+            (JSXExpressionNode.parent.type === 'JSXAttribute' && !isWhiteSpaceLiteral(expression)) ||
+            !isLiteralWithTrailingWhiteSpaces(expression)
+          ) &&
           !needToEscapeCharacterForJSX(expression.raw) && (
           jsxUtil.isJSX(JSXExpressionNode.parent) ||
           !containsQuoteCharacters(expression.value)

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -270,6 +270,14 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       options: ['never']
     },
     {
+      code: '<MyComponent>{"space after "}</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent>{" space before"}</MyComponent>',
+      options: ['never']
+    },
+    {
       code: ['<a a={"start\\', '\\', 'end"}/>'].join('/n'),
       options: ['never']
     },
@@ -315,6 +323,17 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       code: `
         <MyComponent>
           %
+        </MyComponent>
+      `,
+      parser: parsers.BABEL_ESLINT,
+      options: [{children: 'never'}]
+    },
+    {
+      code: `
+        <MyComponent>
+          { 'space after ' }
+          <b>foo</b>
+          { ' space before' }
         </MyComponent>
       `,
       parser: parsers.BABEL_ESLINT,


### PR DESCRIPTION
`jsx-curly-brace-presence` with `never` reports invalid errors in following cases

```
<Foo>{' space before or after '}</Foo>
```

```
<Foo>
  {'space after '}
  <a>link</a>
  {' space before'}
</Foo>
```