### PR TITLE
Disable --fix for sort-prop-types

### DIFF
--- a/docs/rules/jsx-sort-default-props.md
+++ b/docs/rules/jsx-sort-default-props.md
@@ -2,8 +2,6 @@
 
 Some developers prefer to sort `defaultProps` declarations alphabetically to be able to find necessary declarations easier at a later time. Others feel that it adds complexity and becomes a burden to maintain.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
-
 ## Rule Details
 
 This rule checks all components and verifies that all `defaultProps` declarations are sorted alphabetically. A spread attribute resets the verification. The default configuration of the rule is case-sensitive.

--- a/docs/rules/sort-prop-types.md
+++ b/docs/rules/sort-prop-types.md
@@ -2,9 +2,6 @@
 
 Some developers prefer to sort propTypes declarations alphabetically to be able to find necessary declaration easier at the later time. Others feel that it adds complexity and becomes burden to maintain.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
-
-
 ## Rule Details
 
 This rule checks all components and verifies that all propTypes declarations are sorted alphabetically. A spread attribute resets the verification. The default configuration of the rule is case-sensitive.

--- a/lib/rules/jsx-sort-default-props.js
+++ b/lib/rules/jsx-sort-default-props.js
@@ -8,7 +8,7 @@
 const variableUtil = require('../util/variable');
 const docsUrl = require('../util/docsUrl');
 const propWrapperUtil = require('../util/propWrapper');
-const propTypesSortUtil = require('../util/propTypesSort');
+// const propTypesSortUtil = require('../util/propTypesSort');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -23,7 +23,7 @@ module.exports = {
       url: docsUrl('jsx-sort-default-props')
     },
 
