### PR TITLE
Fix title for "no-render-return-value" rule docs

### DIFF
--- a/docs/rules/no-render-return-value.md
+++ b/docs/rules/no-render-return-value.md
@@ -1,4 +1,4 @@
-# Prevent usage of the return value of React.render (react/no-render-return-value)
+# Prevent usage of the return value of ReactDOM.render (react/no-render-return-value)
 
 > `ReactDOM.render()` currently returns a reference to the root `ReactComponent` instance. However, using this return value is legacy and should be avoided because future versions of React may render components asynchronously in some cases. If you need a reference to the root `ReactComponent` instance, the preferred solution is to attach a [callback ref](http://facebook.github.io/react/docs/more-about-refs.html#the-ref-callback-attribute) to the root element.
 


### PR DESCRIPTION
Small fix to change title from `React.render` to `ReactDOM.render` in `react/no-render-return-value` rule.