### PR TITLE
Fix filter of undefined

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -242,12 +242,18 @@ module.exports = {
     }
 
     function hasAdjacentJsxExpressionContainers(node, children) {
+      if (!children) {
+        return false;
+      }
       const childrenExcludingWhitespaceLiteral = children.filter(child => !isWhiteSpaceLiteral(child));
       const adjSiblings = getAdjacentSiblings(node, childrenExcludingWhitespaceLiteral);
 
       return adjSiblings.some(x => x.type && x.type === 'JSXExpressionContainer');
     }
     function hasAdjacentJsx(node, children) {
+      if (!children) {
+        return false;
+      }
       const childrenExcludingWhitespaceLiteral = children.filter(child => !isWhiteSpaceLiteral(child));
       const adjSiblings = getAdjacentSiblings(node, childrenExcludingWhitespaceLiteral);
 

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -146,6 +146,9 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       code: `<App prop='bar'>{'foo \\n bar'}</App>`
     },
     {
+      code: `<App prop={ ' ' }/>`
+    },
+    {
       code: `<MyComponent prop='bar'>foo</MyComponent>`,
       options: [{props: 'never'}]
     },


### PR DESCRIPTION
Cause of error: 
```
<View 
  prop={ ' ' }
/>
```

```
TypeError: Cannot read property 'filter' of undefined
Occurred while linting <file>.js:346
    at hasAdjacentJsx (.../node_modules/eslint-plugin-react/lib/rules/jsx-curly-brace-presence.js:244:59)
    at shouldCheckForUnnecessaryCurly (.../node_modules/eslint-plugin-react/lib/rules/jsx-curly-brace-presence.js:272:49)
    at JSXExpressionContainer (.../node_modules/eslint-plugin-react/lib/rules/jsx-curly-brace-presence.js:304:13)
    at listeners.(anonymous function).forEach.listener (.../node_modules/eslint/lib/linter/safe-emitter.js:45:58)
    at Array.forEach (<anonymous>)
    at Object.emit (.../node_modules/eslint/lib/linter/safe-emitter.js:45:38)
    at NodeEventGenerator.applySelector (.../node_modules/eslint/lib/linter/node-event-generator.js:253:26)
    at NodeEventGenerator.applySelectors (.../node_modules/eslint/lib/linter/node-event-generator.js:282:22)
    at NodeEventGenerator.enterNode (.../node_modules/eslint/lib/linter/node-event-generator.js:296:14)
    at CodePathAnalyzer.enterNode (.../node_modules/eslint/lib/linter/code-path-analysis/code-path-analyzer.js:646:23)
```