-    fixable: 'code',
+    // fixable: 'code',
 
     schema: [{
       type: 'object',
@@ -100,9 +100,9 @@ module.exports = {
      * @returns {void}
      */
     function checkSorted(declarations) {
-      function fix(fixer) {
-        return propTypesSortUtil.fixPropTypesSort(fixer, context, declarations, ignoreCase);
-      }
+      // function fix(fixer) {
+      //   return propTypesSortUtil.fixPropTypesSort(fixer, context, declarations, ignoreCase);
+      // }
 
       declarations.reduce((prev, curr, idx, decls) => {
         if (/Spread(?:Property|Element)$/.test(curr.type)) {
@@ -120,8 +120,8 @@ module.exports = {
         if (currentPropName < prevPropName) {
           context.report({
             node: curr,
-            message: 'Default prop types declarations should be sorted alphabetically',
-            fix
+            message: 'Default prop types declarations should be sorted alphabetically'
+            // fix
           });
 
           return prev;

--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -8,7 +8,7 @@ const variableUtil = require('../util/variable');
 const propsUtil = require('../util/props');
 const docsUrl = require('../util/docsUrl');
 const propWrapperUtil = require('../util/propWrapper');
-const propTypesSortUtil = require('../util/propTypesSort');
+// const propTypesSortUtil = require('../util/propTypesSort');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -23,7 +23,7 @@ module.exports = {
       url: docsUrl('sort-prop-types')
     },
 
-    fixable: 'code',
+    // fixable: 'code',
 
     schema: [{
       type: 'object',
@@ -98,17 +98,17 @@ module.exports = {
         return;
       }
 
-      function fix(fixer) {
-        return propTypesSortUtil.fixPropTypesSort(
-          fixer,
-          context,
-          declarations,
-          ignoreCase,
-          requiredFirst,
-          callbacksLast,
-          sortShapeProp
-        );
-      }
+      // function fix(fixer) {
+      //   return propTypesSortUtil.fixPropTypesSort(
+      //     fixer,
+      //     context,
+      //     declarations,
+      //     ignoreCase,
+      //     requiredFirst,
+      //     callbacksLast,
+      //     sortShapeProp
+      //   );
+      // }
 
       declarations.reduce((prev, curr, idx, decls) => {
         if (curr.type === 'ExperimentalSpreadProperty' || curr.type === 'SpreadElement') {
@@ -136,8 +136,8 @@ module.exports = {
             // Encountered a non-required prop after a required prop
             context.report({
               node: curr,
-              message: 'Required prop types must be listed before all other prop types',
-              fix
+              message: 'Required prop types must be listed before all other prop types'
+            //  fix
             });
             return curr;
           }
@@ -152,8 +152,8 @@ module.exports = {
             // Encountered a non-callback prop after a callback prop
             context.report({
               node: prev,
-              message: 'Callback prop types must be listed after all other prop types',
-              fix
+              message: 'Callback prop types must be listed after all other prop types'
+              // fix
             });
             return prev;
           }
@@ -162,8 +162,8 @@ module.exports = {
         if (!noSortAlphabetically && currentPropName < prevPropName) {
           context.report({
             node: curr,
-            message: 'Prop types declarations should be sorted alphabetically',
-            fix
+            message: 'Prop types declarations should be sorted alphabetically'
+            // fix
           });
           return prev;
         }

--- a/tests/lib/rules/jsx-sort-default-props.js
+++ b/tests/lib/rules/jsx-sort-default-props.js
@@ -374,24 +374,24 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 10,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'class Component extends React.Component {',
-      '  static propTypes = {',
-      '    a: PropTypes.any,',
-      '    b: PropTypes.any,',
-      '    c: PropTypes.any',
-      '  };',
-      '  static defaultProps = {',
-      '    a: "a",',
-      '    b: "b",',
-      '    c: "c"',
-      '  };',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class Component extends React.Component {',
+    //   '  static propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    b: PropTypes.any,',
+    //   '    c: PropTypes.any',
+    //   '  };',
+    //   '  static defaultProps = {',
+    //   '    a: "a",',
+    //   '    b: "b",',
+    //   '    c: "c"',
+    //   '  };',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'class Component extends React.Component {',
@@ -411,24 +411,24 @@ ruleTester.run('jsx-sort-default-props', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: 2,
-    output: [
-      'class Component extends React.Component {',
-      '  static propTypes = {',
-      '    a: PropTypes.any,',
-      '    b: PropTypes.any,',
-      '    c: PropTypes.any',
-      '  };',
-      '  static defaultProps = {',
-      '    a: "a",',
-      '    b: "b",',
-      '    c: "c"',
-      '  };',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}'
-    ].join('\n')
+    errors: 2
+    // output: [
+    //   'class Component extends React.Component {',
+    //   '  static propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    b: PropTypes.any,',
+    //   '    c: PropTypes.any',
+    //   '  };',
+    //   '  static defaultProps = {',
+    //   '    a: "a",',
+    //   '    b: "b",',
+    //   '    c: "c"',
+    //   '  };',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'class Component extends React.Component {',
@@ -454,22 +454,22 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 8,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'class Component extends React.Component {',
-      '  static propTypes = {',
-      '    a: PropTypes.any,',
-      '    b: PropTypes.any',
-      '  };',
-      '  static defaultProps = {',
-      '    a: "a",',
-      '    Z: "Z",',
-      '  };',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class Component extends React.Component {',
+    //   '  static propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    b: PropTypes.any',
+    //   '  };',
+    //   '  static defaultProps = {',
+    //   '    a: "a",',
+    //   '    Z: "Z",',
+    //   '  };',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'class Component extends React.Component {',
@@ -492,22 +492,22 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 8,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'class Component extends React.Component {',
-      '  static propTypes = {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.any',
-      '  };',
-      '  static defaultProps = {',
-      '    Z: "Z",',
-      '    a: "a",',
-      '  };',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class Component extends React.Component {',
+    //   '  static propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.any',
+    //   '  };',
+    //   '  static defaultProps = {',
+    //   '    Z: "Z",',
+    //   '    a: "a",',
+    //   '  };',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -530,22 +530,22 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 12,
       column: 3,
       type: 'Property'
-    }],
-    output: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '}',
-      'Hello.propTypes = {',
-      '  "a": PropTypes.string,',
-      '  "b": PropTypes.string',
-      '};',
-      'Hello.defaultProps = {',
-      '  "a": "a",',
-      '  "b": "b"',
-      '};'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class Hello extends React.Component {',
+    //   '  render() {',
+    //   '    return <div>Hello</div>;',
+    //   '  }',
+    //   '}',
+    //   'Hello.propTypes = {',
+    //   '  "a": PropTypes.string,',
+    //   '  "b": PropTypes.string',
+    //   '};',
+    //   'Hello.defaultProps = {',
+    //   '  "a": "a",',
+    //   '  "b": "b"',
+    //   '};'
+    // ].join('\n')
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -565,24 +565,24 @@ ruleTester.run('jsx-sort-default-props', rule, {
       '};'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: 2,
-    output: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '}',
-      'Hello.propTypes = {',
-      '  "a": PropTypes.string,',
-      '  "b": PropTypes.string,',
-      '  "c": PropTypes.string',
-      '};',
-      'Hello.defaultProps = {',
-      '  "a": "a",',
-      '  "b": "b",',
-      '  "c": "c"',
-      '};'
-    ].join('\n')
+    errors: 2
+    // output: [
+    //   'class Hello extends React.Component {',
+    //   '  render() {',
+    //   '    return <div>Hello</div>;',
+    //   '  }',
+    //   '}',
+    //   'Hello.propTypes = {',
+    //   '  "a": PropTypes.string,',
+    //   '  "b": PropTypes.string,',
+    //   '  "c": PropTypes.string',
+    //   '};',
+    //   'Hello.defaultProps = {',
+    //   '  "a": "a",',
+    //   '  "b": "b",',
+    //   '  "c": "c"',
+    //   '};'
+    // ].join('\n')
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -605,23 +605,66 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 12,
       column: 3,
       type: 'Property'
-    }],
-    output: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '}',
-      'Hello.propTypes = {',
-      '  "a": PropTypes.string,',
-      '  "B": PropTypes.string,',
-      '};',
-      'Hello.defaultProps = {',
-      '  "B": "B",',
-      '  "a": "a",',
-      '};'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class Hello extends React.Component {',
+    //   '  render() {',
+    //   '    return <div>Hello</div>;',
+    //   '  }',
+    //   '}',
+    //   'Hello.propTypes = {',
+    //   '  "a": PropTypes.string,',
+    //   '  "B": PropTypes.string,',
+    //   '};',
+    //   'Hello.defaultProps = {',
+    //   '  "B": "B",',
+    //   '  "a": "a",',
+    //   '};'
+    // ].join('\n')
   }, {
+  // Disabled test for comments -- fails
+  //   code: [
+  //     'class Hello extends React.Component {',
+  //     '  render() {',
+  //     '    return <div>Hello</div>;',
+  //     '  }',
+  //     '}',
+  //     'Hello.propTypes = {',
+  //     '  "a": PropTypes.string,',
+  //     '  "B": PropTypes.string,',
+  //     '};',
+  //     'Hello.defaultProps = {',
+  //     '  /* a */',
+  //     '  "a": "a",',
+  //     '  /* B */',
+  //     '  "B": "B",',
+  //     '};'
+  //   ].join('\n'),
+  //   parser: parsers.BABEL_ESLINT,
+  //   errors: [{
+  //     message: ERROR_MESSAGE,
+  //     line: 14,
+  //     column: 3,
+  //     type: 'Property'
+  //   }],
+  //   output: [
+  //     'class Hello extends React.Component {',
+  //     '  render() {',
+  //     '    return <div>Hello</div>;',
+  //     '  }',
+  //     '}',
+  //     'Hello.propTypes = {',
+  //     '  "a": PropTypes.string,',
+  //     '  "B": PropTypes.string,',
+  //     '};',
+  //     'Hello.defaultProps = {',
+  //     '  /* B */',
+  //     '  "B": "B",',
+  //     '  /* a */',
+  //     '  "a": "a",',
+  //     '};'
+  //   ].join('\n')
+  // }, {
     code: [
       'class Hello extends React.Component {',
       '  render() {',
@@ -646,22 +689,22 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 12,
       column: 3,
       type: 'Property'
-    }],
-    output: [
-      'class Hello extends React.Component {',
-      '  render() {',
-      '    return <div>Hello</div>;',
-      '  }',
-      '}',
-      'Hello.propTypes = {',
-      '  "a": PropTypes.string,',
-      '  "B": PropTypes.string,',
-      '};',
-      'Hello.defaultProps = {',
-      '  "a": "a",',
-      '  "B": "B",',
-      '};'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class Hello extends React.Component {',
+    //   '  render() {',
+    //   '    return <div>Hello</div>;',
+    //   '  }',
+    //   '}',
+    //   'Hello.propTypes = {',
+    //   '  "a": PropTypes.string,',
+    //   '  "B": PropTypes.string,',
+    //   '};',
+    //   'Hello.defaultProps = {',
+    //   '  "a": "a",',
+    //   '  "B": "B",',
+    //   '};'
+    // ].join('\n')
   }, {
     code: [
       'const First = (props) => <div />;',
@@ -681,20 +724,20 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 8,
       column: 3,
       type: 'Property'
-    }],
-    output: [
-      'const First = (props) => <div />;',
-      'const propTypes = {',
-      '  z: PropTypes.string,',
-      '  a: PropTypes.any,',
-      '};',
-      'const defaultProps = {',
-      '  a: "a",',
-      '  z: "z",',
-      '};',
-      'First.propTypes = propTypes;',
-      'First.defaultProps = defaultProps;'
-    ].join('\n')
+    }]
+    // output: [
+    //   'const First = (props) => <div />;',
+    //   'const propTypes = {',
+    //   '  z: PropTypes.string,',
+    //   '  a: PropTypes.any,',
+    //   '};',
+    //   'const defaultProps = {',
+    //   '  a: "a",',
+    //   '  z: "z",',
+    //   '};',
+    //   'First.propTypes = propTypes;',
+    //   'First.defaultProps = defaultProps;'
+    // ].join('\n')
   }, {
     code: [
       'export default class ClassWithSpreadInPropTypes extends BaseClass {',
@@ -716,21 +759,21 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 9,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'export default class ClassWithSpreadInPropTypes extends BaseClass {',
-      '  static propTypes = {',
-      '    b: PropTypes.string,',
-      '    ...c.propTypes,',
-      '    a: PropTypes.string',
-      '  }',
-      '  static defaultProps = {',
-      '    a: "a",',
-      '    b: "b",',
-      '    ...c.defaultProps',
-      '  }',
-      '}'
-    ].join('\n')
+    }]
+    // output: [
+    //   'export default class ClassWithSpreadInPropTypes extends BaseClass {',
+    //   '  static propTypes = {',
+    //   '    b: PropTypes.string,',
+    //   '    ...c.propTypes,',
+    //   '    a: PropTypes.string',
+    //   '  }',
+    //   '  static defaultProps = {',
+    //   '    a: "a",',
+    //   '    b: "b",',
+    //   '    ...c.defaultProps',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'export default class ClassWithSpreadInPropTypes extends BaseClass {',
@@ -753,27 +796,27 @@ ruleTester.run('jsx-sort-default-props', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: 2,
-    output: [
-      'export default class ClassWithSpreadInPropTypes extends BaseClass {',
-      '  static propTypes = {',
-      '    a: PropTypes.string,',
-      '    b: PropTypes.string,',
-      '    c: PropTypes.string,',
-      '    d: PropTypes.string,',
-      '    e: PropTypes.string,',
-      '    f: PropTypes.string',
-      '  }',
-      '  static defaultProps = {',
-      '    a: "a",',
-      '    b: "b",',
-      '    ...c.defaultProps,',
-      '    e: "e",',
-      '    f: "f",',
-      '    ...d.defaultProps',
-      '  }',
-      '}'
-    ].join('\n')
+    errors: 2
+    // output: [
+    //   'export default class ClassWithSpreadInPropTypes extends BaseClass {',
+    //   '  static propTypes = {',
+    //   '    a: PropTypes.string,',
+    //   '    b: PropTypes.string,',
+    //   '    c: PropTypes.string,',
+    //   '    d: PropTypes.string,',
+    //   '    e: PropTypes.string,',
+    //   '    f: PropTypes.string',
+    //   '  }',
+    //   '  static defaultProps = {',
+    //   '    a: "a",',
+    //   '    b: "b",',
+    //   '    ...c.defaultProps,',
+    //   '    e: "e",',
+    //   '    f: "f",',
+    //   '    ...d.defaultProps',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'const defaults = {',
@@ -800,25 +843,25 @@ ruleTester.run('jsx-sort-default-props', rule, {
       line: 15,
       column: 3,
       type: 'Property'
-    }],
-    output: [
-      'const defaults = {',
-      '  b: "b"',
-      '};',
-      'const types = {',
-      '  a: PropTypes.string,',
-      '  b: PropTypes.string,',
-      '  c: PropTypes.string',
-      '};',
-      'function StatelessComponentWithSpreadInPropTypes({ a, b, c }) {',
-      '  return <div>{a}{b}{c}</div>;',
-      '}',
-      'StatelessComponentWithSpreadInPropTypes.propTypes = types;',
-      'StatelessComponentWithSpreadInPropTypes.defaultProps = {',
-      '  a: "a",',
-      '  c: "c",',
-      '  ...defaults,',
-      '};'
-    ].join('\n')
+    }]
+    // output: [
+    //   'const defaults = {',
+    //   '  b: "b"',
+    //   '};',
+    //   'const types = {',
+    //   '  a: PropTypes.string,',
+    //   '  b: PropTypes.string,',
+    //   '  c: PropTypes.string',
+    //   '};',
+    //   'function StatelessComponentWithSpreadInPropTypes({ a, b, c }) {',
+    //   '  return <div>{a}{b}{c}</div>;',
+    //   '}',
+    //   'StatelessComponentWithSpreadInPropTypes.propTypes = types;',
+    //   'StatelessComponentWithSpreadInPropTypes.defaultProps = {',
+    //   '  a: "a",',
+    //   '  c: "c",',
+    //   '  ...defaults,',
+    //   '};'
+    // ].join('\n')
   }]
 });

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -486,18 +486,52 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
+  }, {
+    code: [
       'var First = createReactClass({',
       '  propTypes: {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string',
+      '    /* z */',
+      '    z: PropTypes.string,',
+      '    /* a */',
+      '    a: PropTypes.any',
       '  },',
       '  render: function() {',
       '    return <div />;',
       '  }',
       '});'
-    ].join('\n')
+    ].join('\n'),
+    errors: [{
+      message: ERROR_MESSAGE,
+      line: 6,
+      column: 5,
+      type: 'Property'
+    }]
+    // Disabled test for comments -- fails
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    /* a */',
+    //   '    a: PropTypes.any,',
+    //   '    /* z */',
+    //   '    z: PropTypes.string',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -515,18 +549,18 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    Z: PropTypes.any,',
-      '    z: PropTypes.any',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    Z: PropTypes.any,',
+    //   '    z: PropTypes.any',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -547,18 +581,18 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    a: PropTypes.any,',
-      '    Z: PropTypes.any',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    a: PropTypes.any,',
+    //   '    Z: PropTypes.any',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -573,20 +607,20 @@ ruleTester.run('sort-prop-types', rule, {
       '  }',
       '});'
     ].join('\n'),
-    errors: 2,
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    A: PropTypes.any,',
-      '    Z: PropTypes.string,',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    errors: 2
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    A: PropTypes.any,',
+    //   '    Z: PropTypes.string,',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -608,27 +642,27 @@ ruleTester.run('sort-prop-types', rule, {
       '  }',
       '});'
     ].join('\n'),
-    errors: 2,
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    Zz: PropTypes.string,',
-      '    a: PropTypes.any',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});',
-      'var Second = createReactClass({',
-      '  propTypes: {',
-      '    ZZ: PropTypes.string,',
-      '    aAA: PropTypes.any',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    errors: 2
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    Zz: PropTypes.string,',
+    //   '    a: PropTypes.any',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});',
+    //   'var Second = createReactClass({',
+    //   '  propTypes: {',
+    //   '    ZZ: PropTypes.string,',
+    //   '    aAA: PropTypes.any',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'class First extends React.Component {',
@@ -650,27 +684,27 @@ ruleTester.run('sort-prop-types', rule, {
       '    ZZ: PropTypes.string',
       '};'
     ].join('\n'),
-    errors: 2,
-    output: [
-      'class First extends React.Component {',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}',
-      'First.propTypes = {',
-      '    bb: PropTypes.string,',
-      '    yy: PropTypes.any',
-      '};',
-      'class Second extends React.Component {',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}',
-      'Second.propTypes = {',
-      '    ZZ: PropTypes.string,',
-      '    aAA: PropTypes.any',
-      '};'
-    ].join('\n')
+    errors: 2
+    // output: [
+    //   'class First extends React.Component {',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}',
+    //   'First.propTypes = {',
+    //   '    bb: PropTypes.string,',
+    //   '    yy: PropTypes.any',
+    //   '};',
+    //   'class Second extends React.Component {',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}',
+    //   'Second.propTypes = {',
+    //   '    ZZ: PropTypes.string,',
+    //   '    aAA: PropTypes.any',
+    //   '};'
+    // ].join('\n')
   }, {
     code: [
       'class Component extends React.Component {',
@@ -685,19 +719,19 @@ ruleTester.run('sort-prop-types', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: 2,
-    output: [
-      'class Component extends React.Component {',
-      '  static propTypes = {',
-      '    a: PropTypes.any,',
-      '    y: PropTypes.any,',
-      '    z: PropTypes.any',
-      '  };',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}'
-    ].join('\n')
+    errors: 2
+    // output: [
+    //   'class Component extends React.Component {',
+    //   '  static propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    y: PropTypes.any,',
+    //   '    z: PropTypes.any',
+    //   '  };',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'class Component extends React.Component {',
@@ -715,19 +749,19 @@ ruleTester.run('sort-prop-types', rule, {
     settings: {
       propWrapperFunctions: ['forbidExtraProps']
     },
-    errors: 2,
-    output: [
-      'class Component extends React.Component {',
-      '  static propTypes = forbidExtraProps({',
-      '    a: PropTypes.any,',
-      '    y: PropTypes.any,',
-      '    z: PropTypes.any',
-      '  });',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}'
-    ].join('\n')
+    errors: 2
+    // output: [
+    //   'class Component extends React.Component {',
+    //   '  static propTypes = forbidExtraProps({',
+    //   '    a: PropTypes.any,',
+    //   '    y: PropTypes.any,',
+    //   '    z: PropTypes.any',
+    //   '  });',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -750,20 +784,20 @@ ruleTester.run('sort-prop-types', rule, {
       line: 6,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string,',
-      '    onBar: PropTypes.func,',
-      '    onFoo: PropTypes.func',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string,',
+    //   '    onBar: PropTypes.func,',
+    //   '    onFoo: PropTypes.func',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'class Component extends React.Component {',
@@ -787,20 +821,20 @@ ruleTester.run('sort-prop-types', rule, {
       line: 6,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'class Component extends React.Component {',
-      '  static propTypes = {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string,',
-      '    onBar: PropTypes.func,',
-      '    onFoo: PropTypes.func',
-      '  };',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class Component extends React.Component {',
+    //   '  static propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string,',
+    //   '    onBar: PropTypes.func,',
+    //   '    onFoo: PropTypes.func',
+    //   '  };',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'class First extends React.Component {',
@@ -823,20 +857,20 @@ ruleTester.run('sort-prop-types', rule, {
       line: 10,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'class First extends React.Component {',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}',
-      'First.propTypes = {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string,',
-      '    onBar: PropTypes.func,',
-      '    onFoo: PropTypes.func',
-      '};'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class First extends React.Component {',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}',
+    //   'First.propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string,',
+    //   '    onBar: PropTypes.func,',
+    //   '    onFoo: PropTypes.func',
+    //   '};'
+    // ].join('\n')
   }, {
     code: [
       'class First extends React.Component {',
@@ -862,20 +896,20 @@ ruleTester.run('sort-prop-types', rule, {
       line: 10,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'class First extends React.Component {',
-      '  render() {',
-      '    return <div />;',
-      '  }',
-      '}',
-      'First.propTypes = forbidExtraProps({',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string,',
-      '    onBar: PropTypes.func,',
-      '    onFoo: PropTypes.func',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'class First extends React.Component {',
+    //   '  render() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '}',
+    //   'First.propTypes = forbidExtraProps({',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string,',
+    //   '    onBar: PropTypes.func,',
+    //   '    onFoo: PropTypes.func',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'const First = (props) => <div />;',
@@ -893,15 +927,15 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'const First = (props) => <div />;',
-      'const propTypes = {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string,',
-      '};',
-      'First.propTypes = forbidExtraProps(propTypes);'
-    ].join('\n')
+    }]
+    // output: [
+    //   'const First = (props) => <div />;',
+    //   'const propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string,',
+    //   '};',
+    //   'First.propTypes = forbidExtraProps(propTypes);'
+    // ].join('\n')
   }, {
     code: [
       'const First = (props) => <div />;',
@@ -919,15 +953,15 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'const First = (props) => <div />;',
-      'const propTypes = {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string,',
-      '};',
-      'First.propTypes = propTypes;'
-    ].join('\n')
+    }]
+    // output: [
+    //   'const First = (props) => <div />;',
+    //   'const propTypes = {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string,',
+    //   '};',
+    //   'First.propTypes = propTypes;'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -950,20 +984,20 @@ ruleTester.run('sort-prop-types', rule, {
       line: 5,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string,',
-      '    onBar: PropTypes.func,',
-      '    onFoo: PropTypes.func',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string,',
+    //   '    onBar: PropTypes.func,',
+    //   '    onFoo: PropTypes.func',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -985,19 +1019,19 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    barRequired: PropTypes.string.isRequired,',
-      '    fooRequired: PropTypes.string.isRequired,',
-      '    a: PropTypes.any',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    barRequired: PropTypes.string.isRequired,',
+    //   '    fooRequired: PropTypes.string.isRequired,',
+    //   '    a: PropTypes.any',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -1019,19 +1053,19 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    barRequired: PropTypes.string.isRequired,',
-      '    a: PropTypes.any,',
-      '    onFoo: PropTypes.func',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    barRequired: PropTypes.string.isRequired,',
+    //   '    a: PropTypes.any,',
+    //   '    onFoo: PropTypes.func',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'export default class ClassWithSpreadInPropTypes extends BaseClass {',
@@ -1049,17 +1083,17 @@ ruleTester.run('sort-prop-types', rule, {
       line: 6,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'export default class ClassWithSpreadInPropTypes extends BaseClass {',
-      '  static propTypes = {',
-      '    b: PropTypes.string,',
-      '    ...a.propTypes,',
-      '    c: PropTypes.string,',
-      '    d: PropTypes.string',
-      '  }',
-      '}'
-    ].join('\n')
+    }]
+    // output: [
+    //   'export default class ClassWithSpreadInPropTypes extends BaseClass {',
+    //   '  static propTypes = {',
+    //   '    b: PropTypes.string,',
+    //   '    ...a.propTypes,',
+    //   '    c: PropTypes.string,',
+    //   '    d: PropTypes.string',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'export default class ClassWithSpreadInPropTypes extends BaseClass {',
@@ -1079,19 +1113,19 @@ ruleTester.run('sort-prop-types', rule, {
       line: 6,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'export default class ClassWithSpreadInPropTypes extends BaseClass {',
-      '  static propTypes = {',
-      '    b: PropTypes.string,',
-      '    ...a.propTypes,',
-      '    d: PropTypes.string,',
-      '    f: PropTypes.string,',
-      '    ...e.propTypes,',
-      '    c: PropTypes.string',
-      '  }',
-      '}'
-    ].join('\n')
+    }]
+    // output: [
+    //   'export default class ClassWithSpreadInPropTypes extends BaseClass {',
+    //   '  static propTypes = {',
+    //   '    b: PropTypes.string,',
+    //   '    ...a.propTypes,',
+    //   '    d: PropTypes.string,',
+    //   '    f: PropTypes.string,',
+    //   '    ...e.propTypes,',
+    //   '    c: PropTypes.string',
+    //   '  }',
+    //   '}'
+    // ].join('\n')
   }, {
     code: [
       'const propTypes = {',
@@ -1108,17 +1142,17 @@ ruleTester.run('sort-prop-types', rule, {
       line: 3,
       column: 3,
       type: 'Property'
-    }],
-    output: [
-      'const propTypes = {',
-      '  a: PropTypes.string,',
-      '  b: PropTypes.string,',
-      '};',
-      'const TextFieldLabel = (props) => {',
-      '  return <div />;',
-      '};',
-      'TextFieldLabel.propTypes = propTypes;'
-    ].join('\n')
+    }]
+    // output: [
+    //   'const propTypes = {',
+    //   '  a: PropTypes.string,',
+    //   '  b: PropTypes.string,',
+    //   '};',
+    //   'const TextFieldLabel = (props) => {',
+    //   '  return <div />;',
+    //   '};',
+    //   'TextFieldLabel.propTypes = propTypes;'
+    // ].join('\n')
   }, {
     code: `
       class Component extends React.Component {
@@ -1149,23 +1183,23 @@ ruleTester.run('sort-prop-types', rule, {
       line: 13,
       column: 11,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        x: PropTypes.any,
-        y: PropTypes.any,
-        z: PropTypes.shape({
-          a: PropTypes.any,
-          b: PropTypes.bool,
-          c: PropTypes.any,
-        }),
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     x: PropTypes.any,
+    //     y: PropTypes.any,
+    //     z: PropTypes.shape({
+    //       a: PropTypes.any,
+    //       b: PropTypes.bool,
+    //       c: PropTypes.any,
+    //     }),
+    //   };
+    // `
   }, {
     code: `
       class Component extends React.Component {
@@ -1187,19 +1221,19 @@ ruleTester.run('sort-prop-types', rule, {
       line: 10,
       column: 9,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        x: PropTypes.any,
-        y: PropTypes.any,
-        z: PropTypes.shape(),
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     x: PropTypes.any,
+    //     y: PropTypes.any,
+    //     z: PropTypes.shape(),
+    //   };
+    // `
   }, {
     code: `
       class Component extends React.Component {
@@ -1221,19 +1255,19 @@ ruleTester.run('sort-prop-types', rule, {
       line: 10,
       column: 9,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        x: PropTypes.any,
-        y: PropTypes.any,
-        z: PropTypes.shape(someType),
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     x: PropTypes.any,
+    //     y: PropTypes.any,
+    //     z: PropTypes.shape(someType),
+    //   };
+    // `
   }, {
     code: `
       class Component extends React.Component {
@@ -1280,24 +1314,24 @@ ruleTester.run('sort-prop-types', rule, {
       line: 14,
       column: 11,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        a: PropTypes.shape({
-          C: PropTypes.string,
-          a: PropTypes.any,
-          b: PropTypes.bool,
-          c: PropTypes.any,
-        }),
-        y: PropTypes.any,
-        z: PropTypes.any,
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     a: PropTypes.shape({
+    //       C: PropTypes.string,
+    //       a: PropTypes.any,
+    //       b: PropTypes.bool,
+    //       c: PropTypes.any,
+    //     }),
+    //     y: PropTypes.any,
+    //     z: PropTypes.any,
+    //   };
+    // `
   }, {
     code: `
       class Component extends React.Component {
@@ -1330,24 +1364,24 @@ ruleTester.run('sort-prop-types', rule, {
       line: 14,
       column: 11,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        x: PropTypes.any,
-        y: PropTypes.any,
-        z: PropTypes.shape({
-          a: PropTypes.any,
-          b: PropTypes.bool,
-          c: PropTypes.any,
-          C: PropTypes.string,
-        }),
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     x: PropTypes.any,
+    //     y: PropTypes.any,
+    //     z: PropTypes.shape({
+    //       a: PropTypes.any,
+    //       b: PropTypes.bool,
+    //       c: PropTypes.any,
+    //       C: PropTypes.string,
+    //     }),
+    //   };
+    // `
   }, {
     code: `
       class Component extends React.Component {
@@ -1375,24 +1409,24 @@ ruleTester.run('sort-prop-types', rule, {
       line: 12,
       column: 11,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        x: PropTypes.any,
-        y: PropTypes.any,
-        z: PropTypes.shape({
-          c: PropTypes.number.isRequired,
-          a: PropTypes.string,
-          b: PropTypes.any,
-          d: PropTypes.bool,
-        }),
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     x: PropTypes.any,
+    //     y: PropTypes.any,
+    //     z: PropTypes.shape({
+    //       c: PropTypes.number.isRequired,
+    //       a: PropTypes.string,
+    //       b: PropTypes.any,
+    //       d: PropTypes.bool,
+    //     }),
+    //   };
+    // `
   }, {
     code: `
       class Component extends React.Component {
@@ -1426,25 +1460,25 @@ ruleTester.run('sort-prop-types', rule, {
       line: 14,
       column: 11,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        x: PropTypes.any,
-        y: PropTypes.any,
-        z: PropTypes.shape({
-          a: PropTypes.string,
-          b: PropTypes.any,
-          c: PropTypes.number.isRequired,
-          d: PropTypes.bool,
-          onFoo: PropTypes.func,
-        }),
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     x: PropTypes.any,
+    //     y: PropTypes.any,
+    //     z: PropTypes.shape({
+    //       a: PropTypes.string,
+    //       b: PropTypes.any,
+    //       c: PropTypes.number.isRequired,
+    //       d: PropTypes.bool,
+    //       onFoo: PropTypes.func,
+    //     }),
+    //   };
+    // `
   }, {
     code: `
       class Component extends React.Component {
@@ -1478,26 +1512,26 @@ ruleTester.run('sort-prop-types', rule, {
       line: 16,
       column: 11,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        x: PropTypes.any,
-        y: PropTypes.any,
-        z: PropTypes.shape({
-          a: PropTypes.string,
-          b: PropTypes.any,
-          c: PropTypes.number.isRequired,
-          ...otherPropTypes,
-          d: PropTypes.string,
-          f: PropTypes.bool,
-        }),
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     x: PropTypes.any,
+    //     y: PropTypes.any,
+    //     z: PropTypes.shape({
+    //       a: PropTypes.string,
+    //       b: PropTypes.any,
+    //       c: PropTypes.number.isRequired,
+    //       ...otherPropTypes,
+    //       d: PropTypes.string,
+    //       f: PropTypes.bool,
+    //     }),
+    //   };
+    // `
   }, {
     code: `
       class Component extends React.Component {
@@ -1539,23 +1573,23 @@ ruleTester.run('sort-prop-types', rule, {
       line: 9,
       column: 13,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        static propTypes = {
-          a: PropTypes.shape({
-            a: PropTypes.any,
-            b: PropTypes.bool,
-            c: PropTypes.any,
-          }),
-          y: PropTypes.any,
-          z: PropTypes.any,
-        };
-        render() {
-          return <div />;
-        }
-      }
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     static propTypes = {
+    //       a: PropTypes.shape({
+    //         a: PropTypes.any,
+    //         b: PropTypes.bool,
+    //         c: PropTypes.any,
+    //       }),
+    //       y: PropTypes.any,
+    //       z: PropTypes.any,
+    //     };
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    // `
   }, {
     code: [
       'var First = createReactClass({',
@@ -1576,18 +1610,18 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    a: PropTypes.any,',
-      '    z: PropTypes.string',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    a: PropTypes.any,',
+    //   '    z: PropTypes.string',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: [
       'var First = createReactClass({',
@@ -1609,19 +1643,19 @@ ruleTester.run('sort-prop-types', rule, {
       line: 4,
       column: 5,
       type: 'Property'
-    }],
-    output: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    a: PropTypes.any,',
-      '    \'data-letter\': PropTypes.string,',
-      '    e: PropTypes.any',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n')
+    }]
+    // output: [
+    //   'var First = createReactClass({',
+    //   '  propTypes: {',
+    //   '    a: PropTypes.any,',
+    //   '    \'data-letter\': PropTypes.string,',
+    //   '    e: PropTypes.any',
+    //   '  },',
+    //   '  render: function() {',
+    //   '    return <div />;',
+    //   '  }',
+    //   '});'
+    // ].join('\n')
   }, {
     code: `
       class Component extends React.Component {
@@ -1642,18 +1676,18 @@ ruleTester.run('sort-prop-types', rule, {
       line: 9,
       column: 9,
       type: 'Property'
-    }],
-    output: `
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        0: PropTypes.any,
-        1: PropTypes.any,
-      };
-    `
+    }]
+    // output: `
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     0: PropTypes.any,
+    //     1: PropTypes.any,
+    //   };
+    // `
   }, {
     code: `
       const shape = {
@@ -1685,23 +1719,23 @@ ruleTester.run('sort-prop-types', rule, {
       line: 5,
       column: 9,
       type: 'Property'
-    }],
-    output: `
-      const shape = {
-        a: PropTypes.any,
-        b: PropTypes.bool,
-        c: PropTypes.any,
-      };
-      class Component extends React.Component {
-        static propTypes = {
-          x: PropTypes.shape(shape),
-        };
+    }]
+    // output: `
+    //   const shape = {
+    //     a: PropTypes.any,
+    //     b: PropTypes.bool,
+    //     c: PropTypes.any,
+    //   };
+    //   class Component extends React.Component {
+    //     static propTypes = {
+    //       x: PropTypes.shape(shape),
+    //     };
 
-        render() {
-          return <div />;
-        }
-      }
-    `
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    // `
   }, {
     code: `
       const shape = {
@@ -1731,21 +1765,21 @@ ruleTester.run('sort-prop-types', rule, {
       line: 5,
       column: 9,
       type: 'Property'
-    }],
-    output: `
-      const shape = {
-        a: PropTypes.any,
-        b: PropTypes.bool,
-        c: PropTypes.any,
-      };
-      class Component extends React.Component {
-        render() {
-          return <div />;
-        }
-      }
-      Component.propTypes = {
-        x: PropTypes.shape(shape)
-      };
-    `
+    }]
+    // output: `
+    //   const shape = {
+    //     a: PropTypes.any,
+    //     b: PropTypes.bool,
+    //     c: PropTypes.any,
+    //   };
+    //   class Component extends React.Component {
+    //     render() {
+    //       return <div />;
+    //     }
+    //   }
+    //   Component.propTypes = {
+    //     x: PropTypes.shape(shape)
+    //   };
+    // `
   }]
 });


### PR DESCRIPTION
This addresses #1940 by disabling the fix option for `sort-prop-types` until a better fix to copy the comments is available.