### PR TITLE
[Fix] Compilation error when method name is string instead of identifier

### DIFF
--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -144,7 +144,11 @@ module.exports = {
 
     function reportErrorIfLifecycleMethodCasingTypo(node) {
       LIFECYCLE_METHODS.forEach((method) => {
-        if (method.toLowerCase() === node.key.name.toLowerCase() && method !== node.key.name) {
+        let nodeKeyName = node.key.name;
+        if (node.key.type === 'Literal') {
+          nodeKeyName = node.key.value;
+        }
+        if (method.toLowerCase() === nodeKeyName.toLowerCase() && method !== nodeKeyName) {
           context.report({
             node,
             message: 'Typo in component lifecycle method declaration'

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -205,6 +205,14 @@ ruleTester.run('no-typos', rule, {
     parserOptions
   }, {
     code: `
+      class Hello extends React.Component {
+        "componentDidMount"() { }
+        "my-method"() { }
+      }
+    `,
+    parserOptions
+  }, {
+    code: `
       class MyClass {
         componentWillMount() { }
         componentDidMount() { }


### PR DESCRIPTION
I got a compilation error when a component method name is string instead of identifier. The sample code is,
```javascript
class MyComponent {
    "special-method-name"() {
        // ...
    }
}
```
Normally method names should be valid identifiers. However for some reason, I need one of my methods must be in a special form. `Eslint` raises an error, but babel goes well and the code works well in chrome too.

The difference between `Identifier` and `String` method is that the `node.key.type` is `Identifier`/`Literal`. If method name is `Identifier`, the `node.key.name` is the identifier name, however if method name is `String`, we should get the method name by `node.key.value`.