### PR TITLE
[fix] `jsx-curly-brace-presence`: allow trailing spaces in TemplateLiteral

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -174,8 +174,12 @@ module.exports = {
       return node.type && node.type === 'Literal' && node.value && jsxUtil.isWhiteSpaces(node.value);
     }
 
+    function isStringWithTrailingWhiteSpaces(value) {
+      return /^\s|\s$/.test(value);
+    }
+
     function isLiteralWithTrailingWhiteSpaces(node) {
-      return node.type && node.type === 'Literal' && node.value && /^\s|\s$/.test(node.value);
+      return node.type && node.type === 'Literal' && node.value && isStringWithTrailingWhiteSpaces(node.value);
     }
 
     // Bail out if there is any character that needs to be escaped in JSX
@@ -202,6 +206,7 @@ module.exports = {
         expressionType === 'TemplateLiteral' &&
           expression.expressions.length === 0 &&
           expression.quasis[0].value.raw.indexOf('\n') === -1 &&
+          !isStringWithTrailingWhiteSpaces(expression.quasis[0].value.raw) &&
           !needToEscapeCharacterForJSX(expression.quasis[0].value.raw) && (
           jsxUtil.isJSX(JSXExpressionNode.parent) ||
           !containsQuoteCharacters(expression.quasis[0].value.cooked)

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -281,6 +281,14 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       options: ['never']
     },
     {
+      code: '<MyComponent>{`space after `}</MyComponent>',
+      options: ['never']
+    },
+    {
+      code: '<MyComponent>{` space before`}</MyComponent>',
+      options: ['never']
+    },
+    {
       code: ['<a a={"start\\', '\\', 'end"}/>'].join('/n'),
       options: ['never']
     },
@@ -337,6 +345,17 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
           { 'space after ' }
           <b>foo</b>
           { ' space before' }
+        </MyComponent>
+      `,
+      parser: parsers.BABEL_ESLINT,
+      options: [{children: 'never'}]
+    },
+    {
+      code: `
+        <MyComponent>
+          { \`space after \` }
+          <b>foo</b>
+          { \` space before\` }
         </MyComponent>
       `,
       parser: parsers.BABEL_ESLINT,


### PR DESCRIPTION
Fix similar cases #2448 for template literal 