### PR TITLE
feat(no-target-blank): Configure noreferrer requirement

### DIFF
--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -14,10 +14,11 @@ This rule aims to prevent user generated links from creating security vulnerabil
 ## Rule Options
 ```json
 ...
-"react/jsx-no-target-blank": [<enabled>, { "enforceDynamicLinks": <enforce> }]
+"react/jsx-no-target-blank": [<enabled>, { "allowReferrer": <allow-referrer>, "enforceDynamicLinks": <enforce> }]
 ...
 ```
 
+* allow-referrer: optional boolean. If `true` does not require `noreferrer`. Defaults to `false`.
 * enabled: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
 * enforce: optional string, 'always' or 'never'
 

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -40,11 +40,11 @@ function hasDynamicLink(element, linkAttribute) {
     attr.value.type === 'JSXExpressionContainer');
 }
 
-function hasSecureRel(element) {
+function hasSecureRel(element, allowReferrer) {
   return element.attributes.find((attr) => {
     if (attr.type === 'JSXAttribute' && attr.name.name === 'rel') {
       const tags = attr.value && attr.value.type === 'Literal' && attr.value.value.toLowerCase().split(' ');
-      return tags && (tags.indexOf('noopener') >= 0 && tags.indexOf('noreferrer') >= 0);
+      return tags && (tags.indexOf('noopener') >= 0 && (allowReferrer || tags.indexOf('noreferrer') >= 0));
     }
     return false;
   });
@@ -61,6 +61,9 @@ module.exports = {
     schema: [{
       type: 'object',
       properties: {
+        allowReferrer: {
+          type: 'boolean'
+        },
         enforceDynamicLinks: {
           enum: ['always', 'never']
         }
@@ -71,12 +74,17 @@ module.exports = {
 
   create(context) {
     const configuration = context.options[0] || {};
+    const allowReferrer = configuration.allowReferrer || false;
     const enforceDynamicLinks = configuration.enforceDynamicLinks || 'always';
     const components = linkComponentsUtil.getLinkComponents(context);
 
     return {
       JSXAttribute(node) {
-        if (!components.has(node.parent.name.name) || !isTargetBlank(node) || hasSecureRel(node.parent)) {
+        if (
+          !components.has(node.parent.name.name) ||
+          !isTargetBlank(node) ||
+          hasSecureRel(node.parent, allowReferrer)
+        ) {
           return;
         }
 

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -68,6 +68,10 @@ ruleTester.run('jsx-no-target-blank', rule, {
       code: '<Link target="_blank" to={ dynamicLink }></Link>',
       options: [{enforceDynamicLinks: 'never'}],
       settings: {linkComponents: {name: 'Link', linkAttribute: 'to'}}
+    },
+    {
+      code: '<a href="foobar" target="_blank" rel="noopener"></a>',
+      options: [{allowReferrer: true}]
     }
   ],
   invalid: [{


### PR DESCRIPTION
Allows `<a href="foobar" target="_blank" rel="noopener"></a>` if the rule is configured with `allowReferrer` for links where we want the `referrer` for tracking. For rationale see https://github.com/yannickcr/eslint-plugin-react/issues/2054#issuecomment-466477132.

`referrer` is not a specified [link type](https://html.spec.whatwg.org/multipage/links.html#linkTypes) so I'd rather not introduce this magic-word for this rule.

See https://github.com/yannickcr/eslint-plugin-react/issues/776 (can be closed with this change?) and https://github.com/yannickcr/eslint-plugin-react/issues/2054