### PR TITLE
[New] `jsx-pascal-case`: Support unicode characters

### DIFF
--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const elementType = require('jsx-ast-utils/elementType');
+const XRegExp = require('xregexp');
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
 
@@ -13,8 +14,11 @@ const jsxUtil = require('../util/jsx');
 // Constants
 // ------------------------------------------------------------------------------
 
-const PASCAL_CASE_REGEX = /^(.*[.])*([A-Z]|[A-Z]+[a-z0-9]+(?:[A-Z0-9]+[a-z0-9]*)*)$/;
-const ALL_CAPS_TAG_REGEX = /^[A-Z0-9]+([A-Z0-9_]*[A-Z0-9]+)?$/;
+// eslint-disable-next-line no-new
+const hasU = (function hasU() { try { new RegExp('o', 'u'); return true; } catch (e) { return false; } }());
+
+const PASCAL_CASE_REGEX = XRegExp('^(.*[.])*([\\p{Lu}]|[\\p{Lu}]+[\\p{Ll}0-9]+(?:[\\p{Lu}0-9]+[\\p{Ll}0-9]*)*)$', hasU ? 'u' : '');
+const ALL_CAPS_TAG_REGEX = XRegExp('^[\\p{Lu}0-9]+([\\p{Lu}0-9_]*[\\p{Lu}0-9]+)?$', hasU ? 'u' : '');
 
 // ------------------------------------------------------------------------------
 // Rule Definition

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "object.values": "^1.1.1",
     "prop-types": "^15.7.2",
     "resolve": "^1.14.2",
-    "string.prototype.matchall": "^4.0.2"
+    "string.prototype.matchall": "^4.0.2",
+    "xregexp": "^4.2.4"
   },
   "devDependencies": {
     "@types/eslint": "^6.1.3",

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -47,7 +47,11 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<T3StComp0Nent />'
   }, {
-    code: '<T />'
+    code: '<Éurströmming />'
+  }, {
+    code: '<Año />'
+  }, {
+    code: '<Søknad />'
   }, {
     code: '<T />',
     parser: parsers.BABEL_ESLINT


### PR DESCRIPTION
Fixes #1654 

Uses the `\p` Unicode character property matcher, and the tests run fine. 👍

Note
---

I pulled in the `xregexp` package to definitely support `\p`. The tests _does_ seem to work without it, at least it Works On My Machine™, but `eslint`, or something at least, doesn't seem to like it? 🤔

![image](https://user-images.githubusercontent.com/142162/73352872-5eb80c80-4292-11ea-8dc7-30fdebaf5070.png)