### PR TITLE
react/prop-types: Update 'skipUndeclared' in rule options

### DIFF
--- a/docs/rules/prop-types.md
+++ b/docs/rules/prop-types.md
@@ -102,14 +102,14 @@ This rule can take one argument to ignore some specific props during validation.
 
 ```js
 ...
-"react/prop-types": [<enabled>, { ignore: <ignore>, customValidators: <customValidator> }]
+"react/prop-types": [<enabled>, { ignore: <ignore>, customValidators: <customValidator>, skipUndeclared: <skipUndeclared> }]
 ...
 ```
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
 * `ignore`: optional array of props name to ignore during validation.
 * `customValidators`: optional array of validators used for propTypes validation.
-* `skipUndeclared`: only error on components that have a propTypes block declared
+* `skipUndeclared`: optional boolean to only error on components that have a propTypes block declared.
 
 ### As for "exceptions"
 


### PR DESCRIPTION
Updates to the `react/prop-types` documentation to:
- Include 'skipUndeclared' in rule option's snippet.
- Indicate it's an optional boolean.