### PR TITLE
[Fix] raise an error when a method name is in string form

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -144,7 +144,11 @@ module.exports = {
 
     function reportErrorIfLifecycleMethodCasingTypo(node) {
       LIFECYCLE_METHODS.forEach((method) => {
-        if (method.toLowerCase() === node.key.name.toLowerCase() && method !== node.key.name) {
+        let nodeKeyName = node.key.name;
+        if(node.key.type === "Literal") {
+          nodeKeyName = node.key.value;
+        }
+        if (method.toLowerCase() === nodeKeyName.toLowerCase() && method !== nodeKeyName) {
           context.report({
             node,
             message: 'Typo in component lifecycle method declaration'


### PR DESCRIPTION
I got a compiling error when a component method name is in string form, but not an identifier. The sample code is,
```javascript
class MyComponent {
    "special-method-name"() {
        // ...
    }
}
```
Normally method names should be valid identifiers, but for some reason, I need one of my methods in a special form. However any strings should be valid method name and both babel and Chrome run without any problem.

The difference between `Identifier` and `String` method is that the `node.key.type` is `Identifier`/`Literal`. So I made a special process here.  