### PR TITLE
[Fix] `no-typos`: improve report location

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -124,9 +124,10 @@ module.exports = {
       }
     }
 
-    function reportErrorIfPropertyCasingTypo(node, propertyName, isClassProperty) {
+    function reportErrorIfPropertyCasingTypo(propertyValue, propertyKey, isClassProperty) {
+      const propertyName = propertyKey.name;
       if (propertyName === 'propTypes' || propertyName === 'contextTypes' || propertyName === 'childContextTypes') {
-        checkValidPropObject(node);
+        checkValidPropObject(propertyValue);
       }
       STATIC_CLASS_PROPERTIES.forEach((CLASS_PROP) => {
         if (propertyName && CLASS_PROP.toLowerCase() === propertyName.toLowerCase() && CLASS_PROP !== propertyName) {
@@ -134,7 +135,7 @@ module.exports = {
             'Typo in static class property declaration' :
             'Typo in property declaration';
           context.report({
-            node,
+            node: propertyKey,
             message
           });
         }
@@ -176,9 +177,7 @@ module.exports = {
           return;
         }
 
-        const tokens = context.getFirstTokens(node, 2);
-        const propertyName = tokens[1].value;
-        reportErrorIfPropertyCasingTypo(node.value, propertyName, true);
+        reportErrorIfPropertyCasingTypo(node.value, node.key, true);
       },
 
       MemberExpression(node) {
@@ -198,7 +197,7 @@ module.exports = {
           (utils.isES6Component(relatedComponent.node) || utils.isReturningJSX(relatedComponent.node)) &&
           (node.parent && node.parent.type === 'AssignmentExpression' && node.parent.right)
         ) {
-          reportErrorIfPropertyCasingTypo(node.parent.right, propertyName, true);
+          reportErrorIfPropertyCasingTypo(node.parent.right, node.property, true);
         }
       },
 
@@ -218,7 +217,7 @@ module.exports = {
         }
 
         node.properties.forEach((property) => {
-          reportErrorIfPropertyCasingTypo(property.value, property.key.name, false);
+          reportErrorIfPropertyCasingTypo(property.value, property.key, false);
           reportErrorIfLifecycleMethodCasingTypo(property);
         });
       }

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -618,21 +618,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.PropTypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.PropTypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -664,7 +664,7 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {}
@@ -756,21 +756,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.DefaultProps = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.DefaultProps = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -1567,13 +1567,13 @@ ruleTester.run('no-typos', rule, {
     parserOptions,
     errors: [{
       message: ERROR_MESSAGE_ES5,
-      type: 'ObjectExpression'
+      type: 'Identifier'
     }, {
       message: ERROR_MESSAGE_ES5,
-      type: 'ObjectExpression'
+      type: 'Identifier'
     }, {
       message: ERROR_MESSAGE_ES5,
-      type: 'ObjectExpression'
+      type: 'Identifier'
     }, {
       message: ERROR_MESSAGE_LIFECYCLE_METHOD,
       type: 'Property'
@@ -1619,13 +1619,13 @@ ruleTester.run('no-typos', rule, {
     parserOptions,
     errors: [{
       message: ERROR_MESSAGE_ES5,
-      type: 'ObjectExpression'
+      type: 'Identifier'
     }, {
       message: ERROR_MESSAGE_ES5,
-      type: 'ObjectExpression'
+      type: 'Identifier'
     }, {
       message: ERROR_MESSAGE_ES5,
-      type: 'ObjectExpression'
+      type: 'Identifier'
     }, {
       message: ERROR_MESSAGE_LIFECYCLE_METHOD,
       type: 'Property'


### PR DESCRIPTION
Previously the report location is property value. Now the report location is property key. This change is scoped to typos for `propTypes`, `defaultProps`, and `ContextTypes`.

```js
class Zoo extends React.Component {
  static PROPTYPES = {};
//                   ~~   previous
//       ~~~~~~~~~        now
}

function Foo() {
  return <></>;
}

Foo.PROPTYPES = {};
//              ~~   previous
//  ~~~~~~~~~        now

```