### PR TITLE
[Fix] no-render-return-value should warn when used in assignment expression.

### DIFF
--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -58,7 +58,8 @@ module.exports = {
           parent.type === 'VariableDeclarator' ||
           parent.type === 'Property' ||
           parent.type === 'ReturnStatement' ||
-          parent.type === 'ArrowFunctionExpression'
+          parent.type === 'ArrowFunctionExpression' ||
+          parent.type === 'AssignmentExpression'
         ) {
           context.report({
             node: callee,

--- a/tests/lib/rules/no-render-return-value.js
+++ b/tests/lib/rules/no-render-return-value.js
@@ -97,6 +97,16 @@ ruleTester.run('no-render-return-value', rule, {
       message: 'Do not depend on the return value from ReactDOM.render'
     }]
   }, {
+    code: 'this.o = ReactDOM.render(<div />, document.body);',
+    errors: [{
+      message: 'Do not depend on the return value from ReactDOM.render'
+    }]
+  }, {
+    code: 'var v; v = ReactDOM.render(<div />, document.body);',
+    errors: [{
+      message: 'Do not depend on the return value from ReactDOM.render'
+    }]
+  }, {
     code: 'var inst = React.render(<div />, document.body);',
     settings: {
       react: {


### PR DESCRIPTION
Addresses #2461 .

With this PR, the `no-render-return-value` plugin will warn for usages like this:
```
this.x = ReactDOM.render(...);
```
or
```
let y;
...
y = ReactDOM.render(...);
```