### PR TITLE
[Fix] `jsx-no-target-blank`: allow rel to be an expression

### DIFF
--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -43,8 +43,17 @@ function hasDynamicLink(element, linkAttribute) {
 function hasSecureRel(element, allowReferrer) {
   return element.attributes.find((attr) => {
     if (attr.type === 'JSXAttribute' && attr.name.name === 'rel') {
-      const tags = attr.value && attr.value.type === 'Literal' && attr.value.value.toLowerCase().split(' ');
-      return tags && (tags.indexOf('noopener') >= 0 && (allowReferrer || tags.indexOf('noreferrer') >= 0));
+      const value = attr.value &&
+        ((
+          attr.value.type === 'Literal' &&
+          attr.value.value
+        ) || (
+          attr.value.type === 'JSXExpressionContainer' &&
+          attr.value.expression &&
+          attr.value.expression.value
+        ));
+      const tags = value && value.toLowerCase && value.toLowerCase().split(' ');
+      return tags && tags.indexOf('noopener') >= 0 && (allowReferrer || tags.indexOf('noreferrer') >= 0);
     }
     return false;
   });

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -36,6 +36,10 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {code: '<a randomTag></a>'},
     {code: '<a target />'},
     {code: '<a href="foobar" target="_blank" rel="noopener noreferrer"></a>'},
+    {code: '<a href="foobar" target="_blank" rel={"noopener noreferrer"}></a>'},
+    {code: '<a href={"foobar"} target={"_blank"} rel={"noopener noreferrer"}></a>'},
+    {code: '<a href={\'foobar\'} target={\'_blank\'} rel={\'noopener noreferrer\'}></a>'},
+    {code: '<a href={`foobar`} target={`_blank`} rel={`noopener noreferrer`}></a>'},
     {code: '<a target="_blank" {...spreadProps} rel="noopener noreferrer"></a>'},
     {code: '<a {...spreadProps} target="_blank" rel="noopener noreferrer" href="http://example.com">s</a>'},
     {code: '<a target="_blank" rel="noopener noreferrer" {...spreadProps}></a>'},
@@ -43,10 +47,12 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {code: '<a href="foobar" target="_BLANK" rel="NOOPENER noreferrer"></a>'},
     {code: '<a target="_blank" rel={relValue}></a>'},
     {code: '<a target={targetValue} rel="noopener noreferrer"></a>'},
+    {code: '<a target={targetValue} rel={"noopener noreferrer"}></a>'},
     {code: '<a target={targetValue} href="relative/path"></a>'},
     {code: '<a target={targetValue} href="/absolute/path"></a>'},
     {code: '<a target={\'targetValue\'} href="/absolute/path"></a>'},
     {code: '<a target={"targetValue"} href="/absolute/path"></a>'},
+    {code: '<a target={null} href="//example.com"></a>'},
     {
       code: '<a target="_blank" href={ dynamicLink }></a>',
       options: [{enforceDynamicLinks: 'never'}]
@@ -97,6 +103,12 @@ ruleTester.run('jsx-no-target-blank', rule, {
     errors: defaultErrors
   }, {
     code: '<a target="_blank" href="//example.com" rel={null}></a>',
+    errors: defaultErrors
+  }, {
+    code: '<a target="_blank" href="//example.com" rel={"noopenernoreferrer"}></a>',
+    errors: defaultErrors
+  }, {
+    code: '<a target={"_blank"} href={"//example.com"} rel={"noopenernoreferrer"}></a>',
     errors: defaultErrors
   }, {
     code: '<a target="_blank" href="//example.com" rel></a>',


### PR DESCRIPTION
Previously this would be an error, since the rel wasn't read:

    <a target={"_blank"} href={"//"} rel={"noopener noreferrer"}>

Now this works, so you can enable this rule together with
`jsx-curly-brace-presence`.

Fixes #2508.