### PR TITLE
Fix rule name reference in "Rule Options" section of jsx-first-prop-new-line.md

### DIFF
--- a/docs/rules/jsx-first-prop-new-line.md
+++ b/docs/rules/jsx-first-prop-new-line.md
@@ -102,7 +102,7 @@ The following patterns are **not** considered warnings when configured `"multili
 ## Rule Options
 
 ```jsx
-"react/jsx-first-props-per-line": `"always" | "never" | "multiline" | "multiline-multiprop"`
+"react/jsx-first-prop-new-line": `"always" | "never" | "multiline" | "multiline-multiprop"`
 ```
 
 ## When not to use


### PR DESCRIPTION
"Rule Options" section for the "jsx-first-prop-new-line" rule had an erroneous reference to "react/jsx-first-**props-per-line**" (instead of prop-new-line) which didn't work when I tried to change my .eslintrc file.

This fixes the section of the md, correcting said reference.