### PR TITLE
[eslint] fix func-names and change object-shorthand to 'always'

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "rules": {
         "comma-dangle": [2, "never"],
         "object-curly-spacing": [2, "never"],
+        "object-shorthand": [2, "always"],
         "array-bracket-spacing": [2, "never"],
         "max-len": [2, 120, {
           "ignoreStrings": true,

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -282,7 +282,8 @@ module.exports = {
         }
       },
 
-      'Program:exit': function () {
+      // eslint-disable-next-line object-shorthand
+      'Program:exit'() {
         if (!rule) {
           return;
         }

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -80,7 +80,7 @@ module.exports = {
     // --------------------------------------------------------------------------
 
     return {
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
 
         // If no defaultProps could be found, we don't report anything.

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -227,7 +227,7 @@ module.exports = {
         }
       },
 
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
         // Report missing display name for all components
         Object.keys(list).filter(component => !list[component].hasDisplayName).forEach((component) => {

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -236,7 +236,7 @@ module.exports = {
         lastAttributeNode[getOpeningElementId(node.parent)] = node;
       },
 
-      'JSXOpeningElement:exit': function (node) {
+      'JSXOpeningElement:exit'(node) {
         const attributeNode = lastAttributeNode[getOpeningElementId(node)];
         const cachedLastAttributeEndPos = attributeNode ? attributeNode.range[1] : null;
         let expectedNextLine;

--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -80,7 +80,7 @@ module.exports = {
       JSXElement: handleJSX,
       JSXFragment: handleJSX,
 
-      'Program:exit': function () {
+      'Program:exit'() {
         if (!invalidNode) {
           return;
         }

--- a/lib/rules/jsx-fragments.js
+++ b/lib/rules/jsx-fragments.js
@@ -58,7 +58,7 @@ module.exports = {
 
     function getFixerToLong(jsxFragment) {
       const sourceCode = context.getSourceCode();
-      return function (fixer) {
+      return function fix(fixer) {
         let source = sourceCode.getText();
         source = replaceNode(source, jsxFragment.closingFragment, closeFragLong);
         source = replaceNode(source, jsxFragment.openingFragment, openFragLong);
@@ -71,7 +71,7 @@ module.exports = {
 
     function getFixerToShort(jsxElement) {
       const sourceCode = context.getSourceCode();
-      return function (fixer) {
+      return function fix(fixer) {
         let source = sourceCode.getText();
         let lengthDiff;
         if (jsxElement.closingElement) {
@@ -164,7 +164,7 @@ module.exports = {
         }
       },
 
-      'Program:exit': function () {
+      'Program:exit'() {
         jsxElements.forEach((node) => {
           const openingEl = node.openingElement;
           const elName = elementType(openingEl);

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -95,7 +95,7 @@ module.exports = {
      * @private
      */
     function getFixerFunction(node, needed) {
-      return function (fixer) {
+      return function fix(fixer) {
         const indent = Array(needed + 1).join(indentChar);
         return fixer.replaceTextRange(
           [node.range[0] - node.loc.start.column, node.range[0]],

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -62,7 +62,7 @@ module.exports = {
         }, ''));
       }
       const code = output.join('\n');
-      return function (fixer) {
+      return function fix(fixer) {
         return fixer.replaceTextRange([front, back], code);
       };
     }

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -132,7 +132,7 @@ const generateFixerFunction = (node, context, reservedList) => {
     .slice(0)
     .map(group => group.slice(0).sort((a, b) => contextCompare(a, b, options)));
 
-  return function (fixer) {
+  return function fixFunction(fixer) {
     const fixers = [];
     let source = sourceCode.getText();
 
@@ -178,7 +178,7 @@ function validateReservedFirstConfig(context, reservedFirst) {
       ));
 
       if (reservedFirst.length === 0) {
-        return function (decl) {
+        return function report(decl) {
           context.report({
             node: decl,
             message: 'A customized reserved first list must not be empty'
@@ -186,7 +186,7 @@ function validateReservedFirstConfig(context, reservedFirst) {
         };
       }
       if (nonReservedWords.length > 0) {
-        return function (decl) {
+        return function report(decl) {
           context.report({
             node: decl,
             message: 'A customized reserved first list must only contain a subset of React reserved props.' +

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -213,7 +213,7 @@ module.exports = {
         checkPropValue(value.expression);
       },
 
-      'CallExpression:exit': function (node) {
+      'CallExpression:exit'(node) {
         const mapIndexParamName = getMapIndexParamName(node);
         if (!mapIndexParamName) {
           return;

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -119,13 +119,13 @@ module.exports = {
         }
       },
 
-      'CallExpression:exit': function (node) {
+      'CallExpression:exit'(node) {
         components.set(node, {
           inCallExpression: false
         });
       },
 
-      'MethodDefinition:exit': function (node) {
+      'MethodDefinition:exit'(node) {
         if (node.kind === 'constructor') {
           components.set(node, {
             inConstructor: false
@@ -133,7 +133,7 @@ module.exports = {
         }
       },
 
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
 
         Object.keys(list).forEach((key) => {

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -58,7 +58,7 @@ module.exports = {
     // --------------------------------------------------------------------------
 
     return {
-      'Program:exit': function () {
+      'Program:exit'() {
         if (components.length() <= 1) {
           return;
         }

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -72,7 +72,7 @@ module.exports = {
         });
       },
 
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
         Object.keys(list).filter(component => !isValid(list[component])).forEach((component) => {
           reportSetStateUsages(list[component]);

--- a/lib/rules/no-unescaped-entities.js
+++ b/lib/rules/no-unescaped-entities.js
@@ -109,7 +109,7 @@ module.exports = {
     }
 
     return {
-      'Literal, JSXText': function (node) {
+      'Literal, JSXText'(node) {
         if (jsxUtil.isJSX(node.parent)) {
           reportInvalidEntity(node);
         }

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -131,7 +131,7 @@ module.exports = {
     // --------------------------------------------------------------------------
 
     return {
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
         // Report undeclared proptypes for all classes
         Object.keys(list).filter(component => mustBeValidated(list[component])).forEach((component) => {

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -231,7 +231,7 @@ module.exports = {
         }
       },
 
-      'ObjectExpression:exit': function (node) {
+      'ObjectExpression:exit'(node) {
         if (!classInfo) {
           return;
         }
@@ -242,7 +242,7 @@ module.exports = {
         }
       },
 
-      'ClassDeclaration:exit': function () {
+      'ClassDeclaration:exit'() {
         if (!classInfo) {
           return;
         }
@@ -306,7 +306,7 @@ module.exports = {
         }
       },
 
-      'ClassProperty:exit': function (node) {
+      'ClassProperty:exit'(node) {
         if (
           classInfo &&
           !node.static &&
@@ -326,7 +326,7 @@ module.exports = {
         classInfo.aliases = new Set();
       },
 
-      'MethodDefinition:exit': function () {
+      'MethodDefinition:exit'() {
         if (!classInfo) {
           return;
         }
@@ -422,7 +422,7 @@ module.exports = {
         }
       },
 
-      'ExperimentalSpreadProperty, SpreadElement': function (node) {
+      'ExperimentalSpreadProperty, SpreadElement'(node) {
         if (classInfo && isStateReference(node.argument)) {
           classInfo = null;
         }

--- a/lib/rules/prefer-read-only-props.js
+++ b/lib/rules/prefer-read-only-props.js
@@ -33,7 +33,7 @@ module.exports = {
   },
 
   create: Components.detect((context, components) => ({
-    'Program:exit': function () {
+    'Program:exit'() {
       const list = components.list();
 
       Object.keys(list).forEach((key) => {

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -196,21 +196,21 @@ module.exports = {
      * Mark component as pure as declared
      * @param {ASTNode} node The AST node being checked.
      */
-    const markSCUAsDeclared = function (node) {
+    function markSCUAsDeclared(node) {
       components.set(node, {
         hasSCU: true
       });
-    };
+    }
 
     /**
      * Mark childContextTypes as declared
      * @param {ASTNode} node The AST node being checked.
      */
-    const markChildContextTypesAsDeclared = function (node) {
+    function markChildContextTypesAsDeclared(node) {
       components.set(node, {
         hasChildContextTypes: true
       });
-    };
+    }
 
     /**
      * Mark a setState as used
@@ -351,7 +351,7 @@ module.exports = {
         markReturnAsInvalid(node);
       },
 
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
         Object.keys(list).forEach((component) => {
           if (

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -183,7 +183,7 @@ module.exports = {
     // --------------------------------------------------------------------------
 
     return {
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
         // Report undeclared proptypes for all classes
         Object.keys(list).filter(component => mustBeValidated(list[component])).forEach((component) => {

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -80,7 +80,7 @@ module.exports = {
     // --------------------------------------------------------------------------
 
     return {
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
 
         Object.keys(list).filter(component => list[component].declaredPropTypes).forEach((component) => {

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -41,7 +41,7 @@ module.exports = {
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if node is decorated with a PureRenderMixin, false if not.
      */
-    const hasPureRenderDecorator = function (node) {
+    function hasPureRenderDecorator(node) {
       if (node.decorators && node.decorators.length) {
         for (let i = 0, l = node.decorators.length; i < l; i++) {
           if (
@@ -61,14 +61,14 @@ module.exports = {
       }
 
       return false;
-    };
+    }
 
     /**
      * Checks to see if our component is custom decorated
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if node is decorated name with a custom decorated, false if not.
      */
-    const hasCustomDecorator = function (node) {
+    function hasCustomDecorator(node) {
       const allowLength = allowDecorators.length;
 
       if (allowLength && node.decorators && node.decorators.length) {
@@ -85,26 +85,26 @@ module.exports = {
       }
 
       return false;
-    };
+    }
 
     /**
      * Checks if we are declaring a shouldComponentUpdate method
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if we are declaring a shouldComponentUpdate method, false if not.
      */
-    const isSCUDeclared = function (node) {
+    function isSCUDeclared(node) {
       return Boolean(
         node &&
         node.name === 'shouldComponentUpdate'
       );
-    };
+    }
 
     /**
      * Checks if we are declaring a PureRenderMixin mixin
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if we are declaring a PureRenderMixin method, false if not.
      */
-    const isPureRenderDeclared = function (node) {
+    function isPureRenderDeclared(node) {
       let hasPR = false;
       if (node.value && node.value.elements) {
         for (let i = 0, l = node.value.elements.length; i < l; i++) {
@@ -120,23 +120,23 @@ module.exports = {
         node.key.name === 'mixins' &&
         hasPR
       );
-    };
+    }
 
     /**
      * Mark shouldComponentUpdate as declared
      * @param {ASTNode} node The AST node being checked.
      */
-    const markSCUAsDeclared = function (node) {
+    function markSCUAsDeclared(node) {
       components.set(node, {
         hasSCU: true
       });
-    };
+    }
 
     /**
      * Reports missing optimization for a given component
      * @param {Object} component The component to process
      */
-    const reportMissingOptimization = function (component) {
+    function reportMissingOptimization(component) {
       context.report({
         node: component.node,
         message: MISSING_MESSAGE,
@@ -144,13 +144,13 @@ module.exports = {
           component: component.name
         }
       });
-    };
+    }
 
     /**
      * Checks if we are declaring function in class
      * @returns {Boolean} True if we are declaring function in class, false if not.
      */
-    const isFunctionInClass = function () {
+    function isFunctionInClass() {
       let blockNode;
       let scope = context.getScope();
       while (scope) {
@@ -162,7 +162,7 @@ module.exports = {
       }
 
       return false;
-    };
+    }
 
     return {
       ArrowFunctionExpression(node) {
@@ -217,7 +217,7 @@ module.exports = {
         }
       },
 
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
 
         // Report missing shouldComponentUpdate for all components

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -72,7 +72,7 @@ module.exports = {
         markReturnStatementPresent(node);
       },
 
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
         Object.keys(list).forEach((component) => {
           if (

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -427,7 +427,7 @@ module.exports = {
     }
 
     return {
-      'Program:exit': function () {
+      'Program:exit'() {
         const list = components.list();
         Object.keys(list).forEach((component) => {
           const properties = astUtil.getComponentProperties(list[component].node);

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -875,7 +875,7 @@ function componentRule(rule, context) {
   ));
 
   allKeys.forEach((instruction) => {
-    updatedRuleInstructions[instruction] = function (node) {
+    updatedRuleInstructions[instruction] = (node) => {
       if (instruction in detectionInstructions) {
         detectionInstructions[instruction](node);
       }

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -758,11 +758,11 @@ module.exports = function propTypesInstructions(context, components, utils) {
       stack.push(Object.create(typeScope()));
     },
 
-    'BlockStatement:exit': function () {
+    'BlockStatement:exit'() {
       stack.pop();
     },
 
-    'Program:exit': function () {
+    'Program:exit'() {
       classExpressions.forEach((node) => {
         if (isSuperTypeParameterPropsDeclaration(node)) {
           markPropTypesAsDeclared(node, resolveSuperParameterPropsType(node));

--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -527,7 +527,7 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
       }
     },
 
-    'Program:exit': function () {
+    'Program:exit'() {
       const list = components.list();
 
       Object.keys(list).filter(component => mustBeValidated(list[component])).forEach((component) => {

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -26,10 +26,10 @@ const MESSAGE_PROPS_ALIGNED = 'The closing bracket must be aligned with the last
 const MESSAGE_TAG_ALIGNED = 'The closing bracket must be aligned with the opening tag';
 const MESSAGE_LINE_ALIGNED = 'The closing bracket must be aligned with the line containing the opening tag';
 
-const messageWithDetails = function (message, expectedColumn, expectedNextLine) {
+function messageWithDetails(message, expectedColumn, expectedNextLine) {
   const details = ` (expected column ${expectedColumn}${expectedNextLine ? ' on the next line)' : ')'}`;
   return message + details;
-};
+}
 
 // ------------------------------------------------------------------------------
 // Tests


### PR DESCRIPTION
`object-shorthand` is changed to `always`, otherwise `{'Program:exit'() {}}` is disallowed.
