### PR TITLE
fix[jsx-curly-brace-presence] Fix error related to tag line breaks

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -298,7 +298,11 @@ module.exports = {
       return areRuleConditionsSatisfied(parent, config, OPTION_NEVER);
     }
 
-    function shouldCheckForMissingCurly(parent, config) {
+    function shouldCheckForMissingCurly(node, config) {
+      if (node.raw.trim() === '') {
+        return false;
+      }
+      const parent = node.parent;
       if (
         parent.children &&
         parent.children.length === 1 &&
@@ -322,7 +326,7 @@ module.exports = {
       },
 
       'Literal, JSXText': (node) => {
-        if (shouldCheckForMissingCurly(node.parent, userConfig)) {
+        if (shouldCheckForMissingCurly(node, userConfig)) {
           reportMissingCurly(node);
         }
       }

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -376,6 +376,21 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
         <MyComponent p={<Foo>Bar</Foo>}>
         </MyComponent>
       `
+    },
+    {
+      code: `
+        <MyComponent>
+          <div>
+            <p>
+              <span>
+                {"foo"}
+              </span>
+            </p>
+          </div>
+        </MyComponent>
+      `,
+      parser: parsers.BABEL_ESLINT,
+      options: [{children: 'always'}]
     }
   ],
 


### PR DESCRIPTION
Fixes #1727 

#### Before:

```
  4107 passing (7s)
  1 failing

  1) jsx-curly-brace-presence
       valid

        <MyComponent prop="asdasd">
          <div>
            <p>
              <span>
                {"foo"}
              </span>
            </p>
          </div>
        </MyComponent>
      :

      AssertionError [ERR_ASSERTION]: Should have no errors but had 8: [ { ruleId: 'jsx-curly-brace-presence',
    severity: 1,
    message: 'Need to wrap this literal in a JSX expression.',
    line: 2,
    column: 36,
    nodeType: 'Literal',
    endLine: 3,
    endColumn: 11 },
  { ruleId: 'jsx-curly-brace-presence',
    severity: 1,
    message: 'Need to wrap this literal in a JSX expression.',
    line: 3,
    column: 16,
    nodeType: 'Literal',
    endLine: 4,
    endColumn: 13 },
  { ruleId: 'jsx-curly-brace-presence',
    severity: 1,
    message: 'Need to wrap this literal in a JSX expression.',
    line: 4,
    column: 16,
    nodeType: 'Literal',
    endLine: 5,
    endColumn: 15 },
  { ruleId: 'jsx-curly-brace-presence',
    severity: 1,
    message: 'Need to wrap this literal in a JSX expression.',
    line: 5,
    column: 21,
    nodeType: 'Literal',
    endLine: 6,
    endColumn: 17 },
  { ruleId: 'jsx-curly-brace-presence',
    severity: 1,
    message: 'Need to wrap this literal in a JSX expression.',
    line: 6,
    column: 24,
    nodeType: 'Literal',
    endLine: 7,
    endColumn: 15 },
  { ruleId: 'jsx-curly-brace-presence',
    severity: 1,
    message: 'Need to wrap this literal in a JSX expression.',
    line: 7,
    column: 22,
    nodeType: 'Literal',
    endLine: 8,
    endColumn: 13 },
  { ruleId: 'jsx-curly-brace-presence',
    severity: 1,
    message: 'Need to wrap this literal in a JSX expression.',
    line: 8,
    column: 17,
    nodeType: 'Literal',
    endLine: 9,
    endColumn: 11 },
  { ruleId: 'jsx-curly-brace-presence',
    severity: 1,
    message: 'Need to wrap this literal in a JSX expression.',
    line: 9,
    column: 17,
    nodeType: 'Literal',
    endLine: 10,
    endColumn: 9 } ]
      + expected - actual

      -8
      +0
```