### PR TITLE
Find target={'_blank'} expressions

### DIFF
--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -16,8 +16,15 @@ function isTargetBlank(attr) {
   return attr.name &&
     attr.name.name === 'target' &&
     attr.value &&
-    attr.value.type === 'Literal' &&
-    attr.value.value.toLowerCase() === '_blank';
+    ((
+      attr.value.type === 'Literal' &&
+      attr.value.value.toLowerCase() === '_blank'
+    ) || (
+      attr.value.type === 'JSXExpressionContainer' &&
+      attr.value.expression &&
+      attr.value.expression.value &&
+      attr.value.expression.value.toLowerCase() === '_blank'
+    ));
 }
 
 function hasExternalLink(element, linkAttribute) {

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -45,8 +45,18 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {code: '<a target={targetValue} rel="noopener noreferrer"></a>'},
     {code: '<a target={targetValue} href="relative/path"></a>'},
     {code: '<a target={targetValue} href="/absolute/path"></a>'},
+    {code: '<a target={\'targetValue\'} href="/absolute/path"></a>'},
+    {code: '<a target={"targetValue"} href="/absolute/path"></a>'},
     {
       code: '<a target="_blank" href={ dynamicLink }></a>',
+      options: [{enforceDynamicLinks: 'never'}]
+    },
+    {
+      code: '<a target={"_blank"} href={ dynamicLink }></a>',
+      options: [{enforceDynamicLinks: 'never'}]
+    },
+    {
+      code: '<a target={\'_blank\'} href={ dynamicLink }></a>',
       options: [{enforceDynamicLinks: 'never'}]
     },
     {
@@ -89,6 +99,12 @@ ruleTester.run('jsx-no-target-blank', rule, {
     errors: defaultErrors
   }, {
     code: '<a target="_blank" href={ dynamicLink }></a>',
+    errors: defaultErrors
+  }, {
+    code: '<a target={\'_blank\'} href="//example.com"></a>',
+    errors: defaultErrors
+  }, {
+    code: '<a target={"_blank"} href="//example.com"></a>',
     errors: defaultErrors
   }, {
     code: '<a target="_blank" href={ dynamicLink }></a>',


### PR DESCRIPTION
The `jsx/no-target-blank` rule does not detect the `_blank` value if written as an expression containing a string (such as `target={'_blank'}`). This PR fixes that.