### PR TITLE
[Fix] restore eslint < 4.15 compatibility

### DIFF
--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -30,6 +30,8 @@ jobs:
           - 6
           - 5
           - 4
+          - 4.14 # last version without messageId
+          - 3
         babel-eslint:
           - 10
           - 9

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -9,14 +9,15 @@ const Components = require('../util/Components');
 const propsUtil = require('../util/props');
 const docsUrl = require('../util/docsUrl');
 const propWrapperUtil = require('../util/propWrapper');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
-// Predefine message for use in context.report conditional.
-// messageId will still be usable in tests.
-const PATTERN_MISMATCH_MSG = 'Prop name ({{propName}}) doesn\'t match rule ({{pattern}})';
+const messages = {
+  patternMismatch: 'Prop name ({{propName}}) doesn\'t match rule ({{pattern}})'
+};
 
 module.exports = {
   meta: {
@@ -27,9 +28,7 @@ module.exports = {
       url: docsUrl('boolean-prop-naming')
     },
 
-    messages: {
-      patternMismatch: PATTERN_MISMATCH_MSG
-    },
+    messages,
 
     schema: [{
       additionalProperties: false,
@@ -211,14 +210,14 @@ module.exports = {
     function reportInvalidNaming(component) {
       component.invalidProps.forEach((propNode) => {
         const propName = getPropName(propNode);
-        context.report(Object.assign({
+        report(context, config.message || messages.patternMismatch, !config.message && 'patternMismatch', {
           node: propNode,
           data: {
             component: propName,
             propName,
             pattern: config.rule
           }
-        }, config.message ? {message: config.message} : {messageId: 'patternMismatch'}));
+        });
       });
     }
 

--- a/lib/rules/button-has-type.js
+++ b/lib/rules/button-has-type.js
@@ -9,6 +9,7 @@ const getProp = require('jsx-ast-utils/getProp');
 const getLiteralPropValue = require('jsx-ast-utils/getLiteralPropValue');
 const docsUrl = require('../util/docsUrl');
 const isCreateElement = require('../util/isCreateElement');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -20,6 +21,13 @@ const optionDefaults = {
   reset: true
 };
 
+const messages = {
+  missingType: 'Missing an explicit type attribute for button',
+  complexType: 'The button type attribute must be specified by a static string or a trivial ternary expression',
+  invalidValue: '"{{value}}" is an invalid value for button type attribute',
+  forbiddenValue: '"{{value}}" is an invalid value for button type attribute'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -29,12 +37,7 @@ module.exports = {
       url: docsUrl('button-has-type')
     },
 
-    messages: {
-      missingType: 'Missing an explicit type attribute for button',
-      complexType: 'The button type attribute must be specified by a static string or a trivial ternary expression',
-      invalidValue: '"{{value}}" is an invalid value for button type attribute',
-      forbiddenValue: '"{{value}}" is an invalid value for button type attribute'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -60,32 +63,28 @@ module.exports = {
     const configuration = Object.assign({}, optionDefaults, context.options[0]);
 
     function reportMissing(node) {
-      context.report({
-        node,
-        messageId: 'missingType'
+      report(context, messages.missingType, 'missingType', {
+        node
       });
     }
 
     function reportComplex(node) {
-      context.report({
-        node,
-        messageId: 'complexType'
+      report(context, messages.complexType, 'complexType', {
+        node
       });
     }
 
     function checkValue(node, value) {
       if (!(value in configuration)) {
-        context.report({
+        report(context, messages.invalidValue, 'invalidValue', {
           node,
-          messageId: 'invalidValue',
           data: {
             value
           }
         });
       } else if (!configuration[value]) {
-        context.report({
+        report(context, messages.forbiddenValue, 'forbiddenValue', {
           node,
-          messageId: 'forbiddenValue',
           data: {
             value
           }

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -8,10 +8,16 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  requiredHasDefault: 'defaultProp "{{name}}" defined for isRequired propType.',
+  defaultHasNoType: 'defaultProp "{{name}}" has no corresponding propTypes declaration.'
+};
 
 module.exports = {
   meta: {
@@ -21,10 +27,7 @@ module.exports = {
       url: docsUrl('default-props-match-prop-types')
     },
 
-    messages: {
-      requiredHasDefault: 'defaultProp "{{name}}" defined for isRequired propType.',
-      defaultHasNoType: 'defaultProp "{{name}}" has no corresponding propTypes declaration.'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -65,17 +68,15 @@ module.exports = {
         }
 
         if (prop) {
-          context.report({
+          report(context, messages.requiredHasDefault, 'requiredHasDefault', {
             node: defaultProp.node,
-            messageId: 'requiredHasDefault',
             data: {
               name: defaultPropName
             }
           });
         } else {
-          context.report({
+          report(context, messages.defaultHasNoType, 'defaultHasNoType', {
             node: defaultProp.node,
-            messageId: 'defaultHasNoType',
             data: {
               name: defaultPropName
             }

--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -7,6 +7,7 @@
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 const isAssignmentLHS = require('../util/ast').isAssignmentLHS;
+const report = require('../util/report');
 
 const DEFAULT_OPTION = 'always';
 
@@ -44,6 +45,13 @@ function evalParams(params) {
   }));
 }
 
+const messages = {
+  noDestructPropsInSFCArg: 'Must never use destructuring props assignment in SFC argument',
+  noDestructContextInSFCArg: 'Must never use destructuring context assignment in SFC argument',
+  noDestructAssignment: 'Must never use destructuring {{type}} assignment',
+  useDestructAssignment: 'Must use destructuring {{type}} assignment'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -53,12 +61,7 @@ module.exports = {
       url: docsUrl('destructuring-assignment')
     },
 
-    messages: {
-      noDestructPropsInSFCArg: 'Must never use destructuring props assignment in SFC argument',
-      noDestructContextInSFCArg: 'Must never use destructuring context assignment in SFC argument',
-      noDestructAssignment: 'Must never use destructuring {{type}} assignment',
-      useDestructAssignment: 'Must use destructuring {{type}} assignment'
-    },
+    messages,
 
     schema: [{
       type: 'string',
@@ -96,14 +99,12 @@ module.exports = {
       sfcParams.push(params);
 
       if (params[0] && params[0].destructuring && components.get(node) && configuration === 'never') {
-        context.report({
-          node,
-          messageId: 'noDestructPropsInSFCArg'
+        report(context, messages.noDestructPropsInSFCArg, 'noDestructPropsInSFCArg', {
+          node
         });
       } else if (params[1] && params[1].destructuring && components.get(node) && configuration === 'never') {
-        context.report({
-          node,
-          messageId: 'noDestructContextInSFCArg'
+        report(context, messages.noDestructContextInSFCArg, 'noDestructContextInSFCArg', {
+          node
         });
       }
     }
@@ -125,9 +126,8 @@ module.exports = {
       )
         && !isAssignmentLHS(node);
       if (isPropUsed && configuration === 'always') {
-        context.report({
+        report(context, messages.useDestructAssignment, 'useDestructAssignment', {
           node,
-          messageId: 'useDestructAssignment',
           data: {
             type: node.object.name
           }
@@ -158,9 +158,8 @@ module.exports = {
         isPropUsed && configuration === 'always'
         && !(ignoreClassFields && isInClassProperty(node))
       ) {
-        context.report({
+        report(context, messages.useDestructAssignment, 'useDestructAssignment', {
           node,
-          messageId: 'useDestructAssignment',
           data: {
             type: node.object.property.name
           }
@@ -206,9 +205,8 @@ module.exports = {
         );
 
         if (SFCComponent && destructuringSFC && configuration === 'never') {
-          context.report({
+          report(context, messages.noDestructAssignment, 'noDestructAssignment', {
             node,
-            messageId: 'noDestructAssignment',
             data: {
               type: node.init.name
             }
@@ -219,9 +217,8 @@ module.exports = {
           classComponent && destructuringClass && configuration === 'never'
           && !(ignoreClassFields && node.parent.type === 'ClassProperty')
         ) {
-          context.report({
+          report(context, messages.noDestructAssignment, 'noDestructAssignment', {
             node,
-            messageId: 'noDestructAssignment',
             data: {
               type: node.init.property.name
             }

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -9,10 +9,15 @@ const Components = require('../util/Components');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
 const propsUtil = require('../util/props');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noDisplayName: 'Component definition is missing display name'
+};
 
 module.exports = {
   meta: {
@@ -23,9 +28,7 @@ module.exports = {
       url: docsUrl('display-name')
     },
 
-    messages: {
-      noDisplayName: 'Component definition is missing display name'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -57,9 +60,8 @@ module.exports = {
      * @param {Object} component The component to process
      */
     function reportMissingDisplayName(component) {
-      context.report({
-        node: component.node,
-        messageId: 'noDisplayName'
+      report(context, messages.noDisplayName, 'noDisplayName', {
+        node: component.node
       });
     }
 

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -17,6 +18,10 @@ const DEFAULTS = ['className', 'style'];
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  propIsForbidden: 'Prop "{{prop}}" is forbidden on Components'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -26,9 +31,7 @@ module.exports = {
       url: docsUrl('forbid-component-props')
     },
 
-    messages: {
-      propIsForbidden: 'Prop "{{prop}}" is forbidden on Components'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -99,12 +102,12 @@ module.exports = {
 
         const customMessage = forbid.get(prop).message;
 
-        context.report(Object.assign({
+        report(context, customMessage || messages.propIsForbidden, !customMessage && 'propIsForbidden', {
           node,
           data: {
             prop
           }
-        }, customMessage ? {message: customMessage} : {messageId: 'propIsForbidden'}));
+        });
       }
     };
   }

--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -17,6 +18,10 @@ const DEFAULTS = [];
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  propIsForbidden: 'Prop "{{prop}}" is forbidden on DOM Nodes'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -26,9 +31,7 @@ module.exports = {
       url: docsUrl('forbid-dom-props')
     },
 
-    messages: {
-      propIsForbidden: 'Prop "{{prop}}" is forbidden on DOM Nodes'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -88,12 +91,12 @@ module.exports = {
 
         const customMessage = forbid.get(prop).message;
 
-        context.report(Object.assign({
+        report(context, customMessage || messages.propIsForbidden, !customMessage && 'propIsForbidden', {
           node,
           data: {
             prop
           }
-        }, customMessage ? {message: customMessage} : {messageId: 'propIsForbidden'}));
+        });
       }
     };
   }

--- a/lib/rules/forbid-elements.js
+++ b/lib/rules/forbid-elements.js
@@ -8,10 +8,16 @@
 const has = require('object.hasown/polyfill')();
 const docsUrl = require('../util/docsUrl');
 const isCreateElement = require('../util/isCreateElement');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  forbiddenElement: '<{{element}}> is forbidden',
+  forbiddenElement_message: '<{{element}}> is forbidden, {{message}}'
+};
 
 module.exports = {
   meta: {
@@ -22,10 +28,7 @@ module.exports = {
       url: docsUrl('forbid-elements')
     },
 
-    messages: {
-      forbiddenElement: '<{{element}}> is forbidden',
-      forbiddenElement_message: '<{{element}}> is forbidden, {{message}}'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -70,14 +73,18 @@ module.exports = {
       if (has(indexedForbidConfigs, element)) {
         const message = indexedForbidConfigs[element].message;
 
-        context.report({
-          node,
-          messageId: message ? 'forbiddenElement_message' : 'forbiddenElement',
-          data: {
-            element,
-            message
+        report(
+          context,
+          message ? messages.forbiddenElement_message : messages.forbiddenElement,
+          message ? 'forbiddenElement_message' : 'forbiddenElement',
+          {
+            node,
+            data: {
+              element,
+              message
+            }
           }
-        });
+        );
       }
     }
 

--- a/lib/rules/forbid-foreign-prop-types.js
+++ b/lib/rules/forbid-foreign-prop-types.js
@@ -7,6 +7,11 @@
 
 const docsUrl = require('../util/docsUrl');
 const ast = require('../util/ast');
+const report = require('../util/report');
+
+const messages = {
+  forbiddenPropType: 'Using propTypes from another component is not safe because they may be removed in production builds'
+};
 
 module.exports = {
   meta: {
@@ -17,9 +22,7 @@ module.exports = {
       url: docsUrl('forbid-foreign-prop-types')
     },
 
-    messages: {
-      forbiddenPropType: 'Using propTypes from another component is not safe because they may be removed in production builds'
-    },
+    messages,
 
     schema: [
       {
@@ -111,9 +114,8 @@ module.exports = {
             && !isAllowedAssignment(node)
           )
         ) {
-          context.report({
-            node: node.property,
-            messageId: 'forbiddenPropType'
+          report(context, messages.forbiddenPropType, 'forbiddenPropType', {
+            node: node.property
           });
         }
       },
@@ -122,9 +124,8 @@ module.exports = {
         const propTypesNode = node.properties.find((property) => property.type === 'Property' && property.key.name === 'propTypes');
 
         if (propTypesNode) {
-          context.report({
-            node: propTypesNode,
-            messageId: 'forbiddenPropType'
+          report(context, messages.forbiddenPropType, 'forbiddenPropType', {
+            node: propTypesNode
           });
         }
       }

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -9,6 +9,7 @@ const propsUtil = require('../util/props');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
 const propWrapperUtil = require('../util/propWrapper');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -20,6 +21,10 @@ const DEFAULTS = ['any', 'array', 'object'];
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  forbiddenPropType: 'Prop type "{{target}}" is forbidden'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -29,9 +34,7 @@ module.exports = {
       url: docsUrl('forbid-prop-types')
     },
 
-    messages: {
-      forbiddenPropType: 'Prop type "{{target}}" is forbidden'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -65,9 +68,8 @@ module.exports = {
 
     function reportIfForbidden(type, declaration, target) {
       if (isForbidden(type)) {
-        context.report({
+        report(context, messages.forbiddenPropType, 'forbiddenPropType', {
           node: declaration,
-          messageId: 'forbiddenPropType',
           data: {
             target
           }

--- a/lib/rules/function-component-definition.js
+++ b/lib/rules/function-component-definition.js
@@ -7,6 +7,7 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const reportC = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -90,6 +91,12 @@ function isFunctionExpressionWithName(node) {
   return node.type === 'FunctionExpression' && node.id && node.id.name;
 }
 
+const messages = {
+  'function-declaration': 'Function component is not a function declaration',
+  'function-expression': 'Function component is not a function expression',
+  'arrow-function': 'Function component is not an arrow function'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -100,11 +107,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      'function-declaration': 'Function component is not a function declaration',
-      'function-expression': 'Function component is not a function expression',
-      'arrow-function': 'Function component is not an arrow function'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -147,9 +150,8 @@ module.exports = {
     }
 
     function report(node, options) {
-      context.report({
+      reportC(context, messages[options.messageId], options.messageId, {
         node,
-        messageId: options.messageId,
         fix: getFixer(node, options.fixerOptions)
       });
     }

--- a/lib/rules/jsx-boolean-value.js
+++ b/lib/rules/jsx-boolean-value.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -46,6 +47,13 @@ function isNever(configuration, exceptions, propName) {
   return isException;
 }
 
+const messages = {
+  omitBoolean: 'Value must be omitted for boolean attributes{{exceptionsMessage}}',
+  omitBoolean_noMessage: 'Value must be omitted for boolean attributes',
+  setBoolean: 'Value must be set for boolean attributes{{exceptionsMessage}}',
+  setBoolean_noMessage: 'Value must be set for boolean attributes'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -56,12 +64,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      omitBoolean: 'Value must be omitted for boolean attributes{{exceptionsMessage}}',
-      omitBoolean_noMessage: 'Value must be omitted for boolean attributes',
-      setBoolean: 'Value must be set for boolean attributes{{exceptionsMessage}}',
-      setBoolean_noMessage: 'Value must be set for boolean attributes'
-    },
+    messages,
 
     schema: {
       anyOf: [{
@@ -108,9 +111,9 @@ module.exports = {
 
         if (isAlways(configuration, exceptions, propName) && value === null) {
           const data = getErrorData(exceptions);
-          context.report({
+          const messageId = data.exceptionsMessage ? 'setBoolean' : 'setBoolean_noMessage';
+          report(context, messages[messageId], messageId, {
             node,
-            messageId: data.exceptionsMessage ? 'setBoolean' : 'setBoolean_noMessage',
             data,
             fix(fixer) {
               return fixer.insertTextAfter(node, '={true}');
@@ -119,9 +122,9 @@ module.exports = {
         }
         if (isNever(configuration, exceptions, propName) && value && value.type === 'JSXExpressionContainer' && value.expression.value === true) {
           const data = getErrorData(exceptions);
-          context.report({
+          const messageId = data.exceptionsMessage ? 'omitBoolean' : 'omitBoolean_noMessage';
+          report(context, messages[messageId], messageId, {
             node,
-            messageId: data.exceptionsMessage ? 'omitBoolean' : 'omitBoolean_noMessage',
             data,
             fix(fixer) {
               return fixer.removeRange([node.name.range[1], value.range[1]]);

--- a/lib/rules/jsx-child-element-spacing.js
+++ b/lib/rules/jsx-child-element-spacing.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // This list is taken from https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
 
@@ -38,6 +39,11 @@ const INLINE_ELEMENTS = new Set([
   'var'
 ]);
 
+const messages = {
+  spacingAfterPrev: 'Ambiguous spacing after previous element {{element}}',
+  spacingBeforeNext: 'Ambiguous spacing before next element {{element}}'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -48,10 +54,7 @@ module.exports = {
     },
     fixable: null,
 
-    messages: {
-      spacingAfterPrev: 'Ambiguous spacing after previous element {{element}}',
-      spacingBeforeNext: 'Ambiguous spacing before next element {{element}}'
-    },
+    messages,
 
     schema: [
       {
@@ -90,19 +93,17 @@ module.exports = {
           && true
         ) {
           if (lastChild && child.value.match(TEXT_FOLLOWING_ELEMENT_PATTERN)) {
-            context.report({
+            report(context, messages.spacingAfterPrev, 'spacingAfterPrev', {
               node: lastChild,
               loc: lastChild.loc.end,
-              messageId: 'spacingAfterPrev',
               data: {
                 element: elementName(lastChild)
               }
             });
           } else if (nextChild && child.value.match(TEXT_PRECEDING_ELEMENT_PATTERN)) {
-            context.report({
+            report(context, messages.spacingBeforeNext, 'spacingBeforeNext', {
               node: nextChild,
               loc: nextChild.loc.start,
-              messageId: 'spacingBeforeNext',
               data: {
                 element: elementName(nextChild)
               }

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -7,10 +7,16 @@
 
 const has = require('object.hasown/polyfill')();
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  bracketLocation: 'The closing bracket must be {{location}}{{details}}'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -21,9 +27,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      bracketLocation: 'The closing bracket must be {{location}}{{details}}'
-    },
+    messages,
 
     schema: [{
       oneOf: [
@@ -271,10 +275,9 @@ module.exports = {
           data.details = ` (expected column ${correctColumn + 1}${expectedNextLine ? ' on the next line)' : ')'}`;
         }
 
-        context.report({
+        report(context, messages.bracketLocation, 'bracketLocation', {
           node,
           loc: tokens.closing,
-          messageId: 'bracketLocation',
           data,
           fix(fixer) {
             const closingTag = tokens.selfClosing ? '/>' : '>';

--- a/lib/rules/jsx-closing-tag-location.js
+++ b/lib/rules/jsx-closing-tag-location.js
@@ -7,10 +7,16 @@
 
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  onOwnLine: 'Closing tag of a multiline JSX expression must be on its own line.',
+  matchIndent: 'Expected closing tag to match indentation of opening.'
+};
 
 module.exports = {
   meta: {
@@ -22,10 +28,7 @@ module.exports = {
     },
     fixable: 'whitespace',
 
-    messages: {
-      onOwnLine: 'Closing tag of a multiline JSX expression must be on its own line.',
-      matchIndent: 'Expected closing tag to match indentation of opening.'
-    }
+    messages
   },
 
   create(context) {
@@ -43,12 +46,12 @@ module.exports = {
         return;
       }
 
-      context.report({
+      const messageId = astUtil.isNodeFirstInLine(context, node)
+        ? 'matchIndent'
+        : 'onOwnLine';
+      report(context, messages[messageId], messageId, {
         node,
         loc: node.loc,
-        messageId: astUtil.isNodeFirstInLine(context, node)
-          ? 'matchIndent'
-          : 'onOwnLine',
         fix(fixer) {
           const indent = Array(opening.loc.start.column + 1).join(' ');
           if (astUtil.isNodeFirstInLine(context, node)) {

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -10,6 +10,7 @@ const arrayIncludes = require('array-includes');
 
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -30,6 +31,11 @@ const DEFAULT_CONFIG = {props: OPTION_NEVER, children: OPTION_NEVER};
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  unnecessaryCurly: 'Curly braces are unnecessary here.',
+  missingCurly: 'Need to wrap this literal in a JSX expression.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -42,10 +48,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      unnecessaryCurly: 'Curly braces are unnecessary here.',
-      missingCurly: 'Need to wrap this literal in a JSX expression.'
-    },
+    messages,
 
     schema: [
       {
@@ -166,9 +169,8 @@ module.exports = {
      * @param {ASTNode} JSXExpressionNode - The AST node with an unnecessary JSX expression
      */
     function reportUnnecessaryCurly(JSXExpressionNode) {
-      context.report({
+      report(context, messages.unnecessaryCurly, 'unnecessaryCurly', {
         node: JSXExpressionNode,
-        messageId: 'unnecessaryCurly',
         fix(fixer) {
           const expression = JSXExpressionNode.expression;
           const expressionType = expression.type;
@@ -195,9 +197,8 @@ module.exports = {
     }
 
     function reportMissingCurly(literalNode) {
-      context.report({
+      report(context, messages.missingCurly, 'missingCurly', {
         node: literalNode,
-        messageId: 'missingCurly',
         fix(fixer) {
           // If a HTML entity name is found, bail out because it can be fixed
           // by either using the real character or the unicode equivalent.
@@ -240,8 +241,9 @@ module.exports = {
       const expression = JSXExpressionNode.expression;
       const expressionType = expression.type;
 
+      const sourceCode = context.getSourceCode();
       // Curly braces containing comments are necessary
-      if (context.getSourceCode().getCommentsInside(JSXExpressionNode).length > 0) {
+      if (sourceCode.getCommentsInside && sourceCode.getCommentsInside(JSXExpressionNode).length > 0) {
         return;
       }
 

--- a/lib/rules/jsx-curly-newline.js
+++ b/lib/rules/jsx-curly-newline.js
@@ -5,6 +5,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -32,6 +33,13 @@ function getNormalizedOption(context) {
     singleline: rawOption.singleline || 'consistent'
   };
 }
+
+const messages = {
+  expectedBefore: 'Expected newline before \'}\'.',
+  expectedAfter: 'Expected newline after \'{\'.',
+  unexpectedBefore: 'Unexpected newline before \'}\'.',
+  unexpectedAfter: 'Unexpected newline after \'{\'.'
+};
 
 module.exports = {
   meta: {
@@ -64,12 +72,7 @@ module.exports = {
       }
     ],
 
-    messages: {
-      expectedBefore: 'Expected newline before \'}\'.',
-      expectedAfter: 'Expected newline after \'{\'.',
-      unexpectedBefore: 'Unexpected newline before \'}\'.',
-      unexpectedAfter: 'Unexpected newline after \'{\'.'
-    }
+    messages
   },
 
   create(context) {
@@ -123,9 +126,8 @@ module.exports = {
       const needsNewlines = shouldHaveNewlines(expression, hasLeftNewline);
 
       if (hasLeftNewline && !needsNewlines) {
-        context.report({
+        report(context, messages.unexpectedAfter, 'unexpectedAfter', {
           node: leftCurly,
-          messageId: 'unexpectedAfter',
           fix(fixer) {
             return sourceCode
               .getText()
@@ -136,17 +138,15 @@ module.exports = {
           }
         });
       } else if (!hasLeftNewline && needsNewlines) {
-        context.report({
+        report(context, messages.expectedAfter, 'expectedAfter', {
           node: leftCurly,
-          messageId: 'expectedAfter',
           fix: (fixer) => fixer.insertTextAfter(leftCurly, '\n')
         });
       }
 
       if (hasRightNewline && !needsNewlines) {
-        context.report({
+        report(context, messages.unexpectedBefore, 'unexpectedBefore', {
           node: rightCurly,
-          messageId: 'unexpectedBefore',
           fix(fixer) {
             return sourceCode
               .getText()
@@ -160,9 +160,8 @@ module.exports = {
           }
         });
       } else if (!hasRightNewline && needsNewlines) {
-        context.report({
+        report(context, messages.expectedBefore, 'expectedBefore', {
           node: rightCurly,
-          messageId: 'expectedBefore',
           fix: (fixer) => fixer.insertTextBefore(rightCurly, '\n')
         });
       }

--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -13,6 +13,7 @@
 
 const has = require('object.hasown/polyfill')();
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -24,6 +25,15 @@ const SPACING = {
 };
 const SPACING_VALUES = [SPACING.always, SPACING.never];
 
+const messages = {
+  noNewlineAfter: 'There should be no newline after \'{{token}}\'',
+  noNewlineBefore: 'There should be no newline before \'{{token}}\'',
+  noSpaceAfter: 'There should be no space after \'{{token}}\'',
+  noSpaceBefore: 'There should be no space before \'{{token}}\'',
+  spaceNeededAfter: 'A space is required after \'{{token}}\'',
+  spaceNeededBefore: 'A space is required before \'{{token}}\''
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -34,14 +44,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      noNewlineAfter: 'There should be no newline after \'{{token}}\'',
-      noNewlineBefore: 'There should be no newline before \'{{token}}\'',
-      noSpaceAfter: 'There should be no space after \'{{token}}\'',
-      noSpaceBefore: 'There should be no space before \'{{token}}\'',
-      spaceNeededAfter: 'A space is required after \'{{token}}\'',
-      spaceNeededBefore: 'A space is required before \'{{token}}\''
-    },
+    messages,
 
     schema: {
       definitions: {
@@ -196,10 +199,9 @@ module.exports = {
     * @returns {void}
     */
     function reportNoBeginningNewline(node, token, spacing) {
-      context.report({
+      report(context, messages.noNewlineAfter, 'noNewlineAfter', {
         node,
         loc: token.loc.start,
-        messageId: 'noNewlineAfter',
         data: {
           token: token.value
         },
@@ -218,10 +220,9 @@ module.exports = {
     * @returns {void}
     */
     function reportNoEndingNewline(node, token, spacing) {
-      context.report({
+      report(context, messages.noNewlineBefore, 'noNewlineBefore', {
         node,
         loc: token.loc.start,
-        messageId: 'noNewlineBefore',
         data: {
           token: token.value
         },
@@ -239,10 +240,9 @@ module.exports = {
     * @returns {void}
     */
     function reportNoBeginningSpace(node, token) {
-      context.report({
+      report(context, messages.noSpaceAfter, 'noSpaceAfter', {
         node,
         loc: token.loc.start,
-        messageId: 'noSpaceAfter',
         data: {
           token: token.value
         },
@@ -277,10 +277,9 @@ module.exports = {
     * @returns {void}
     */
     function reportNoEndingSpace(node, token) {
-      context.report({
+      report(context, messages.noSpaceBefore, 'noSpaceBefore', {
         node,
         loc: token.loc.start,
-        messageId: 'noSpaceBefore',
         data: {
           token: token.value
         },
@@ -315,10 +314,9 @@ module.exports = {
     * @returns {void}
     */
     function reportRequiredBeginningSpace(node, token) {
-      context.report({
+      report(context, messages.spaceNeededAfter, 'spaceNeededAfter', {
         node,
         loc: token.loc.start,
-        messageId: 'spaceNeededAfter',
         data: {
           token: token.value
         },
@@ -335,10 +333,9 @@ module.exports = {
     * @returns {void}
     */
     function reportRequiredEndingSpace(node, token) {
-      context.report({
+      report(context, messages.spaceNeededBefore, 'spaceNeededBefore', {
         node,
         loc: token.loc.start,
-        messageId: 'spaceNeededBefore',
         data: {
           token: token.value
         },

--- a/lib/rules/jsx-equals-spacing.js
+++ b/lib/rules/jsx-equals-spacing.js
@@ -6,10 +6,18 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noSpaceBefore: 'There should be no space before \'=\'',
+  noSpaceAfter: 'There should be no space after \'=\'',
+  needSpaceBefore: 'A space is required before \'=\'',
+  needSpaceAfter: 'A space is required after \'=\''
+};
 
 module.exports = {
   meta: {
@@ -21,12 +29,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      noSpaceBefore: 'There should be no space before \'=\'',
-      noSpaceAfter: 'There should be no space after \'=\'',
-      needSpaceBefore: 'A space is required before \'=\'',
-      needSpaceAfter: 'A space is required after \'=\''
-    },
+    messages,
 
     schema: [{
       enum: ['always', 'never']
@@ -65,20 +68,18 @@ module.exports = {
             default:
             case 'never':
               if (spacedBefore) {
-                context.report({
+                report(context, messages.noSpaceBefore, 'noSpaceBefore', {
                   node: attrNode,
                   loc: equalToken.loc.start,
-                  messageId: 'noSpaceBefore',
                   fix(fixer) {
                     return fixer.removeRange([attrNode.name.range[1], equalToken.range[0]]);
                   }
                 });
               }
               if (spacedAfter) {
-                context.report({
+                report(context, messages.noSpaceAfter, 'noSpaceAfter', {
                   node: attrNode,
                   loc: equalToken.loc.start,
-                  messageId: 'noSpaceAfter',
                   fix(fixer) {
                     return fixer.removeRange([equalToken.range[1], attrNode.value.range[0]]);
                   }
@@ -87,20 +88,18 @@ module.exports = {
               break;
             case 'always':
               if (!spacedBefore) {
-                context.report({
+                report(context, messages.needSpaceBefore, 'needSpaceBefore', {
                   node: attrNode,
                   loc: equalToken.loc.start,
-                  messageId: 'needSpaceBefore',
                   fix(fixer) {
                     return fixer.insertTextBefore(equalToken, ' ');
                   }
                 });
               }
               if (!spacedAfter) {
-                context.report({
+                report(context, messages.needSpaceAfter, 'needSpaceAfter', {
                   node: attrNode,
                   loc: equalToken.loc.start,
-                  messageId: 'needSpaceAfter',
                   fix(fixer) {
                     return fixer.insertTextAfter(equalToken, ' ');
                   }

--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -7,6 +7,7 @@
 
 const path = require('path');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -21,6 +22,11 @@ const DEFAULTS = {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  noJSXWithExtension: 'JSX not allowed in files with extension \'{{ext}}\'',
+  extensionOnlyForJSX: 'Only files containing JSX may use the extension \'{{ext}}\''
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -30,10 +36,7 @@ module.exports = {
       url: docsUrl('jsx-filename-extension')
     },
 
-    messages: {
-      noJSXWithExtension: 'JSX not allowed in files with extension \'{{ext}}\'',
-      extensionOnlyForJSX: 'Only files containing JSX may use the extension \'{{ext}}\''
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -83,9 +86,8 @@ module.exports = {
       'Program:exit'(node) {
         if (jsxNode) {
           if (!isAllowedExtension) {
-            context.report({
+            report(context, messages.noJSXWithExtension, 'noJSXWithExtension', {
               node: jsxNode,
-              messageId: 'noJSXWithExtension',
               data: {
                 ext: path.extname(filename)
               }
@@ -95,9 +97,8 @@ module.exports = {
         }
 
         if (isAllowedExtension && allow === 'as-needed') {
-          context.report({
+          report(context, messages.extensionOnlyForJSX, 'extensionOnlyForJSX', {
             node,
-            messageId: 'extensionOnlyForJSX',
             data: {
               ext: path.extname(filename)
             }

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -6,10 +6,16 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  propOnNewLine: 'Property should be placed on a new line',
+  propOnSameLine: 'Property should be placed on the same line as the component declaration'
+};
 
 module.exports = {
   meta: {
@@ -21,10 +27,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      propOnNewLine: 'Property should be placed on a new line',
-      propOnSameLine: 'Property should be placed on the same line as the component declaration'
-    },
+    messages,
 
     schema: [{
       enum: ['always', 'never', 'multiline', 'multiline-multiprop']
@@ -47,9 +50,8 @@ module.exports = {
         ) {
           node.attributes.some((decl) => {
             if (decl.loc.start.line === node.loc.start.line) {
-              context.report({
+              report(context, messages.propOnNewLine, 'propOnNewLine', {
                 node: decl,
-                messageId: 'propOnNewLine',
                 fix(fixer) {
                   return fixer.replaceTextRange([node.name.range[1], decl.range[0]], '\n');
                 }
@@ -60,9 +62,8 @@ module.exports = {
         } else if (configuration === 'never' && node.attributes.length > 0) {
           const firstNode = node.attributes[0];
           if (node.loc.start.line < firstNode.loc.start.line) {
-            context.report({
+            report(context, messages.propOnSameLine, 'propOnSameLine', {
               node: firstNode,
-              messageId: 'propOnSameLine',
               fix(fixer) {
                 return fixer.replaceTextRange([node.name.range[1], firstNode.range[0]], ' ');
               }

--- a/lib/rules/jsx-fragments.js
+++ b/lib/rules/jsx-fragments.js
@@ -10,6 +10,7 @@ const pragmaUtil = require('../util/pragma');
 const variableUtil = require('../util/variable');
 const versionUtil = require('../util/version');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -18,6 +19,13 @@ const docsUrl = require('../util/docsUrl');
 function replaceNode(source, node, text) {
   return `${source.slice(0, node.range[0])}${text}${source.slice(node.range[1])}`;
 }
+
+const messages = {
+  fragmentsNotSupported: 'Fragments are only supported starting from React v16.2. '
+    + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.',
+  preferPragma: 'Prefer {{react}}.{{fragment}} over fragment shorthand',
+  preferFragment: 'Prefer fragment shorthand over {{react}}.{{fragment}}'
+};
 
 module.exports = {
   meta: {
@@ -29,12 +37,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      fragmentsNotSupported: 'Fragments are only supported starting from React v16.2. '
-        + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.',
-      preferPragma: 'Prefer {{react}}.{{fragment}} over fragment shorthand',
-      preferFragment: 'Prefer fragment shorthand over {{react}}.{{fragment}}'
-    },
+    messages,
 
     schema: [{
       enum: ['syntax', 'element']
@@ -52,9 +55,8 @@ module.exports = {
 
     function reportOnReactVersion(node) {
       if (!versionUtil.testReactVersion(context, '16.2.0')) {
-        context.report({
-          node,
-          messageId: 'fragmentsNotSupported'
+        report(context, messages.fragmentsNotSupported, 'fragmentsNotSupported', {
+          node
         });
         return true;
       }
@@ -150,9 +152,8 @@ module.exports = {
         }
 
         if (configuration === 'element') {
-          context.report({
+          report(context, messages.preferPragma, 'preferPragma', {
             node,
-            messageId: 'preferPragma',
             data: {
               react: reactPragma,
               fragment: fragmentPragma
@@ -186,9 +187,8 @@ module.exports = {
 
             const attrs = openingEl.attributes;
             if (configuration === 'syntax' && !(attrs && attrs.length > 0)) {
-              context.report({
+              report(context, messages.preferFragment, 'preferFragment', {
                 node,
-                messageId: 'preferFragment',
                 data: {
                   react: reactPragma,
                   fragment: fragmentPragma

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -6,10 +6,16 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  badHandlerName: 'Handler function for {{propKey}} prop key must be a camelCase name beginning with \'{{handlerPrefix}}\' only',
+  badPropKey: 'Prop key for {{propValue}} must begin with \'{{handlerPropPrefix}}\''
+};
 
 module.exports = {
   meta: {
@@ -20,10 +26,7 @@ module.exports = {
       url: docsUrl('jsx-handler-names')
     },
 
-    messages: {
-      badHandlerName: 'Handler function for {{propKey}} prop key must be a camelCase name beginning with \'{{handlerPrefix}}\' only',
-      badPropKey: 'Prop key for {{propValue}} must begin with \'{{handlerPropPrefix}}\''
-    },
+    messages,
 
     schema: [{
       anyOf: [
@@ -142,9 +145,8 @@ module.exports = {
           && propFnIsNamedCorrectly !== null
           && !propFnIsNamedCorrectly
         ) {
-          context.report({
+          report(context, messages.badHandlerName, 'badHandlerName', {
             node,
-            messageId: 'badHandlerName',
             data: {
               propKey,
               handlerPrefix: eventHandlerPrefix
@@ -155,9 +157,8 @@ module.exports = {
           && propIsEventHandler !== null
           && !propIsEventHandler
         ) {
-          context.report({
+          report(context, messages.badPropKey, 'badPropKey', {
             node,
-            messageId: 'badPropKey',
             data: {
               propValue,
               handlerPropPrefix: eventHandlerPropPrefix

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -32,10 +32,16 @@
 
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
+const reportC = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  wrongIndent: 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -46,9 +52,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      wrongIndent: 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.'
-    },
+    messages,
 
     schema: [{
       oneOf: [{
@@ -120,9 +124,8 @@ module.exports = {
         gotten
       };
 
-      context.report({
+      reportC(context, messages.wrongIndent, 'wrongIndent', {
         node,
-        messageId: 'wrongIndent',
         data: msgContext,
         fix(fixer) {
           return fixer.replaceTextRange([node.range[0] - node.loc.start.column, node.range[0]],

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -34,10 +34,16 @@ const matchAll = require('string.prototype.matchall');
 
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
+const reportC = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  wrongIndent: 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -48,9 +54,7 @@ module.exports = {
     },
     fixable: 'whitespace',
 
-    messages: {
-      wrongIndent: 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.'
-    },
+    messages,
 
     schema: [{
       oneOf: [{
@@ -129,9 +133,8 @@ module.exports = {
         gotten
       };
 
-      context.report(Object.assign({
+      reportC(context, messages.wrongIndent, 'wrongIndent', Object.assign({
         node,
-        messageId: 'wrongIndent',
         data: msgContext,
         fix: getFixerFunction(node, needed)
       }, loc && {loc}));

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -9,6 +9,7 @@ const hasProp = require('jsx-ast-utils/hasProp');
 const propName = require('jsx-ast-utils/propName');
 const docsUrl = require('../util/docsUrl');
 const pragmaUtil = require('../util/pragma');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -17,6 +18,14 @@ const pragmaUtil = require('../util/pragma');
 const defaultOptions = {
   checkFragmentShorthand: false,
   checkKeyMustBeforeSpread: false
+};
+
+const messages = {
+  missingIterKey: 'Missing "key" prop for element in iterator',
+  missingIterKeyUsePrag: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use {{reactPrag}}.{{fragPrag}} instead',
+  missingArrayKey: 'Missing "key" prop for element in array',
+  missingArrayKeyUsePrag: 'Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use {{reactPrag}}.{{fragPrag}} instead',
+  keyBeforeSpread: '`key` prop must be placed before any `{...spread}, to avoid conflicting with React’s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`'
 };
 
 module.exports = {
@@ -28,13 +37,7 @@ module.exports = {
       url: docsUrl('jsx-key')
     },
 
-    messages: {
-      missingIterKey: 'Missing "key" prop for element in iterator',
-      missingIterKeyUsePrag: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use {{reactPrag}}.{{fragPrag}} instead',
-      missingArrayKey: 'Missing "key" prop for element in array',
-      missingArrayKeyUsePrag: 'Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use {{reactPrag}}.{{fragPrag}} instead',
-      keyBeforeSpread: '`key` prop must be placed before any `{...spread}, to avoid conflicting with React’s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -61,14 +64,12 @@ module.exports = {
 
     function checkIteratorElement(node) {
       if (node.type === 'JSXElement' && !hasProp(node.openingElement.attributes, 'key')) {
-        context.report({
-          node,
-          messageId: 'missingIterKey'
+        report(context, messages.missingIterKey, 'missingIterKey', {
+          node
         });
       } else if (checkFragmentShorthand && node.type === 'JSXFragment') {
-        context.report({
+        report(context, messages.missingIterKeyUsePrag, 'missingIterKeyUsePrag', {
           node,
-          messageId: 'missingIterKeyUsePrag',
           data: {
             reactPrag: reactPragma,
             fragPrag: fragmentPragma
@@ -99,18 +100,16 @@ module.exports = {
       JSXElement(node) {
         if (hasProp(node.openingElement.attributes, 'key')) {
           if (checkKeyMustBeforeSpread && isKeyAfterSpread(node.openingElement.attributes)) {
-            context.report({
-              node,
-              messageId: 'keyBeforeSpread'
+            report(context, messages.keyBeforeSpread, 'keyBeforeSpread', {
+              node
             });
           }
           return;
         }
 
         if (node.parent.type === 'ArrayExpression') {
-          context.report({
-            node,
-            messageId: 'missingArrayKey'
+          report(context, messages.missingArrayKey, 'missingArrayKey', {
+            node
           });
         }
       },
@@ -121,9 +120,8 @@ module.exports = {
         }
 
         if (node.parent.type === 'ArrayExpression') {
-          context.report({
+          report(context, messages.missingArrayKeyUsePrag, 'missingArrayKeyUsePrag', {
             node,
-            messageId: 'missingArrayKeyUsePrag',
             data: {
               reactPrag: reactPragma,
               fragPrag: fragmentPragma

--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -10,10 +10,16 @@ const includes = require('array-includes');
 const variableUtil = require('../util/variable');
 const jsxUtil = require('../util/jsx');
 const docsUrl = require('../util/docsUrl');
+const reportC = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  wrongDepth: 'Expected the depth of nested jsx elements to be <= {{needed}}, but found {{found}}.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -23,9 +29,7 @@ module.exports = {
       url: docsUrl('jsx-max-depth')
     },
 
-    messages: {
-      wrongDepth: 'Expected the depth of nested jsx elements to be <= {{needed}}, but found {{found}}.'
-    },
+    messages,
 
     schema: [
       {
@@ -74,9 +78,8 @@ module.exports = {
     }
 
     function report(node, depth) {
-      context.report({
+      reportC(context, messages.wrongDepth, 'wrongDepth', {
         node,
-        messageId: 'wrongDepth',
         data: {
           found: depth,
           needed: maxDepth

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -6,10 +6,15 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  newLine: 'Prop `{{prop}}` must be placed on a new line'
+};
 
 module.exports = {
   meta: {
@@ -21,9 +26,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      newLine: 'Prop `{{prop}}` must be placed on a new line'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -97,9 +100,8 @@ module.exports = {
         linePartitionedProps.forEach((propsInLine) => {
           if (propsInLine.length > maximum) {
             const name = getPropName(propsInLine[maximum]);
-            context.report({
+            report(context, messages.newLine, 'newLine', {
               node: propsInLine[maximum],
-              messageId: 'newLine',
               data: {
                 prop: name
               },

--- a/lib/rules/jsx-newline.js
+++ b/lib/rules/jsx-newline.js
@@ -7,10 +7,16 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  require: 'JSX element should start in a new line',
+  prevent: 'JSX element should not start in a new line'
+};
 
 module.exports = {
   meta: {
@@ -22,10 +28,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      require: 'JSX element should start in a new line',
-      prevent: 'JSX element should not start in a new line'
-    },
+    messages,
     schema: [
       {
         type: 'object',
@@ -75,9 +78,8 @@ module.exports = {
                 ? '\n'
                 : '\n\n';
 
-              context.report({
+              report(context, messages[messageId], messageId, {
                 node: secondAdjacentSibling,
-                messageId,
                 fix(fixer) {
                   return fixer.replaceText(
                     firstAdjacentSibling,

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -11,10 +11,18 @@ const propName = require('jsx-ast-utils/propName');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 // -----------------------------------------------------------------------------
 // Rule Definition
 // -----------------------------------------------------------------------------
+
+const messages = {
+  bindCall: 'JSX props should not use .bind()',
+  arrowFunc: 'JSX props should not use arrow functions',
+  bindExpression: 'JSX props should not use ::',
+  func: 'JSX props should not use functions'
+};
 
 module.exports = {
   meta: {
@@ -25,12 +33,7 @@ module.exports = {
       url: docsUrl('jsx-no-bind')
     },
 
-    messages: {
-      bindCall: 'JSX props should not use .bind()',
-      arrowFunc: 'JSX props should not use arrow functions',
-      bindExpression: 'JSX props should not use ::',
-      func: 'JSX props should not use functions'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -125,9 +128,8 @@ module.exports = {
 
       return violationTypes.find((type) => {
         if (blockSets[type].has(name)) {
-          context.report({
-            node,
-            messageId: type
+          report(context, messages[type], type, {
+            node
           });
           return true;
         }
@@ -190,9 +192,8 @@ module.exports = {
         if (valueNodeType === 'Identifier') {
           findVariableViolation(node, valueNode.name);
         } else if (nodeViolationType) {
-          context.report({
-            node,
-            messageId: nodeViolationType
+          report(context, messages[nodeViolationType], nodeViolationType, {
+            node
           });
         }
       }

--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -6,10 +6,15 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  putCommentInBraces: 'Comments inside children section of tag should be placed inside braces'
+};
 
 function checkText(node, context) {
   // since babel-eslint has the wrong node.raw, we'll get the source text
@@ -21,9 +26,8 @@ function checkText(node, context) {
       && node.parent.type !== 'JSXExpressionContainer'
       && node.parent.type.indexOf('JSX') !== -1
     ) {
-      context.report({
-        node,
-        messageId: 'putCommentInBraces'
+      report(context, messages.putCommentInBraces, 'putCommentInBraces', {
+        node
       });
     }
   }
@@ -38,9 +42,7 @@ module.exports = {
       url: docsUrl('jsx-no-comment-textnodes')
     },
 
-    messages: {
-      putCommentInBraces: 'Comments inside children section of tag should be placed inside braces'
-    },
+    messages,
 
     schema: [{
       type: 'object',

--- a/lib/rules/jsx-no-constructed-context-values.js
+++ b/lib/rules/jsx-no-constructed-context-values.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -120,6 +121,13 @@ function isConstruction(node, callScope) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  withIdentifierMsg: "The '{{variableName}}' {{type}} (at line {{nodeLine}}) passed as the value prop to the Context provider (at line {{usageLine}}) changes every render. To fix this consider wrapping it in a useMemo hook.",
+  withIdentifierMsgFunc: "The '{{variableName}}' {{type}} (at line {{nodeLine}}) passed as the value prop to the Context provider (at line {{usageLine}}) changes every render. To fix this consider wrapping it in a useCallback hook.",
+  defaultMsg: 'The {{type}} passed as the value prop to the Context provider (at line {{nodeLine}}) changes every render. To fix this consider wrapping it in a useMemo hook.',
+  defaultMsgFunc: 'The {{type}} passed as the value prop to the Context provider (at line {{nodeLine}}) changes every render. To fix this consider wrapping it in a useCallback hook.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -128,16 +136,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-no-constructed-context-values')
     },
-    messages: {
-      withIdentifierMsg:
-        "The '{{variableName}}' {{type}} (at line {{nodeLine}}) passed as the value prop to the Context provider (at line {{usageLine}}) changes every render. To fix this consider wrapping it in a useMemo hook.",
-      withIdentifierMsgFunc:
-        "The '{{variableName}}' {{type}} (at line {{nodeLine}}) passed as the value prop to the Context provider (at line {{usageLine}}) changes every render. To fix this consider wrapping it in a useCallback hook.",
-      defaultMsg:
-        'The {{type}} passed as the value prop to the Context provider (at line {{nodeLine}}) changes every render. To fix this consider wrapping it in a useMemo hook.',
-      defaultMsgFunc:
-        'The {{type}} passed as the value prop to the Context provider (at line {{nodeLine}}) changes every render. To fix this consider wrapping it in a useCallback hook.'
-    }
+    messages
   },
 
   create(context) {
@@ -202,15 +201,15 @@ module.exports = {
         }
 
         // Type of expression
-        if (constructType === 'function expression'
+        if (
+          constructType === 'function expression'
           || constructType === 'function declaration'
         ) {
           messageId += 'Func';
         }
 
-        context.report({
+        report(context, messages[messageId], messageId, {
           node: constructNode,
-          messageId,
           data
         });
       }

--- a/lib/rules/jsx-no-duplicate-props.js
+++ b/lib/rules/jsx-no-duplicate-props.js
@@ -7,10 +7,15 @@
 
 const has = require('object.hasown/polyfill')();
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noDuplicateProps: 'No duplicate props allowed'
+};
 
 module.exports = {
   meta: {
@@ -21,9 +26,7 @@ module.exports = {
       url: docsUrl('jsx-no-duplicate-props')
     },
 
-    messages: {
-      noDuplicateProps: 'No duplicate props allowed'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -60,9 +63,8 @@ module.exports = {
           }
 
           if (has(props, name)) {
-            context.report({
-              node: decl,
-              messageId: 'noDuplicateProps'
+            report(context, messages.noDuplicateProps, 'noDuplicateProps', {
+              node: decl
             });
           } else {
             props[name] = 1;

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -7,6 +7,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -15,6 +16,13 @@ const docsUrl = require('../util/docsUrl');
 function trimIfString(val) {
   return typeof val === 'string' ? val.trim() : val;
 }
+
+const messages = {
+  invalidPropValue: 'Invalid prop value: "{{text}}"',
+  noStringsInAttributes: 'Strings not allowed in attributes: "{{text}}"',
+  noStringsInJSX: 'Strings not allowed in JSX files: "{{text}}"',
+  literalNotInJSXExpression: 'Missing JSX expression container around literal string: "{{text}}"'
+};
 
 module.exports = {
   meta: {
@@ -25,12 +33,7 @@ module.exports = {
       url: docsUrl('jsx-no-literals')
     },
 
-    messages: {
-      invalidPropValue: 'Invalid prop value: "{{text}}"',
-      noStringsInAttributes: 'Strings not allowed in attributes: "{{text}}"',
-      noStringsInJSX: 'Strings not allowed in JSX files: "{{text}}"',
-      literalNotInJSXExpression: 'Missing JSX expression container around literal string: "{{text}}"'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -79,9 +82,8 @@ module.exports = {
     function reportLiteralNode(node, messageId) {
       messageId = messageId || defaultMessageId();
 
-      context.report({
+      report(context, messages[messageId], messageId, {
         node,
-        messageId,
         data: {
           text: context.getSourceCode().getText(node).trim()
         }

--- a/lib/rules/jsx-no-script-url.js
+++ b/lib/rules/jsx-no-script-url.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -42,6 +43,10 @@ function shouldVerifyProp(node, config) {
   return node.name && props.indexOf(name) !== -1;
 }
 
+const messages = {
+  noScriptURL: 'A future version of React will block javascript: URLs as a security precaution. Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -51,10 +56,7 @@ module.exports = {
       url: docsUrl('jsx-no-script-url')
     },
 
-    messages: {
-      noScriptURL: 'A future version of React will block javascript: URLs as a security precaution. '
-        + 'Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.'
-    },
+    messages,
 
     schema: [{
       type: 'array',
@@ -85,9 +87,8 @@ module.exports = {
       JSXAttribute(node) {
         const parent = node.parent;
         if (shouldVerifyElement(parent, config) && shouldVerifyProp(node, config) && hasJavaScriptProtocol(node)) {
-          context.report({
-            node,
-            messageId: 'noScriptURL'
+          report(context, messages.noScriptURL, 'noScriptURL', {
+            node
           });
         }
       }

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -7,6 +7,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const linkComponentsUtil = require('../util/linkComponents');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -95,6 +96,10 @@ function hasSecureRel(node, allowReferrer, warnOnSpreadAttributes, spreadAttribu
   return allowReferrer && tags && tags.indexOf('noopener') >= 0;
 }
 
+const messages = {
+  noTargetBlank: 'Using target="_blank" without rel="noreferrer" is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
+};
+
 module.exports = {
   meta: {
     fixable: 'code',
@@ -105,10 +110,7 @@ module.exports = {
       url: docsUrl('jsx-no-target-blank')
     },
 
-    messages: {
-      noTargetBlank: 'Using target="_blank" without rel="noreferrer" '
-        + 'is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -171,9 +173,8 @@ module.exports = {
           const hasDangerousLink = hasExternalLink(node, linkAttribute, warnOnSpreadAttributes, spreadAttributeIndex)
             || (enforceDynamicLinks === 'always' && hasDynamicLink(node, linkAttribute));
           if (hasDangerousLink && !hasSecureRel(node, allowReferrer, warnOnSpreadAttributes, spreadAttributeIndex)) {
-            context.report({
+            report(context, messages.noTargetBlank, 'noTargetBlank', {
               node,
-              messageId: 'noTargetBlank',
               fix(fixer) {
                 // eslint 5 uses `node.attributes`; eslint 6+ uses `node.parent.attributes`
                 const nodeWithAttrs = node.parent.attributes ? node.parent : node;
@@ -243,9 +244,8 @@ module.exports = {
             hasExternalLink(node, formAttribute)
             || (enforceDynamicLinks === 'always' && hasDynamicLink(node, formAttribute))
           ) {
-            context.report({
-              node,
-              messageId: 'noTargetBlank'
+            report(context, messages.noTargetBlank, 'noTargetBlank', {
+              node
             });
           }
         }

--- a/lib/rules/jsx-no-undef.js
+++ b/lib/rules/jsx-no-undef.js
@@ -7,10 +7,15 @@
 
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  undefined: '\'{{identifier}}\' is not defined.'
+};
 
 module.exports = {
   meta: {
@@ -21,9 +26,7 @@ module.exports = {
       url: docsUrl('jsx-no-undef')
     },
 
-    messages: {
-      undefined: '\'{{identifier}}\' is not defined.'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -77,9 +80,8 @@ module.exports = {
         }
       }
 
-      context.report({
+      report(context, messages.undefined, 'undefined', {
         node,
-        messageId: 'undefined',
         data: {
           identifier: node.name
         }

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -9,6 +9,7 @@ const arrayIncludes = require('array-includes');
 const pragmaUtil = require('../util/pragma');
 const jsxUtil = require('../util/jsx');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 function isJSXText(node) {
   return !!node && (node.type === 'JSXText' || node.type === 'Literal');
@@ -77,6 +78,11 @@ function containsCallExpression(node) {
     && node.expression.type === 'CallExpression';
 }
 
+const messages = {
+  NeedsMoreChildren: 'Fragments should contain more than one child - otherwise, there‘s no need for a Fragment at all.',
+  ChildOfHtmlElement: 'Passing a fragment to an HTML element is useless.'
+};
+
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -87,10 +93,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-no-useless-fragment')
     },
-    messages: {
-      NeedsMoreChildren: 'Fragments should contain more than one child - otherwise, there‘s no need for a Fragment at all.',
-      ChildOfHtmlElement: 'Passing a fragment to an HTML element is useless.'
-    }
+    messages
   },
 
   create(context) {
@@ -215,17 +218,15 @@ module.exports = {
         && !isFragmentWithOnlyTextAndIsNotChild(node)
         && !(allowExpressions && isFragmentWithSingleExpression(node))
       ) {
-        context.report({
+        report(context, messages.NeedsMoreChildren, 'NeedsMoreChildren', {
           node,
-          messageId: 'NeedsMoreChildren',
           fix: getFix(node)
         });
       }
 
       if (isChildOfHtmlElement(node)) {
-        context.report({
+        report(context, messages.ChildOfHtmlElement, 'ChildOfHtmlElement', {
           node,
-          messageId: 'ChildOfHtmlElement',
           fix: getFix(node)
         });
       }

--- a/lib/rules/jsx-one-expression-per-line.js
+++ b/lib/rules/jsx-one-expression-per-line.js
@@ -7,6 +7,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -14,6 +15,10 @@ const jsxUtil = require('../util/jsx');
 
 const optionDefaults = {
   allow: 'none'
+};
+
+const messages = {
+  moveToNewLine: '`{{descriptor}}` must be placed on a new line'
 };
 
 module.exports = {
@@ -26,9 +31,7 @@ module.exports = {
     },
     fixable: 'whitespace',
 
-    messages: {
-      moveToNewLine: '`{{descriptor}}` must be placed on a new line'
-    },
+    messages,
 
     schema: [
       {
@@ -210,9 +213,8 @@ module.exports = {
 
         const replaceText = `${leadingSpaceString}${leadingNewLineString}${source}${trailingNewLineString}${trailingSpaceString}`;
 
-        context.report({
+        report(context, messages.moveToNewLine, 'moveToNewLine', {
           node: nodeToReport,
-          messageId: 'moveToNewLine',
           data: {
             descriptor
           },

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -9,6 +9,7 @@ const elementType = require('jsx-ast-utils/elementType');
 const minimatch = require('minimatch');
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 function testDigit(char) {
   const charCode = char.charCodeAt(0);
@@ -70,6 +71,11 @@ function ignoreCheck(ignore, name) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  usePascalCase: 'Imported JSX component {{name}} must be in PascalCase',
+  usePascalOrSnakeCase: 'Imported JSX component {{name}} must be in PascalCase or SCREAMING_SNAKE_CASE'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -79,10 +85,7 @@ module.exports = {
       url: docsUrl('jsx-pascal-case')
     },
 
-    messages: {
-      usePascalCase: 'Imported JSX component {{name}} must be in PascalCase',
-      usePascalOrSnakeCase: 'Imported JSX component {{name}} must be in PascalCase or SCREAMING_SNAKE_CASE'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -143,9 +146,9 @@ module.exports = {
           const isAllowedAllCaps = allowAllCaps && testAllCaps(checkName);
 
           if (!isPascalCase && !isAllowedAllCaps && !isIgnored) {
-            context.report({
+            const messageId = allowAllCaps ? 'usePascalOrSnakeCase' : 'usePascalCase';
+            report(context, messages[messageId], messageId, {
               node,
-              messageId: allowAllCaps ? 'usePascalOrSnakeCase' : 'usePascalCase',
               data: {
                 name: splitName
               }

--- a/lib/rules/jsx-props-no-multi-spaces.js
+++ b/lib/rules/jsx-props-no-multi-spaces.js
@@ -6,10 +6,16 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noLineGap: 'Expected no line gap between “{{prop1}}” and “{{prop2}}”',
+  onlyOneSpace: 'Expected only one space between “{{prop1}}” and “{{prop2}}”'
+};
 
 module.exports = {
   meta: {
@@ -21,10 +27,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      noLineGap: 'Expected no line gap between “{{prop1}}” and “{{prop2}}”',
-      onlyOneSpace: 'Expected only one space between “{{prop1}}” and “{{prop2}}”'
-    },
+    messages,
 
     schema: []
   },
@@ -47,7 +50,7 @@ module.exports = {
 
     // First and second must be adjacent nodes
     function hasEmptyLines(first, second) {
-      const comments = sourceCode.getCommentsBefore(second);
+      const comments = sourceCode.getCommentsBefore ? sourceCode.getCommentsBefore(second) : [];
       const nodes = [].concat(first, comments, second);
 
       for (let i = 1; i < nodes.length; i += 1) {
@@ -63,9 +66,8 @@ module.exports = {
 
     function checkSpacing(prev, node) {
       if (hasEmptyLines(prev, node)) {
-        context.report({
+        report(context, messages.noLineGap, 'noLineGap', {
           node,
-          messageId: 'noLineGap',
           data: {
             prop1: getPropName(prev),
             prop2: getPropName(node)
@@ -80,9 +82,8 @@ module.exports = {
       const between = context.getSourceCode().text.slice(prev.range[1], node.range[0]);
 
       if (between !== ' ') {
-        context.report({
+        report(context, messages.onlyOneSpace, 'onlyOneSpace', {
           node,
-          messageId: 'onlyOneSpace',
           data: {
             prop1: getPropName(prev),
             prop2: getPropName(node)

--- a/lib/rules/jsx-props-no-spreading.js
+++ b/lib/rules/jsx-props-no-spreading.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -19,9 +20,23 @@ const DEFAULTS = {
   exceptions: []
 };
 
+const isException = (tag, allExceptions) => allExceptions.indexOf(tag) !== -1;
+const isProperty = (property) => property.type === 'Property';
+const getTagNameFromMemberExpression = (node) => {
+  if (node.property.parent) {
+    return `${node.property.parent.object.name}.${node.property.name}`;
+  }
+  // for eslint 3
+  return `${node.object.name}.${node.property.name}`;
+};
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noSpreading: 'Prop spreading is forbidden'
+};
 
 module.exports = {
   meta: {
@@ -32,9 +47,7 @@ module.exports = {
       url: docsUrl('jsx-props-no-spreading')
     },
 
-    messages: {
-      noSpreading: 'Prop spreading is forbidden'
-    },
+    messages,
 
     schema: [{
       allOf: [{
@@ -82,9 +95,6 @@ module.exports = {
     const ignoreCustomTags = (configuration.custom || DEFAULTS.custom) === OPTIONS.ignore;
     const ignoreExplicitSpread = (configuration.explicitSpread || DEFAULTS.explicitSpread) === OPTIONS.ignore;
     const exceptions = configuration.exceptions || DEFAULTS.exceptions;
-    const isException = (tag, allExceptions) => allExceptions.indexOf(tag) !== -1;
-    const isProperty = (property) => property.type === 'Property';
-    const getTagNameFromMemberExpression = (node) => `${node.property.parent.object.name}.${node.property.name}`;
     return {
       JSXSpreadAttribute(node) {
         const jsxOpeningElement = node.parent.name;
@@ -122,9 +132,8 @@ module.exports = {
         ) {
           return;
         }
-        context.report({
-          node,
-          messageId: 'noSpreading'
+        report(context, messages.noSpreading, 'noSpreading', {
+          node
         });
       }
     };

--- a/lib/rules/jsx-sort-default-props.js
+++ b/lib/rules/jsx-sort-default-props.js
@@ -9,10 +9,15 @@ const variableUtil = require('../util/variable');
 const docsUrl = require('../util/docsUrl');
 const propWrapperUtil = require('../util/propWrapper');
 // const propTypesSortUtil = require('../util/propTypesSort');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  propsNotSorted: 'Default prop types declarations should be sorted alphabetically'
+};
 
 module.exports = {
   meta: {
@@ -24,9 +29,7 @@ module.exports = {
     },
     // fixable: 'code',
 
-    messages: {
-      propsNotSorted: 'Default prop types declarations should be sorted alphabetically'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -121,9 +124,8 @@ module.exports = {
         }
 
         if (currentPropName < prevPropName) {
-          context.report({
-            node: curr,
-            messageId: 'propsNotSorted'
+          report(context, messages.propsNotSorted, 'propsNotSorted', {
+            node: curr
             // fix
           });
 

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -8,6 +8,7 @@
 const propName = require('jsx-ast-utils/propName');
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -16,6 +17,16 @@ const jsxUtil = require('../util/jsx');
 function isCallbackPropName(name) {
   return /^on[A-Z]/.test(name);
 }
+
+const messages = {
+  noUnreservedProps: 'A customized reserved first list must only contain a subset of React reserved props. Remove: {{unreservedWords}}',
+  listIsEmpty: 'A customized reserved first list must not be empty',
+  listReservedPropsFirst: 'Reserved props must be listed before all other props',
+  listCallbacksLast: 'Callbacks must be listed after all other props',
+  listShorthandFirst: 'Shorthand props must be listed before all other props',
+  listShorthandLast: 'Shorthand props must be listed after all other props',
+  sortPropsByAlpha: 'Props should be sorted alphabetically'
+};
 
 const RESERVED_PROPS_LIST = [
   'children',
@@ -182,18 +193,16 @@ function validateReservedFirstConfig(context, reservedFirst) {
       ));
 
       if (reservedFirst.length === 0) {
-        return function report(decl) {
-          context.report({
-            node: decl,
-            messageId: 'listIsEmpty'
+        return function Report(decl) {
+          report(context, messages.listIsEmpty, 'listIsEmpty', {
+            node: decl
           });
         };
       }
       if (nonReservedWords.length > 0) {
-        return function report(decl) {
-          context.report({
+        return function Report(decl) {
+          report(context, messages.noUnreservedProps, 'noUnreservedProps', {
             node: decl,
-            messageId: 'noUnreservedProps',
             data: {
               unreservedWords: nonReservedWords.toString()
             }
@@ -214,15 +223,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      noUnreservedProps: 'A customized reserved first list must only contain a subset of React reserved props. Remove: {{unreservedWords}}',
-      listIsEmpty: 'A customized reserved first list must not be empty',
-      listReservedPropsFirst: 'Reserved props must be listed before all other props',
-      listCallbacksLast: 'Callbacks must be listed after all other props',
-      listShorthandFirst: 'Shorthand props must be listed before all other props',
-      listShorthandLast: 'Shorthand props must be listed after all other props',
-      sortPropsByAlpha: 'Props should be sorted alphabetically'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -303,9 +304,8 @@ module.exports = {
               return decl;
             }
             if (!previousIsReserved && currentIsReserved) {
-              context.report({
+              report(context, messages.listReservedPropsFirst, 'listReservedPropsFirst', {
                 node: decl.name,
-                messageId: 'listReservedPropsFirst',
                 fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
@@ -319,9 +319,8 @@ module.exports = {
             }
             if (previousIsCallback && !currentIsCallback) {
               // Encountered a non-callback prop after a callback prop
-              context.report({
+              report(context, messages.listCallbacksLast, 'listCallbacksLast', {
                 node: memo.name,
-                messageId: 'listCallbacksLast',
                 fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
@@ -333,9 +332,8 @@ module.exports = {
               return decl;
             }
             if (!currentValue && previousValue) {
-              context.report({
+              report(context, messages.listShorthandFirst, 'listShorthandFirst', {
                 node: memo.name,
-                messageId: 'listShorthandFirst',
                 fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
@@ -347,9 +345,8 @@ module.exports = {
               return decl;
             }
             if (currentValue && !previousValue) {
-              context.report({
+              report(context, messages.listShorthandLast, 'listShorthandLast', {
                 node: memo.name,
-                messageId: 'listShorthandLast',
                 fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
@@ -364,9 +361,8 @@ module.exports = {
                 : previousPropName > currentPropName
             )
           ) {
-            context.report({
+            report(context, messages.sortPropsByAlpha, 'sortPropsByAlpha', {
               node: decl.name,
-              messageId: 'sortPropsByAlpha',
               fix: generateFixerFunction(node, context, reservedList)
             });
             return memo;

--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -9,12 +9,18 @@
 const getTokenBeforeClosingBracket = require('../util/getTokenBeforeClosingBracket');
 const docsUrl = require('../util/docsUrl');
 const log = require('../util/log');
+const report = require('../util/report');
 
 let isWarnedForDeprecation = false;
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noSpaceBeforeClose: 'A space is forbidden before closing bracket',
+  needSpaceBeforeClose: 'A space is required before closing bracket'
+};
 
 module.exports = {
   meta: {
@@ -27,10 +33,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      noSpaceBeforeClose: 'A space is forbidden before closing bracket',
-      needSpaceBeforeClose: 'A space is required before closing bracket'
-    },
+    messages,
 
     schema: [{
       enum: ['always', 'never']
@@ -60,17 +63,15 @@ module.exports = {
         }
 
         if (configuration === 'always' && !sourceCode.isSpaceBetweenTokens(leftToken, closingSlash)) {
-          context.report({
+          report(context, messages.needSpaceBeforeClose, 'needSpaceBeforeClose', {
             loc: closingSlash.loc.start,
-            messageId: 'needSpaceBeforeClose',
             fix(fixer) {
               return fixer.insertTextBefore(closingSlash, ' ');
             }
           });
         } else if (configuration === 'never' && sourceCode.isSpaceBetweenTokens(leftToken, closingSlash)) {
-          context.report({
+          report(context, messages.noSpaceBeforeClose, 'noSpaceBeforeClose', {
             loc: closingSlash.loc.start,
-            messageId: 'noSpaceBeforeClose',
             fix(fixer) {
               const previousToken = sourceCode.getTokenBefore(closingSlash);
               return fixer.removeRange([previousToken.range[1], closingSlash.range[0]]);

--- a/lib/rules/jsx-tag-spacing.js
+++ b/lib/rules/jsx-tag-spacing.js
@@ -7,6 +7,20 @@
 
 const getTokenBeforeClosingBracket = require('../util/getTokenBeforeClosingBracket');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
+
+const messages = {
+  selfCloseSlashNoSpace: 'Whitespace is forbidden between `/` and `>`; write `/>`',
+  selfCloseSlashNeedSpace: 'Whitespace is required between `/` and `>`; write `/ >`',
+  closeSlashNoSpace: 'Whitespace is forbidden between `<` and `/`; write `</`',
+  closeSlashNeedSpace: 'Whitespace is required between `<` and `/`; write `< /`',
+  beforeSelfCloseNoSpace: 'A space is forbidden before closing bracket',
+  beforeSelfCloseNeedSpace: 'A space is required before closing bracket',
+  afterOpenNoSpace: 'A space is forbidden after opening bracket',
+  afterOpenNeedSpace: 'A space is required after opening bracket',
+  beforeCloseNoSpace: 'A space is forbidden before closing bracket',
+  beforeCloseNeedSpace: 'Whitespace is required before closing bracket'
+};
 
 // ------------------------------------------------------------------------------
 // Validators
@@ -24,26 +38,24 @@ function validateClosingSlash(context, node, option) {
 
     if (option === 'never') {
       if (!adjacent) {
-        context.report({
+        report(context, messages.selfCloseSlashNoSpace, 'selfCloseSlashNoSpace', {
           node,
           loc: {
             start: lastTokens[0].loc.start,
             end: lastTokens[1].loc.end
           },
-          messageId: 'selfCloseSlashNoSpace',
           fix(fixer) {
             return fixer.removeRange([lastTokens[0].range[1], lastTokens[1].range[0]]);
           }
         });
       }
     } else if (option === 'always' && adjacent) {
-      context.report({
+      report(context, messages.selfCloseSlashNeedSpace, 'selfCloseSlashNeedSpace', {
         node,
         loc: {
           start: lastTokens[0].loc.start,
           end: lastTokens[1].loc.end
         },
-        messageId: 'selfCloseSlashNeedSpace',
         fix(fixer) {
           return fixer.insertTextBefore(lastTokens[1], ' ');
         }
@@ -56,26 +68,24 @@ function validateClosingSlash(context, node, option) {
 
     if (option === 'never') {
       if (!adjacent) {
-        context.report({
+        report(context, messages.closeSlashNoSpace, 'closeSlashNoSpace', {
           node,
           loc: {
             start: firstTokens[0].loc.start,
             end: firstTokens[1].loc.end
           },
-          messageId: 'closeSlashNoSpace',
           fix(fixer) {
             return fixer.removeRange([firstTokens[0].range[1], firstTokens[1].range[0]]);
           }
         });
       }
     } else if (option === 'always' && adjacent) {
-      context.report({
+      report(context, messages.closeSlashNeedSpace, 'closeSlashNeedSpace', {
         node,
         loc: {
           start: firstTokens[0].loc.start,
           end: firstTokens[1].loc.end
         },
-        messageId: 'closeSlashNeedSpace',
         fix(fixer) {
           return fixer.insertTextBefore(firstTokens[1], ' ');
         }
@@ -94,19 +104,17 @@ function validateBeforeSelfClosing(context, node, option) {
   }
 
   if (option === 'always' && !sourceCode.isSpaceBetweenTokens(leftToken, closingSlash)) {
-    context.report({
+    report(context, messages.beforeSelfCloseNeedSpace, 'beforeSelfCloseNeedSpace', {
       node,
       loc: closingSlash.loc.start,
-      messageId: 'beforeSelfCloseNeedSpace',
       fix(fixer) {
         return fixer.insertTextBefore(closingSlash, ' ');
       }
     });
   } else if (option === 'never' && sourceCode.isSpaceBetweenTokens(leftToken, closingSlash)) {
-    context.report({
+    report(context, messages.beforeSelfCloseNoSpace, 'beforeSelfCloseNoSpace', {
       node,
       loc: closingSlash.loc.start,
-      messageId: 'beforeSelfCloseNoSpace',
       fix(fixer) {
         const previousToken = sourceCode.getTokenBefore(closingSlash);
         return fixer.removeRange([previousToken.range[1], closingSlash.range[0]]);
@@ -129,26 +137,24 @@ function validateAfterOpening(context, node, option) {
 
   if (option === 'never' || option === 'allow-multiline') {
     if (!adjacent) {
-      context.report({
+      report(context, messages.afterOpenNoSpace, 'afterOpenNoSpace', {
         node,
         loc: {
           start: openingToken.loc.start,
           end: node.name.loc.start
         },
-        messageId: 'afterOpenNoSpace',
         fix(fixer) {
           return fixer.removeRange([openingToken.range[1], node.name.range[0]]);
         }
       });
     }
   } else if (option === 'always' && adjacent) {
-    context.report({
+    report(context, messages.afterOpenNeedSpace, 'afterOpenNeedSpace', {
       node,
       loc: {
         start: openingToken.loc.start,
         end: node.name.loc.start
       },
-      messageId: 'afterOpenNeedSpace',
       fix(fixer) {
         return fixer.insertTextBefore(node.name, ' ');
       }
@@ -171,25 +177,23 @@ function validateBeforeClosing(context, node, option) {
     const adjacent = !sourceCode.isSpaceBetweenTokens(leftToken, closingToken);
 
     if (option === 'never' && !adjacent) {
-      context.report({
+      report(context, messages.beforeCloseNoSpace, 'beforeCloseNoSpace', {
         node,
         loc: {
           start: leftToken.loc.end,
           end: closingToken.loc.start
         },
-        messageId: 'beforeCloseNoSpace',
         fix(fixer) {
           return fixer.removeRange([leftToken.range[1], closingToken.range[0]]);
         }
       });
     } else if (option === 'always' && adjacent) {
-      context.report({
+      report(context, messages.beforeCloseNeedSpace, 'beforeCloseNeedSpace', {
         node,
         loc: {
           start: leftToken.loc.end,
           end: closingToken.loc.start
         },
-        messageId: 'beforeCloseNeedSpace',
         fix(fixer) {
           return fixer.insertTextBefore(closingToken, ' ');
         }
@@ -219,18 +223,7 @@ module.exports = {
     },
     fixable: 'whitespace',
 
-    messages: {
-      selfCloseSlashNoSpace: 'Whitespace is forbidden between `/` and `>`; write `/>`',
-      selfCloseSlashNeedSpace: 'Whitespace is required between `/` and `>`; write `/ >`',
-      closeSlashNoSpace: 'Whitespace is forbidden between `<` and `/`; write `</`',
-      closeSlashNeedSpace: 'Whitespace is required between `<` and `/`; write `< /`',
-      beforeSelfCloseNoSpace: 'A space is forbidden before closing bracket',
-      beforeSelfCloseNeedSpace: 'A space is required before closing bracket',
-      afterOpenNoSpace: 'A space is forbidden after opening bracket',
-      afterOpenNeedSpace: 'A space is required after opening bracket',
-      beforeCloseNoSpace: 'A space is forbidden before closing bracket',
-      beforeCloseNeedSpace: 'Whitespace is required before closing bracket'
-    },
+    messages,
 
     schema: [
       {

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -8,6 +8,7 @@
 const has = require('object.hasown/polyfill')();
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const reportC = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -27,6 +28,11 @@ const DEFAULTS = {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  missingParens: 'Missing parentheses around multilines JSX',
+  parensOnNewLines: 'Parentheses around JSX should be on separate lines'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -37,10 +43,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      missingParens: 'Missing parentheses around multilines JSX',
-      parensOnNewLines: 'Parentheses around JSX should be on separate lines'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -129,9 +132,8 @@ module.exports = {
     }
 
     function report(node, messageId, fix) {
-      context.report({
+      reportC(context, messages[messageId], messageId, {
         node,
-        messageId,
         fix
       });
     }

--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -7,10 +7,15 @@
 
 const docsUrl = require('../util/docsUrl');
 const Components = require('../util/Components');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  useCallback: 'Use callback in setState when referencing the previous state.'
+};
 
 module.exports = {
   meta: {
@@ -21,9 +26,7 @@ module.exports = {
       url: docsUrl('no-access-state-in-setstate')
     },
 
-    messages: {
-      useCallback: 'Use callback in setState when referencing the previous state.'
-    }
+    messages
   },
 
   create: Components.detect((context, components, utils) => {
@@ -84,9 +87,8 @@ module.exports = {
             const methodName = node.callee.name;
             methods.forEach((method) => {
               if (method.methodName === methodName) {
-                context.report({
-                  node: method.node,
-                  messageId: 'useCallback'
+                report(context, messages.useCallback, 'useCallback', {
+                  node: method.node
                 });
               }
             });
@@ -107,9 +109,8 @@ module.exports = {
           while (current.type !== 'Program') {
             // Reporting if this.state is directly within this.setState
             if (isFirstArgumentInSetStateCall(current, node)) {
-              context.report({
-                node,
-                messageId: 'useCallback'
+              report(context, messages.useCallback, 'useCallback', {
+                node
               });
               break;
             }
@@ -159,9 +160,8 @@ module.exports = {
               vars
                 .filter((v) => v.scope === context.getScope() && v.variableName === node.name)
                 .forEach((v) => {
-                  context.report({
-                    node: v.node,
-                    messageId: 'useCallback'
+                  report(context, messages.useCallback, 'useCallback', {
+                    node: v.node
                   });
                 });
             }

--- a/lib/rules/no-adjacent-inline-elements.js
+++ b/lib/rules/no-adjacent-inline-elements.js
@@ -7,6 +7,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const isCreateElement = require('../util/isCreateElement');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -71,6 +72,10 @@ function isInline(node) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  inlineElement: 'Child elements which render as inline HTML elements should be separated by a space or wrapped in block level elements.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -81,9 +86,7 @@ module.exports = {
     },
     schema: [],
 
-    messages: {
-      inlineElement: 'Child elements which render as inline HTML elements should be separated by a space or wrapped in block level elements.'
-    }
+    messages
   },
   create(context) {
     function validate(node, children) {
@@ -95,9 +98,8 @@ module.exports = {
       for (let i = 0; i < children.length; i++) {
         currentIsInline = isInline(children[i]);
         if (previousIsInline && currentIsInline) {
-          context.report({
-            node,
-            messageId: 'inlineElement'
+          report(context, messages.inlineElement, 'inlineElement', {
+            node
           });
           return;
         }

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -9,10 +9,15 @@ const has = require('object.hasown/polyfill')();
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
 const pragma = require('../util/pragma');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noArrayIndex: 'Do not use Array index in keys'
+};
 
 module.exports = {
   meta: {
@@ -23,9 +28,7 @@ module.exports = {
       url: docsUrl('no-array-index-key')
     },
 
-    messages: {
-      noArrayIndex: 'Do not use Array index in keys'
-    },
+    messages,
 
     schema: []
   },
@@ -130,9 +133,8 @@ module.exports = {
     function checkPropValue(node) {
       if (isArrayIndex(node)) {
         // key={bar}
-        context.report({
-          node,
-          messageId: 'noArrayIndex'
+        report(context, messages.noArrayIndex, 'noArrayIndex', {
+          node
         });
         return;
       }
@@ -140,7 +142,9 @@ module.exports = {
       if (node.type === 'TemplateLiteral') {
         // key={`foo-${bar}`}
         node.expressions.filter(isArrayIndex).forEach(() => {
-          context.report({node, messageId: 'noArrayIndex'});
+          report(context, messages.noArrayIndex, 'noArrayIndex', {
+            node
+          });
         });
 
         return;
@@ -151,7 +155,9 @@ module.exports = {
         const identifiers = getIdentifiersFromBinaryExpression(node);
 
         identifiers.filter(isArrayIndex).forEach(() => {
-          context.report({node, messageId: 'noArrayIndex'});
+          report(context, messages.noArrayIndex, 'noArrayIndex', {
+            node
+          });
         });
       }
     }

--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -7,6 +7,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const isCreateElement = require('../util/isCreateElement');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -29,6 +30,13 @@ function isCreateElementWithProps(node, context) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  nestChildren: 'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+  passChildrenAsArgs: 'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
+  nestFunction: 'Do not nest a function between the opening and closing tags. Instead, pass it as a prop.',
+  passFunctionAsArgs: 'Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -38,12 +46,7 @@ module.exports = {
       url: docsUrl('no-children-prop')
     },
 
-    messages: {
-      nestChildren: 'Do not pass children as props. Instead, nest children between the opening and closing tags.',
-      passChildrenAsArgs: 'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.',
-      nestFunction: 'Do not nest a function between the opening and closing tags. Instead, pass it as a prop.',
-      passFunctionAsArgs: 'Do not pass a function as an additional argument to React.createElement. Instead, pass it as a prop.'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -74,9 +77,8 @@ module.exports = {
           return;
         }
 
-        context.report({
-          node,
-          messageId: 'nestChildren'
+        report(context, messages.nestChildren, 'nestChildren', {
+          node
         });
       },
       CallExpression(node) {
@@ -89,17 +91,15 @@ module.exports = {
 
         if (childrenProp) {
           if (childrenProp.value && !isFunction(childrenProp.value)) {
-            context.report({
-              node,
-              messageId: 'passChildrenAsArgs'
+            report(context, messages.passChildrenAsArgs, 'passChildrenAsArgs', {
+              node
             });
           }
         } else if (node.arguments.length === 3) {
           const children = node.arguments[2];
           if (isFunction(children)) {
-            context.report({
-              node,
-              messageId: 'passFunctionAsArgs'
+            report(context, messages.passFunctionAsArgs, 'passFunctionAsArgs', {
+              node
             });
           }
         }
@@ -108,9 +108,8 @@ module.exports = {
         const children = node.children;
         if (children && children.length === 1 && children[0].type === 'JSXExpressionContainer') {
           if (isFunction(children[0].expression)) {
-            context.report({
-              node,
-              messageId: 'nestFunction'
+            report(context, messages.nestFunction, 'nestFunction', {
+              node
             });
           }
         }

--- a/lib/rules/no-danger-with-children.js
+++ b/lib/rules/no-danger-with-children.js
@@ -8,10 +8,15 @@
 const variableUtil = require('../util/variable');
 const jsxUtil = require('../util/jsx');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+const messages = {
+  dangerWithChildren: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -21,9 +26,7 @@ module.exports = {
       url: docsUrl('no-danger-with-children')
     },
 
-    messages: {
-      dangerWithChildren: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'
-    },
+    messages,
 
     schema: [] // no options
   },
@@ -107,9 +110,8 @@ module.exports = {
           && hasChildren
           && findJsxProp(node, 'dangerouslySetInnerHTML')
         ) {
-          context.report({
-            node,
-            messageId: 'dangerWithChildren'
+          report(context, messages.dangerWithChildren, 'dangerWithChildren', {
+            node
           });
         }
       },
@@ -142,9 +144,8 @@ module.exports = {
           }
 
           if (dangerously && hasChildren) {
-            context.report({
-              node,
-              messageId: 'dangerWithChildren'
+            report(context, messages.dangerWithChildren, 'dangerWithChildren', {
+              node
             });
           }
         }

--- a/lib/rules/no-danger.js
+++ b/lib/rules/no-danger.js
@@ -7,6 +7,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -38,6 +39,10 @@ function isDangerous(name) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  dangerousProp: 'Dangerous property \'{{name}}\' found'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -47,28 +52,23 @@ module.exports = {
       url: docsUrl('no-danger')
     },
 
-    messages: {
-      dangerousProp: 'Dangerous property \'{{name}}\' found'
-    },
+    messages,
 
     schema: []
   },
 
   create(context) {
     return {
-
       JSXAttribute(node) {
         if (jsxUtil.isDOMComponent(node.parent) && isDangerous(node.name.name)) {
-          context.report({
+          report(context, messages.dangerousProp, 'dangerousProp', {
             node,
-            messageId: 'dangerousProp',
             data: {
               name: node.name.name
             }
           });
         }
       }
-
     };
   }
 };

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -14,6 +14,7 @@ const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
 const pragmaUtil = require('../util/pragma');
 const versionUtil = require('../util/version');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -28,6 +29,10 @@ const MODULES = {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  deprecated: '{{oldMethod}} is deprecated since React {{version}}{{newMethod}}{{refs}}'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -37,9 +42,7 @@ module.exports = {
       url: docsUrl('no-deprecated')
     },
 
-    messages: {
-      deprecated: '{{oldMethod}} is deprecated since React {{version}}{{newMethod}}{{refs}}'
-    },
+    messages,
 
     schema: []
   },
@@ -123,9 +126,8 @@ module.exports = {
       const version = deprecated[methodName][0];
       const newMethod = deprecated[methodName][1];
       const refs = deprecated[methodName][2];
-      context.report({
+      report(context, messages.deprecated, 'deprecated', {
         node: methodNode || node,
-        messageId: 'deprecated',
         data: {
           oldMethod: methodName,
           version,

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -8,10 +8,15 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noDirectMutation: 'Do not mutate state directly. Use setState().'
+};
 
 module.exports = {
   meta: {
@@ -22,9 +27,7 @@ module.exports = {
       url: docsUrl('no-direct-mutation-state')
     },
 
-    messages: {
-      noDirectMutation: 'Do not mutate state directly. Use setState().'
-    }
+    messages
   },
 
   create: Components.detect((context, components, utils) => {
@@ -45,9 +48,8 @@ module.exports = {
       let mutation;
       for (let i = 0, j = component.mutations.length; i < j; i++) {
         mutation = component.mutations[i];
-        context.report({
-          node: mutation,
-          messageId: 'noDirectMutation'
+        report(context, messages.noDirectMutation, 'noDirectMutation', {
+          node: mutation
         });
       }
     }

--- a/lib/rules/no-find-dom-node.js
+++ b/lib/rules/no-find-dom-node.js
@@ -6,10 +6,15 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noFindDOMNode: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
+};
 
 module.exports = {
   meta: {
@@ -20,20 +25,13 @@ module.exports = {
       url: docsUrl('no-find-dom-node')
     },
 
-    messages: {
-      noFindDOMNode: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
-    },
+    messages,
 
     schema: []
   },
 
   create(context) {
-    // --------------------------------------------------------------------------
-    // Public
-    // --------------------------------------------------------------------------
-
     return {
-
       CallExpression(node) {
         const callee = node.callee;
 
@@ -43,9 +41,8 @@ module.exports = {
           return;
         }
 
-        context.report({
-          node: callee,
-          messageId: 'noFindDOMNode'
+        report(context, messages.noFindDOMNode, 'noFindDOMNode', {
+          node: callee
         });
       }
     };

--- a/lib/rules/no-is-mounted.js
+++ b/lib/rules/no-is-mounted.js
@@ -6,10 +6,15 @@
 'use strict';
 
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noIsMounted: 'Do not use isMounted'
+};
 
 module.exports = {
   meta: {
@@ -20,20 +25,13 @@ module.exports = {
       url: docsUrl('no-is-mounted')
     },
 
-    messages: {
-      noIsMounted: 'Do not use isMounted'
-    },
+    messages,
 
     schema: []
   },
 
   create(context) {
-    // --------------------------------------------------------------------------
-    // Public
-    // --------------------------------------------------------------------------
-
     return {
-
       CallExpression(node) {
         const callee = node.callee;
         if (callee.type !== 'MemberExpression') {
@@ -45,9 +43,8 @@ module.exports = {
         const ancestors = context.getAncestors(callee);
         for (let i = 0, j = ancestors.length; i < j; i++) {
           if (ancestors[i].type === 'Property' || ancestors[i].type === 'MethodDefinition') {
-            context.report({
-              node: callee,
-              messageId: 'noIsMounted'
+            report(context, messages.noIsMounted, 'noIsMounted', {
+              node: callee
             });
             break;
           }

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -7,10 +7,15 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  onlyOneComponent: 'Declare only one React component per file'
+};
 
 module.exports = {
   meta: {
@@ -21,9 +26,7 @@ module.exports = {
       url: docsUrl('no-multi-comp')
     },
 
-    messages: {
-      onlyOneComponent: 'Declare only one React component per file'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -55,10 +58,6 @@ module.exports = {
       );
     }
 
-    // --------------------------------------------------------------------------
-    // Public
-    // --------------------------------------------------------------------------
-
     return {
       'Program:exit'() {
         if (components.length() <= 1) {
@@ -69,9 +68,8 @@ module.exports = {
 
         Object.keys(list).filter((component) => !isIgnored(list[component])).forEach((component, i) => {
           if (i >= 1) {
-            context.report({
-              node: list[component].node,
-              messageId: 'onlyOneComponent'
+            report(context, messages.onlyOneComponent, 'onlyOneComponent', {
+              node: list[component].node
             });
           }
         });

--- a/lib/rules/no-namespace.js
+++ b/lib/rules/no-namespace.js
@@ -8,10 +8,15 @@
 const elementType = require('jsx-ast-utils/elementType');
 const docsUrl = require('../util/docsUrl');
 const isCreateElement = require('../util/isCreateElement');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noNamespace: 'React component {{name}} must not be in a namespace, as React does not support them'
+};
 
 module.exports = {
   meta: {
@@ -21,6 +26,8 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-namespace')
     },
+
+    messages,
 
     schema: [{
       type: 'object',
@@ -34,15 +41,23 @@ module.exports = {
         if (isCreateElement(node, context) && node.arguments.length > 0 && node.arguments[0].type === 'Literal') {
           const name = node.arguments[0].value;
           if (name.indexOf(':') === -1) return undefined;
-          const message = `React component ${name} must not be in a namespace as React does not support them`;
-          context.report({node, message});
+          report(context, messages.noNamespace, 'noNamespace', {
+            node,
+            data: {
+              name
+            }
+          });
         }
       },
       JSXOpeningElement(node) {
         const name = elementType(node);
         if (name.indexOf(':') === -1) return undefined;
-        const message = `React component ${name} must not be in a namespace as React does not support them`;
-        context.report({node, message});
+        report(context, messages.noNamespace, 'noNamespace', {
+          node,
+          data: {
+            name
+          }
+        });
       }
     };
   }

--- a/lib/rules/no-redundant-should-component-update.js
+++ b/lib/rules/no-redundant-should-component-update.js
@@ -7,10 +7,15 @@
 const Components = require('../util/Components');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noShouldCompUpdate: '{{component}} does not need shouldComponentUpdate when extending React.PureComponent.'
+};
 
 module.exports = {
   meta: {
@@ -21,9 +26,7 @@ module.exports = {
       url: docsUrl('no-redundant-should-component-update')
     },
 
-    messages: {
-      noShouldCompUpdate: '{{component}} does not need shouldComponentUpdate when extending React.PureComponent.'
-    },
+    messages,
 
     schema: []
   },
@@ -66,9 +69,8 @@ module.exports = {
         const hasScu = hasShouldComponentUpdate(node);
         if (hasScu) {
           const className = getNodeName(node);
-          context.report({
+          report(context, messages.noShouldCompUpdate, 'noShouldCompUpdate', {
             node,
-            messageId: 'noShouldCompUpdate',
             data: {
               component: className
             }

--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -7,10 +7,15 @@
 
 const versionUtil = require('../util/version');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noReturnValue: 'Do not depend on the return value from {{node}}.render'
+};
 
 module.exports = {
   meta: {
@@ -21,9 +26,7 @@ module.exports = {
       url: docsUrl('no-render-return-value')
     },
 
-    messages: {
-      noReturnValue: 'Do not depend on the return value from {{node}}.render'
-    },
+    messages,
 
     schema: []
   },
@@ -66,9 +69,8 @@ module.exports = {
           || parent.type === 'ArrowFunctionExpression'
           || parent.type === 'AssignmentExpression'
         ) {
-          context.report({
+          report(context, messages.noReturnValue, 'noReturnValue', {
             node: callee,
-            messageId: 'noReturnValue',
             data: {
               node: callee.object.name
             }

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -7,10 +7,15 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noSetState: 'Do not use setState'
+};
 
 module.exports = {
   meta: {
@@ -21,9 +26,7 @@ module.exports = {
       url: docsUrl('no-set-state')
     },
 
-    messages: {
-      noSetState: 'Do not use setState'
-    },
+    messages,
 
     schema: []
   },
@@ -46,19 +49,13 @@ module.exports = {
       let setStateUsage;
       for (let i = 0, j = component.setStateUsages.length; i < j; i++) {
         setStateUsage = component.setStateUsages[i];
-        context.report({
-          node: setStateUsage,
-          messageId: 'noSetState'
+        report(context, messages.noSetState, 'noSetState', {
+          node: setStateUsage
         });
       }
     }
 
-    // --------------------------------------------------------------------------
-    // Public
-    // --------------------------------------------------------------------------
-
     return {
-
       CallExpression(node) {
         const callee = node.callee;
         if (

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -7,10 +7,16 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  thisRefsDeprecated: 'Using this.refs is deprecated.',
+  stringInRefDeprecated: 'Using string literals in ref attributes is deprecated.'
+};
 
 module.exports = {
   meta: {
@@ -21,10 +27,7 @@ module.exports = {
       url: docsUrl('no-string-refs')
     },
 
-    messages: {
-      thisRefsDeprecated: 'Using this.refs is deprecated.',
-      stringInRefDeprecated: 'Using string literals in ref attributes is deprecated.'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -45,11 +48,8 @@ module.exports = {
      * @returns {Boolean} True if we are using refs, false if not.
      */
     function isRefsUsage(node) {
-      return Boolean(
-        (
-          utils.getParentES6Component()
-          || utils.getParentES5Component()
-        )
+      return !!(
+        (utils.getParentES6Component() || utils.getParentES5Component())
         && node.object.type === 'ThisExpression'
         && node.property.name === 'refs'
       );
@@ -61,7 +61,7 @@ module.exports = {
      * @returns {Boolean} True if we are using a ref attribute, false if not.
      */
     function isRefAttribute(node) {
-      return Boolean(
+      return !!(
         node.type === 'JSXAttribute'
         && node.name
         && node.name.name === 'ref'
@@ -74,7 +74,7 @@ module.exports = {
      * @returns {Boolean} True if the node contains a string value, false if not.
      */
     function containsStringLiteral(node) {
-      return Boolean(
+      return !!(
         node.value
         && node.value.type === 'Literal'
         && typeof node.value.value === 'string'
@@ -87,7 +87,7 @@ module.exports = {
      * @returns {Boolean} True if the node contains a string value within a jsx expression, false if not.
      */
     function containsStringExpressionContainer(node) {
-      return Boolean(
+      return !!(
         node.value
         && node.value.type === 'JSXExpressionContainer'
         && node.value.expression
@@ -99,9 +99,8 @@ module.exports = {
     return {
       MemberExpression(node) {
         if (isRefsUsage(node)) {
-          context.report({
-            node,
-            messageId: 'thisRefsDeprecated'
+          report(context, messages.thisRefsDeprecated, 'thisRefsDeprecated', {
+            node
           });
         }
       },
@@ -110,9 +109,8 @@ module.exports = {
           isRefAttribute(node)
           && (containsStringLiteral(node) || containsStringExpressionContainer(node))
         ) {
-          context.report({
-            node,
-            messageId: 'stringInRefDeprecated'
+          report(context, messages.stringInRefDeprecated, 'stringInRefDeprecated', {
+            node
           });
         }
       }

--- a/lib/rules/no-this-in-sfc.js
+++ b/lib/rules/no-this-in-sfc.js
@@ -6,10 +6,15 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noThisInSFC: 'Stateless functional components should not use `this`'
+};
 
 module.exports = {
   meta: {
@@ -20,9 +25,7 @@ module.exports = {
       url: docsUrl('no-this-in-sfc')
     },
 
-    messages: {
-      noThisInSFC: 'Stateless functional components should not use `this`'
-    },
+    messages,
 
     schema: []
   },
@@ -34,9 +37,8 @@ module.exports = {
         if (!component || (component.node && component.node.parent && component.node.parent.type === 'Property')) {
           return;
         }
-        context.report({
-          node,
-          messageId: 'noThisInSFC'
+        report(context, messages.noThisInSFC, 'noThisInSFC', {
+          node
         });
       }
     }

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -7,6 +7,7 @@
 const PROP_TYPES = Object.keys(require('prop-types'));
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -31,6 +32,17 @@ const LIFECYCLE_METHODS = [
   'render'
 ];
 
+const messages = {
+  typoPropTypeChain: 'Typo in prop type chain qualifier: {{name}}',
+  typoPropType: 'Typo in declared prop type: {{name}}',
+  typoStaticClassProp: 'Typo in static class property declaration',
+  typoPropDeclaration: 'Typo in property declaration',
+  typoLifecycleMethod: 'Typo in component lifecycle method declaration: {{actual}} should be {{expected}}',
+  staticLifecycleMethod: 'Lifecycle method should be static: {{method}}',
+  noPropTypesBinding: '`\'prop-types\'` imported without a local `PropTypes` binding.',
+  noReactBinding: '`\'react\'` imported without a local `React` binding.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -40,16 +52,7 @@ module.exports = {
       url: docsUrl('no-typos')
     },
 
-    messages: {
-      typoPropTypeChain: 'Typo in prop type chain qualifier: {{name}}',
-      typoPropType: 'Typo in declared prop type: {{name}}',
-      typoStaticClassProp: 'Typo in static class property declaration',
-      typoPropDeclaration: 'Typo in property declaration',
-      typoLifecycleMethod: 'Typo in component lifecycle method declaration: {{actual}} should be {{expected}}',
-      staticLifecycleMethod: 'Lifecycle method should be static: {{method}}',
-      noPropTypesBinding: '`\'prop-types\'` imported without a local `PropTypes` binding.',
-      noReactBinding: '`\'react\'` imported without a local `React` binding.'
-    },
+    messages,
 
     schema: []
   },
@@ -60,9 +63,8 @@ module.exports = {
 
     function checkValidPropTypeQualifier(node) {
       if (node.name !== 'isRequired') {
-        context.report({
+        report(context, messages.typoPropTypeChain, 'typoPropTypeChain', {
           node,
-          messageId: 'typoPropTypeChain',
           data: {name: node.name}
         });
       }
@@ -70,9 +72,8 @@ module.exports = {
 
     function checkValidPropType(node) {
       if (node.name && !PROP_TYPES.some((propTypeName) => propTypeName === node.name)) {
-        context.report({
+        report(context, messages.typoPropType, 'typoPropType', {
           node,
-          messageId: 'typoPropType',
           data: {name: node.name}
         });
       }
@@ -146,11 +147,11 @@ module.exports = {
       }
       STATIC_CLASS_PROPERTIES.forEach((CLASS_PROP) => {
         if (propertyName && CLASS_PROP.toLowerCase() === propertyName.toLowerCase() && CLASS_PROP !== propertyName) {
-          context.report({
-            node: propertyKey,
-            messageId: isClassProperty
-              ? 'typoStaticClassProp'
-              : 'typoPropDeclaration'
+          const messageId = isClassProperty
+            ? 'typoStaticClassProp'
+            : 'typoPropDeclaration';
+          report(context, messages[messageId], messageId, {
+            node: propertyKey
           });
         }
       });
@@ -168,9 +169,8 @@ module.exports = {
 
       STATIC_LIFECYCLE_METHODS.forEach((method) => {
         if (!node.static && nodeKeyName.toLowerCase() === method.toLowerCase()) {
-          context.report({
+          report(context, messages.staticLifecycleMethod, 'staticLifecycleMethod', {
             node,
-            messageId: 'staticLifecycleMethod',
             data: {
               method: nodeKeyName
             }
@@ -180,9 +180,8 @@ module.exports = {
 
       LIFECYCLE_METHODS.forEach((method) => {
         if (method.toLowerCase() === nodeKeyName.toLowerCase() && method !== nodeKeyName) {
-          context.report({
+          report(context, messages.typoLifecycleMethod, 'typoLifecycleMethod', {
             node,
-            messageId: 'typoLifecycleMethod',
             data: {actual: nodeKeyName, expected: method}
           });
         }
@@ -195,18 +194,16 @@ module.exports = {
           if (node.specifiers.length > 0) {
             propTypesPackageName = node.specifiers[0].local.name;
           } else {
-            context.report({
-              node,
-              messageId: 'noPropTypesBinding'
+            report(context, messages.noPropTypesBinding, 'noPropTypesBinding', {
+              node
             });
           }
         } else if (node.source && node.source.value === 'react') { // import { PropTypes } from "react"
           if (node.specifiers.length > 0) {
             reactPackageName = node.specifiers[0].local.name; // guard against accidental anonymous `import "react"`
           } else {
-            context.report({
-              node,
-              messageId: 'noReactBinding'
+            report(context, messages.noReactBinding, 'noReactBinding', {
+              node
             });
           }
           if (node.specifiers.length >= 1) {

--- a/lib/rules/no-unescaped-entities.js
+++ b/lib/rules/no-unescaped-entities.js
@@ -7,6 +7,7 @@
 
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -29,6 +30,11 @@ const DEFAULTS = [{
   alternatives: ['&#125;']
 }];
 
+const messages = {
+  unescapedEntity: 'HTML entity, `{{entity}}` , must be escaped.',
+  unescapedEntityAlts: '`{{entity}}` can be escaped with {{alts}}.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -38,10 +44,7 @@ module.exports = {
       url: docsUrl('no-unescaped-entities')
     },
 
-    messages: {
-      unescapedEntity: 'HTML entity, `{{entity}}` , must be escaped.',
-      unescapedEntityAlts: '`{{entity}}` can be escaped with {{alts}}.'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -96,20 +99,18 @@ module.exports = {
             const c = rawLine[index];
             if (typeof entities[j] === 'string') {
               if (c === entities[j]) {
-                context.report({
+                report(context, messages.unescapedEntity, 'unescapedEntity', {
                   node,
                   loc: {line: i, column: start + index},
-                  messageId: 'unescapedEntity',
                   data: {
                     entity: entities[j]
                   }
                 });
               }
             } else if (c === entities[j].char) {
-              context.report({
+              report(context, messages.unescapedEntityAlts, 'unescapedEntityAlts', {
                 node,
                 loc: {line: i, column: start + index},
-                messageId: 'unescapedEntityAlts',
                 data: {
                   entity: entities[j].char,
                   alts: entities[j].alternatives.map((alt) => `\`${alt}\``).join(', ')

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -8,6 +8,7 @@
 const has = require('object.hasown/polyfill')();
 const docsUrl = require('../util/docsUrl');
 const versionUtil = require('../util/version');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -211,6 +212,11 @@ function getStandardName(name, context) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  invalidPropOnTag: 'Invalid property \'{{name}}\' found on tag \'{{tagName}}\', but it is only allowed on: {{allowedTags}}',
+  unknownProp: 'Unknown property \'{{name}}\' found, use \'{{standardName}}\' instead'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -221,10 +227,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      invalidPropOnTag: 'Invalid property \'{{name}}\' found on tag \'{{tagName}}\', but it is only allowed on: {{allowedTags}}',
-      unknownProp: 'Unknown property \'{{name}}\' found, use \'{{standardName}}\' instead'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -263,9 +266,8 @@ module.exports = {
         // 1. Some attributes are allowed on some tags only.
         const allowedTags = has(ATTRIBUTE_TAGS_MAP, name) ? ATTRIBUTE_TAGS_MAP[name] : null;
         if (tagName && allowedTags && /[^A-Z]/.test(tagName.charAt(0)) && allowedTags.indexOf(tagName) === -1) {
-          context.report({
+          report(context, messages.invalidPropOnTag, 'invalidPropOnTag', {
             node,
-            messageId: 'invalidPropOnTag',
             data: {
               name,
               tagName,
@@ -282,9 +284,8 @@ module.exports = {
         if (!isTagName(node) || !standardName || standardName === name) {
           return;
         }
-        context.report({
+        report(context, messages.unknownProp, 'unknownProp', {
           node,
-          messageId: 'unknownProp',
           data: {
             name,
             standardName

--- a/lib/rules/no-unsafe.js
+++ b/lib/rules/no-unsafe.js
@@ -9,10 +9,15 @@ const Components = require('../util/Components');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
 const versionUtil = require('../util/version');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  unsafeMethod: '{{method}} is unsafe for use in async rendering. Update the component to use {{newMethod}} instead. {{details}}'
+};
 
 module.exports = {
   meta: {
@@ -23,9 +28,7 @@ module.exports = {
       url: docsUrl('no-unsafe')
     },
 
-    messages: {
-      unsafeMethod: '{{method}} is unsafe for use in async rendering. Update the component to use {{newMethod}} instead. {{details}}'
-    },
+    messages,
 
     schema: [
       {
@@ -105,9 +108,8 @@ module.exports = {
       const newMethod = meta.newMethod;
       const details = meta.details;
 
-      context.report({
+      report(context, messages.unsafeMethod, 'unsafeMethod', {
         node,
-        messageId: 'unsafeMethod',
         data: {
           method,
           newMethod,

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -7,6 +7,7 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Constants
@@ -450,7 +451,9 @@ module.exports = {
           message += COMPONENT_AS_PROPS_INFO;
         }
 
-        context.report({node, message});
+        report(context, message, null, {
+          node
+        });
       }
     }
 

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -10,10 +10,15 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  unusedPropType: '\'{{name}}\' PropType is defined but prop is never used'
+};
 
 module.exports = {
   meta: {
@@ -24,9 +29,7 @@ module.exports = {
       url: docsUrl('no-unused-prop-types')
     },
 
-    messages: {
-      unusedPropType: '\'{{name}}\' PropType is defined but prop is never used'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -128,9 +131,8 @@ module.exports = {
         }
 
         if (prop.node && !isIgnored(prop.fullName) && !isPropUsed(component, prop)) {
-          context.report({
+          report(context, messages.unusedPropType, 'unusedPropType', {
             node: prop.node.key || prop.node,
-            messageId: 'unusedPropType',
             data: {
               name: prop.fullName
             }

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -12,6 +12,7 @@
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 const ast = require('../util/ast');
+const report = require('../util/report');
 
 // Descend through all wrapping TypeCastExpressions and return the expression
 // that was cast.
@@ -72,6 +73,10 @@ function isSetStateCall(node) {
   );
 }
 
+const messages = {
+  unusedStateField: 'Unused state field: \'{{name}}\''
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -81,9 +86,7 @@ module.exports = {
       url: docsUrl('no-unused-state')
     },
 
-    messages: {
-      unusedStateField: 'Unused state field: \'{{name}}\''
-    },
+    messages,
 
     schema: []
   },
@@ -216,9 +219,8 @@ module.exports = {
       for (const node of classInfo.stateFields) {
         const name = getName(node.key);
         if (!classInfo.usedStateFields.has(name)) {
-          context.report({
+          report(context, messages.unusedStateField, 'unusedStateField', {
             node,
-            messageId: 'unusedStateField',
             data: {
               name
             }

--- a/lib/rules/prefer-es6-class.js
+++ b/lib/rules/prefer-es6-class.js
@@ -7,10 +7,16 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  shouldUseES6Class: 'Component should use es6 class instead of createClass',
+  shouldUseCreateClass: 'Component should use createClass instead of es6 class'
+};
 
 module.exports = {
   meta: {
@@ -21,10 +27,7 @@ module.exports = {
       url: docsUrl('prefer-es6-class')
     },
 
-    messages: {
-      shouldUseES6Class: 'Component should use es6 class instead of createClass',
-      shouldUseCreateClass: 'Component should use createClass instead of es6 class'
-    },
+    messages,
 
     schema: [{
       enum: ['always', 'never']
@@ -37,17 +40,15 @@ module.exports = {
     return {
       ObjectExpression(node) {
         if (utils.isES5Component(node) && configuration === 'always') {
-          context.report({
-            node,
-            messageId: 'shouldUseES6Class'
+          report(context, messages.shouldUseES6Class, 'shouldUseES6Class', {
+            node
           });
         }
       },
       ClassDeclaration(node) {
         if (utils.isES6Component(node) && configuration === 'never') {
-          context.report({
-            node,
-            messageId: 'shouldUseCreateClass'
+          report(context, messages.shouldUseCreateClass, 'shouldUseCreateClass', {
+            node
           });
         }
       }

--- a/lib/rules/prefer-exact-props.js
+++ b/lib/rules/prefer-exact-props.js
@@ -9,13 +9,16 @@ const docsUrl = require('../util/docsUrl');
 const propsUtil = require('../util/props');
 const propWrapperUtil = require('../util/propWrapper');
 const variableUtil = require('../util/variable');
-
-const PROP_TYPES_MESSAGE = 'Component propTypes should be exact by using {{exactPropWrappers}}.';
-const FLOW_MESSAGE = 'Component flow props should be set with exact objects.';
+const report = require('../util/report');
 
 // -----------------------------------------------------------------------------
 // Rule Definition
 // -----------------------------------------------------------------------------
+
+const messages = {
+  propTypes: 'Component propTypes should be exact by using {{exactPropWrappers}}.',
+  flow: 'Component flow props should be set with exact objects.'
+};
 
 module.exports = {
   meta: {
@@ -25,6 +28,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('prefer-exact-props')
     },
+    messages,
     schema: []
   },
 
@@ -83,17 +87,15 @@ module.exports = {
     }
 
     function reportPropTypesError(node) {
-      context.report({
+      report(context, messages.propTypes, 'propTypes', {
         node,
-        message: PROP_TYPES_MESSAGE,
         data: getPropTypesErrorMessage()
       });
     }
 
     function reportFlowError(node) {
-      context.report({
-        node,
-        message: FLOW_MESSAGE
+      report(context, messages.flow, 'flow', {
+        node
       });
     }
 

--- a/lib/rules/prefer-read-only-props.js
+++ b/lib/rules/prefer-read-only-props.js
@@ -7,18 +7,30 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 function isFlowPropertyType(node) {
   return node.type === 'ObjectTypeProperty';
 }
 
 function isCovariant(node) {
-  return (node.variance && (node.variance.kind === 'plus')) || (node.parent.parent.parent.id && (node.parent.parent.parent.id.name === '$ReadOnly'));
+  return (node.variance && node.variance.kind === 'plus')
+    || (
+      node.parent
+      && node.parent.parent
+      && node.parent.parent.parent
+      && node.parent.parent.parent.id
+      && node.parent.parent.parent.id.name === '$ReadOnly'
+    );
 }
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  readOnlyProp: 'Prop \'{{name}}\' should be read-only.'
+};
 
 module.exports = {
   meta: {
@@ -30,9 +42,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      readOnlyProp: 'Prop \'{{name}}\' should be read-only.'
-    },
+    messages,
 
     schema: []
   },
@@ -56,9 +66,8 @@ module.exports = {
           }
 
           if (!isCovariant(prop.node)) {
-            context.report({
+            report(context, messages.readOnlyProp, 'readOnlyProp', {
               node: prop.node,
-              messageId: 'readOnlyProp',
               data: {
                 name: propName
               },

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -11,10 +11,15 @@ const Components = require('../util/Components');
 const versionUtil = require('../util/version');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  componentShouldBePure: 'Component should be written as a pure function'
+};
 
 module.exports = {
   meta: {
@@ -25,9 +30,7 @@ module.exports = {
       url: docsUrl('prefer-stateless-function')
     },
 
-    messages: {
-      componentShouldBePure: 'Component should be written as a pure function'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -375,9 +378,8 @@ module.exports = {
           if (list[component].hasSCU) {
             return;
           }
-          context.report({
-            node: list[component].node,
-            messageId: 'componentShouldBePure'
+          report(context, messages.componentShouldBePure, 'componentShouldBePure', {
+            node: list[component].node
           });
         });
       }

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -10,10 +10,15 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  missingPropType: '\'{{name}}\' is missing in props validation'
+};
 
 module.exports = {
   meta: {
@@ -24,9 +29,7 @@ module.exports = {
       url: docsUrl('prop-types')
     },
 
-    messages: {
-      missingPropType: '\'{{name}}\' is missing in props validation'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -172,19 +175,14 @@ module.exports = {
         && !isDeclaredInComponent(component.node, propType.allNames)
       ));
       undeclareds.forEach((propType) => {
-        context.report({
+        report(context, messages.missingPropType, 'missingPropType', {
           node: propType.node,
-          messageId: 'missingPropType',
           data: {
             name: propType.allNames.join('.').replace(/\.__COMPUTED_PROP__/g, '[]')
           }
         });
       });
     }
-
-    // --------------------------------------------------------------------------
-    // Public
-    // --------------------------------------------------------------------------
 
     return {
       'Program:exit'() {

--- a/lib/rules/react-in-jsx-scope.js
+++ b/lib/rules/react-in-jsx-scope.js
@@ -8,10 +8,15 @@
 const variableUtil = require('../util/variable');
 const pragmaUtil = require('../util/pragma');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // -----------------------------------------------------------------------------
 // Rule Definition
 // -----------------------------------------------------------------------------
+
+const messages = {
+  notInScope: '\'{{name}}\' must be in scope when using JSX'
+};
 
 module.exports = {
   meta: {
@@ -22,9 +27,7 @@ module.exports = {
       url: docsUrl('react-in-jsx-scope')
     },
 
-    messages: {
-      notInScope: '\'{{name}}\' must be in scope when using JSX'
-    },
+    messages,
 
     schema: []
   },
@@ -37,9 +40,8 @@ module.exports = {
       if (variableUtil.findVariable(variables, pragma)) {
         return;
       }
-      context.report({
+      report(context, messages.notInScope, 'notInScope', {
         node,
-        messageId: 'notInScope',
         data: {
           name: pragma
         }

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -8,10 +8,16 @@
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 const astUtil = require('../util/ast');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noDefaultWithRequired: 'propType "{{name}}" is required and should not have a defaultProps declaration.',
+  shouldHaveDefault: 'propType "{{name}}" is not required, but has no corresponding defaultProps declaration.'
+};
 
 module.exports = {
   meta: {
@@ -21,10 +27,7 @@ module.exports = {
       url: docsUrl('require-default-props')
     },
 
-    messages: {
-      noDefaultWithRequired: 'propType "{{name}}" is required and should not have a defaultProps declaration.',
-      shouldHaveDefault: 'propType "{{name}}" is not required, but has no corresponding defaultProps declaration.'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -65,9 +68,8 @@ module.exports = {
         }
         if (prop.isRequired) {
           if (forbidDefaultForRequired && defaultProps[propName]) {
-            context.report({
+            report(context, messages.noDefaultWithRequired, 'noDefaultWithRequired', {
               node: prop.node,
-              messageId: 'noDefaultWithRequired',
               data: {name: propName}
             });
           }
@@ -78,9 +80,8 @@ module.exports = {
           return;
         }
 
-        context.report({
+        report(context, messages.shouldHaveDefault, 'shouldHaveDefault', {
           node: prop.node,
-          messageId: 'shouldHaveDefault',
           data: {name: propName}
         });
       });

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -7,6 +7,11 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
+
+const messages = {
+  noShouldComponentUpdate: 'Component is not optimized. Please add a shouldComponentUpdate method.'
+};
 
 module.exports = {
   meta: {
@@ -17,9 +22,7 @@ module.exports = {
       url: docsUrl('require-optimization')
     },
 
-    messages: {
-      noShouldComponentUpdate: 'Component is not optimized. Please add a shouldComponentUpdate method.'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -140,9 +143,8 @@ module.exports = {
      * @param {Object} component The component to process
      */
     function reportMissingOptimization(component) {
-      context.report({
-        node: component.node,
-        messageId: 'noShouldComponentUpdate'
+      report(context, messages.noShouldComponentUpdate, 'noShouldComponentUpdate', {
+        node: component.node
       });
     }
 

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -8,10 +8,15 @@
 const Components = require('../util/Components');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  noRenderReturn: 'Your render method should have a return statement'
+};
 
 module.exports = {
   meta: {
@@ -22,9 +27,7 @@ module.exports = {
       url: docsUrl('require-render-return')
     },
 
-    messages: {
-      noRenderReturn: 'Your render method should have a return statement'
-    },
+    messages,
 
     schema: []
   },
@@ -87,9 +90,8 @@ module.exports = {
           ) {
             return;
           }
-          context.report({
-            node: findRenderMethod(list[component].node),
-            messageId: 'noRenderReturn'
+          report(context, messages.noRenderReturn, 'noRenderReturn', {
+            node: findRenderMethod(list[component].node)
           });
         });
       }

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -7,12 +7,17 @@
 
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
 const optionDefaults = {component: true, html: true};
+
+const messages = {
+  notSelfClosing: 'Empty components are self-closing'
+};
 
 module.exports = {
   meta: {
@@ -24,9 +29,7 @@ module.exports = {
     },
     fixable: 'code',
 
-    messages: {
-      notSelfClosing: 'Empty components are self-closing'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -76,19 +79,13 @@ module.exports = {
       ) && !node.selfClosing && (childrenIsEmpty(node) || childrenIsMultilineSpaces(node));
     }
 
-    // --------------------------------------------------------------------------
-    // Public
-    // --------------------------------------------------------------------------
-
     return {
-
       JSXOpeningElement(node) {
         if (!isShouldBeSelfClosed(node)) {
           return;
         }
-        context.report({
+        report(context, messages.notSelfClosing, 'notSelfClosing', {
           node,
-          messageId: 'notSelfClosing',
           fix(fixer) {
             // Represents the last character of the JSXOpeningElement, the '>' character
             const openingElementEnding = node.range[1] - 1;

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -12,6 +12,7 @@ const arrayIncludes = require('array-includes');
 const Components = require('../util/Components');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 const defaultConfig = {
   order: [
@@ -80,6 +81,10 @@ function getMethodsOrder(userConfig) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  unsortedProps: '{{propA}} should be placed {{position}} {{propB}}'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -89,9 +94,7 @@ module.exports = {
       url: docsUrl('sort-comp')
     },
 
-    messages: {
-      unsortedProps: '{{propA}} should be placed {{position}} {{propB}}'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -308,9 +311,8 @@ module.exports = {
         const indexA = entry[0];
         const indexB = entry[1].closest.ref.index;
 
-        context.report({
+        report(context, messages.unsortedProps, 'unsortedProps', {
           node: nodeA,
-          messageId: 'unsortedProps',
           data: {
             propA: getPropertyName(nodeA),
             propB: getPropertyName(nodeB),

--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -9,10 +9,17 @@ const propsUtil = require('../util/props');
 const docsUrl = require('../util/docsUrl');
 const propWrapperUtil = require('../util/propWrapper');
 // const propTypesSortUtil = require('../util/propTypesSort');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  requiredPropsFirst: 'Required prop types must be listed before all other prop types',
+  callbackPropsLast: 'Callback prop types must be listed after all other prop types',
+  propsNotSorted: 'Prop types declarations should be sorted alphabetically'
+};
 
 module.exports = {
   meta: {
@@ -24,11 +31,7 @@ module.exports = {
     },
     // fixable: 'code',
 
-    messages: {
-      requiredPropsFirst: 'Required prop types must be listed before all other prop types',
-      callbackPropsLast: 'Callback prop types must be listed after all other prop types',
-      propsNotSorted: 'Prop types declarations should be sorted alphabetically'
-    },
+    messages,
 
     schema: [{
       type: 'object',
@@ -139,9 +142,8 @@ module.exports = {
           }
           if (!previousIsRequired && currentIsRequired) {
             // Encountered a non-required prop after a required prop
-            context.report({
-              node: curr,
-              messageId: 'requiredPropsFirst'
+            report(context, messages.requiredPropsFirst, 'requiredPropsFirst', {
+              node: curr
             //  fix
             });
             return curr;
@@ -155,9 +157,8 @@ module.exports = {
           }
           if (previousIsCallback && !currentIsCallback) {
             // Encountered a non-callback prop after a callback prop
-            context.report({
-              node: prev,
-              messageId: 'callbackPropsLast'
+            report(context, messages.callbackPropsLast, 'callbackPropsLast', {
+              node: prev
               // fix
             });
             return prev;
@@ -165,9 +166,8 @@ module.exports = {
         }
 
         if (!noSortAlphabetically && currentPropName < prevPropName) {
-          context.report({
-            node: curr,
-            messageId: 'propsNotSorted'
+          report(context, messages.propsNotSorted, 'propsNotSorted', {
+            node: curr
             // fix
           });
           return prev;

--- a/lib/rules/state-in-constructor.js
+++ b/lib/rules/state-in-constructor.js
@@ -7,10 +7,16 @@
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  stateInitConstructor: 'State initialization should be in a constructor',
+  stateInitClassProp: 'State initialization should be in a class property'
+};
 
 module.exports = {
   meta: {
@@ -21,10 +27,7 @@ module.exports = {
       url: docsUrl('state-in-constructor')
     },
 
-    messages: {
-      stateInitConstructor: 'State initialization should be in a constructor',
-      stateInitClassProp: 'State initialization should be in a class property'
-    },
+    messages,
 
     schema: [{
       enum: ['always', 'never']
@@ -41,9 +44,8 @@ module.exports = {
           && node.key.name === 'state'
           && utils.getParentES6Component()
         ) {
-          context.report({
-            node,
-            messageId: 'stateInitConstructor'
+          report(context, messages.stateInitConstructor, 'stateInitConstructor', {
+            node
           });
         }
       },
@@ -54,9 +56,8 @@ module.exports = {
           && utils.inConstructor()
           && utils.getParentES6Component()
         ) {
-          context.report({
-            node,
-            messageId: 'stateInitClassProp'
+          report(context, messages.stateInitClassProp, 'stateInitClassProp', {
+            node
           });
         }
       }

--- a/lib/rules/static-property-placement.js
+++ b/lib/rules/static-property-placement.js
@@ -10,6 +10,7 @@ const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 const astUtil = require('../util/ast');
 const propsUtil = require('../util/props');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Positioning Options
@@ -47,6 +48,12 @@ const schemaProperties = fromEntries(classProperties.map((property) => [property
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const messages = {
+  notStaticClassProp: '\'{{name}}\' should be declared as a static class property.',
+  notGetterClassFunc: '\'{{name}}\' should be declared as a static getter class function.',
+  declareOutsideClass: '\'{{name}}\' should be declared outside the class body.'
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -57,11 +64,7 @@ module.exports = {
     },
     fixable: null, // or 'code' or 'whitespace'
 
-    messages: {
-      notStaticClassProp: '\'{{name}}\' should be declared as a static class property.',
-      notGetterClassFunc: '\'{{name}}\' should be declared as a static getter class function.',
-      declareOutsideClass: '\'{{name}}\' should be declared outside the class body.'
-    },
+    messages,
 
     schema: [
       {enum: POSITION_SETTINGS},
@@ -125,10 +128,9 @@ module.exports = {
 
       // If name is set but the configured rule does not match expected then report error
       if (name && config[name] !== expectedRule) {
-        // Report the error
-        context.report({
+        const messageId = ERROR_MESSAGES[config[name]];
+        report(context, messages[messageId], messageId, {
           node,
-          messageId: ERROR_MESSAGES[config[name]],
           data: {name}
         });
       }

--- a/lib/rules/style-prop-object.js
+++ b/lib/rules/style-prop-object.js
@@ -8,10 +8,15 @@
 const variableUtil = require('../util/variable');
 const docsUrl = require('../util/docsUrl');
 const isCreateElement = require('../util/isCreateElement');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
+const messages = {
+  stylePropNotObject: 'Style prop value must be an object'
+};
 
 module.exports = {
   meta: {
@@ -22,9 +27,7 @@ module.exports = {
       url: docsUrl('style-prop-object')
     },
 
-    messages: {
-      stylePropNotObject: 'Style prop value must be an object'
-    },
+    messages,
 
     schema: [
       {
@@ -65,9 +68,8 @@ module.exports = {
       }
 
       if (isNonNullaryLiteral(variable.defs[0].node.init)) {
-        context.report({
-          node,
-          messageId: 'stylePropNotObject'
+        report(context, messages.stylePropNotObject, 'stylePropNotObject', {
+          node
         });
       }
     }
@@ -94,9 +96,8 @@ module.exports = {
               if (style.value.type === 'Identifier') {
                 checkIdentifiers(style.value);
               } else if (isNonNullaryLiteral(style.value)) {
-                context.report({
-                  node: style.value,
-                  messageId: 'stylePropNotObject'
+                report(context, messages.stylePropNotObject, 'stylePropNotObject', {
+                  node: style.value
                 });
               }
             }
@@ -124,9 +125,8 @@ module.exports = {
         }
 
         if (node.value.type !== 'JSXExpressionContainer' || isNonNullaryLiteral(node.value.expression)) {
-          context.report({
-            node,
-            messageId: 'stylePropNotObject'
+          report(context, messages.stylePropNotObject, 'stylePropNotObject', {
+            node
           });
         } else if (node.value.expression.type === 'Identifier') {
           checkIdentifiers(node.value.expression);

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -10,6 +10,7 @@ const has = require('object.hasown/polyfill')();
 
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -44,6 +45,8 @@ function isVoidDOMElement(elementName) {
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const noChildrenInVoidEl = 'Void DOM element <{{element}} /> cannot receive children.';
+
 module.exports = {
   meta: {
     docs: {
@@ -54,7 +57,7 @@ module.exports = {
     },
 
     messages: {
-      noChildrenInVoidEl: 'Void DOM element <{{element}} /> cannot receive children.'
+      noChildrenInVoidEl
     },
 
     schema: []
@@ -71,9 +74,8 @@ module.exports = {
 
       if (node.children.length > 0) {
         // e.g. <br>Foo</br>
-        context.report({
+        report(context, noChildrenInVoidEl, 'noChildrenInVoidEl', {
           node,
-          messageId: 'noChildrenInVoidEl',
           data: {
             element: elementName
           }
@@ -92,9 +94,8 @@ module.exports = {
 
       if (hasChildrenAttributeOrDanger) {
         // e.g. <br children="Foo" />
-        context.report({
+        report(context, noChildrenInVoidEl, 'noChildrenInVoidEl', {
           node,
-          messageId: 'noChildrenInVoidEl',
           data: {
             element: elementName
           }
@@ -132,9 +133,8 @@ module.exports = {
       const firstChild = args[2];
       if (firstChild) {
         // e.g. React.createElement('br', undefined, 'Foo')
-        context.report({
+        report(context, noChildrenInVoidEl, 'noChildrenInVoidEl', {
           node,
-          messageId: 'noChildrenInVoidEl',
           data: {
             element: elementName
           }
@@ -153,9 +153,8 @@ module.exports = {
 
       if (hasChildrenPropOrDanger) {
         // e.g. React.createElement('br', { children: 'Foo' })
-        context.report({
+        report(context, noChildrenInVoidEl, 'noChildrenInVoidEl', {
           node,
-          messageId: 'noChildrenInVoidEl',
           data: {
             element: elementName
           }

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const docsUrl = require('./docsUrl');
+const report = require('./report');
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -24,6 +25,10 @@ function mapTitle(methodName) {
   return `no-${title}-set-state`;
 }
 
+const messages = {
+  noSetState: 'Do not use setState in {{name}}'
+};
+
 function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
   return {
     meta: {
@@ -34,9 +39,7 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
         url: docsUrl(mapTitle(methodName))
       },
 
-      messages: {
-        noSetState: 'Do not use setState in {{name}}'
-      },
+      messages,
 
       schema: [{
         enum: ['disallow-in-func']
@@ -86,9 +89,8 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
             ) {
               return false;
             }
-            context.report({
+            report(context, messages.noSetState, 'noSetState', {
               node: callee,
-              messageId: 'noSetState',
               data: {
                 name: ancestor.key.name
               }

--- a/lib/util/report.js
+++ b/lib/util/report.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
+
+module.exports = function report(context, message, messageId, data) {
+  context.report(
+    Object.assign(
+      messageId && semver.satisfies(eslintPkg.version, '>= 4.15') ? {messageId} : {message},
+      data
+    )
+  );
+};

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "object.values": "^1.1.4",
     "prop-types": "^15.7.2",
     "resolve": "^2.0.0-next.3",
+    "semver": "^6.3.0",
     "string.prototype.matchall": "^4.0.5"
   },
   "devDependencies": {
@@ -55,11 +56,11 @@
     "eslint-plugin-import": "^2.24.2",
     "eslint-remote-tester": "^1.3.0",
     "eslint-remote-tester-repositories": "^0.0.3",
+    "eslint-scope": "^3.7.3",
     "espree": "^3.5.4",
     "istanbul": "^0.4.5",
     "markdown-magic": "^2.5.2",
     "mocha": "^5.2.0",
-    "semver": "^6.3.0",
     "sinon": "^7.5.0",
     "typescript": "^3.9.9",
     "typescript-eslint-parser": "^20.1.1"

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -931,15 +931,11 @@ ruleTester.run('display-name', rule, {
     errors: [{
       messageId: 'noDisplayName',
       line: 2,
-      column: 22,
-      endLine: 6,
-      endColumn: 8
+      column: 22
     }, {
       messageId: 'noDisplayName',
       line: 9,
-      column: 16,
-      endLine: 11,
-      endColumn: 11
+      column: 16
     }]
   }, {
     code: `

--- a/tests/lib/rules/forbid-dom-props.js
+++ b/tests/lib/rules/forbid-dom-props.js
@@ -24,7 +24,7 @@ const parserOptions = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({parserOptions});
-ruleTester.run('forbid-element-props', rule, {
+ruleTester.run('forbid-dom-props', rule, {
 
   valid: [{
     code: [

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -12,6 +12,8 @@
 // ------------------------------------------------------------------------------
 
 const RuleTester = require('eslint').RuleTester;
+const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
 const rule = require('../../../lib/rules/jsx-curly-brace-presence');
 
 const parsers = require('../../helpers/parsers');
@@ -30,7 +32,7 @@ const parserOptions = {
 
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('jsx-curly-brace-presence', rule, {
-  valid: [
+  valid: [].concat(
     {
       code: '<App {...props}>foo</App>'
     },
@@ -418,26 +420,28 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
     {
       code: `<App>{/* comment */}</App>`
     },
-    {
-      code: `<App>{/* comment */ <Foo />}</App>`
-    },
-    {
-      code: `<App>{/* comment */ 'foo'}</App>`
-    },
-    {
-      code: `<App prop={/* comment */ 'foo'} />`
-    },
-    {
-      code: `
-        <App>
-          {
-            // comment
-            <Foo />
-          }
-        </App>
-      `
-    }
-  ],
+    (semver.satisfies(eslintPkg.version, '> 3') ? [
+      {
+        code: `<App>{/* comment */ <Foo />}</App>`
+      },
+      {
+        code: `<App>{/* comment */ 'foo'}</App>`
+      },
+      {
+        code: `<App prop={/* comment */ 'foo'} />`
+      },
+      {
+        code: `
+          <App>
+            {
+              // comment
+              <Foo />
+            }
+          </App>
+        `
+      }
+    ] : [])
+  ),
 
   invalid: [
     {

--- a/tests/lib/rules/jsx-props-no-multi-spaces.js
+++ b/tests/lib/rules/jsx-props-no-multi-spaces.js
@@ -10,6 +10,8 @@
 // ------------------------------------------------------------------------------
 
 const RuleTester = require('eslint').RuleTester;
+const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
 const rule = require('../../../lib/rules/jsx-props-no-multi-spaces');
 
 const parsers = require('../../helpers/parsers');
@@ -28,7 +30,7 @@ const parserOptions = {
 
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('jsx-props-no-multi-spaces', rule, {
-  valid: [{
+  valid: [].concat({
     code: [
       '<App />'
     ].join('\n')
@@ -85,7 +87,7 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
         type="button"
       />
     `
-  }, {
+  }, (semver.satisfies(eslintPkg.version, '> 3') ? [{
     code: `
       <button
         title="Some button"
@@ -129,9 +131,9 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
        type="button"
      />
    `
-  }],
+  }] : [])),
 
-  invalid: [{
+  invalid: [].concat({
     code: [
       '<App  foo />'
     ].join('\n'),
@@ -240,7 +242,7 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
       messageId: 'noLineGap',
       data: {prop1: 'onClick', prop2: 'type'}
     }]
-  }, {
+  }, (semver.satisfies(eslintPkg.version, '> 3') ? [{
     code: `
       <button
         title="Some button"
@@ -302,5 +304,5 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
       messageId: 'noLineGap',
       data: {prop1: 'onClick', prop2: 'type'}
     }]
-  }]
+  }] : []))
 });

--- a/tests/lib/rules/no-namespace.js
+++ b/tests/lib/rules/no-namespace.js
@@ -25,7 +25,7 @@ const parserOptions = {
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({parserOptions});
-ruleTester.run('jsx-no-namespace', rule, {
+ruleTester.run('no-namespace', rule, {
   valid: [{
     code: '<testcomponent />'
   }, {
@@ -78,51 +78,51 @@ ruleTester.run('jsx-no-namespace', rule, {
 
   invalid: [{
     code: '<ns:testcomponent />',
-    errors: [{message: 'React component ns:testcomponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component ns:testcomponent must not be in a namespace, as React does not support them'}]
   }, {
     code: 'React.createElement("ns:testcomponent")',
-    errors: [{message: 'React component ns:testcomponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component ns:testcomponent must not be in a namespace, as React does not support them'}]
   }, {
     code: '<ns:testComponent />',
-    errors: [{message: 'React component ns:testComponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component ns:testComponent must not be in a namespace, as React does not support them'}]
   }, {
     code: 'React.createElement("ns:testComponent")',
-    errors: [{message: 'React component ns:testComponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component ns:testComponent must not be in a namespace, as React does not support them'}]
   }, {
     code: '<ns:test_component />',
-    errors: [{message: 'React component ns:test_component must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component ns:test_component must not be in a namespace, as React does not support them'}]
   }, {
     code: 'React.createElement("ns:test_component")',
-    errors: [{message: 'React component ns:test_component must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component ns:test_component must not be in a namespace, as React does not support them'}]
   }, {
     code: '<ns:TestComponent />',
-    errors: [{message: 'React component ns:TestComponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component ns:TestComponent must not be in a namespace, as React does not support them'}]
   }, {
     code: 'React.createElement("ns:TestComponent")',
-    errors: [{message: 'React component ns:TestComponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component ns:TestComponent must not be in a namespace, as React does not support them'}]
   }, {
     code: '<Ns:testcomponent />',
-    errors: [{message: 'React component Ns:testcomponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component Ns:testcomponent must not be in a namespace, as React does not support them'}]
   }, {
     code: 'React.createElement("Ns:testcomponent")',
-    errors: [{message: 'React component Ns:testcomponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component Ns:testcomponent must not be in a namespace, as React does not support them'}]
   }, {
     code: '<Ns:testComponent />',
-    errors: [{message: 'React component Ns:testComponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component Ns:testComponent must not be in a namespace, as React does not support them'}]
   }, {
     code: 'React.createElement("Ns:testComponent")',
-    errors: [{message: 'React component Ns:testComponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component Ns:testComponent must not be in a namespace, as React does not support them'}]
   }, {
     code: '<Ns:test_component />',
-    errors: [{message: 'React component Ns:test_component must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component Ns:test_component must not be in a namespace, as React does not support them'}]
   }, {
     code: 'React.createElement("Ns:test_component")',
-    errors: [{message: 'React component Ns:test_component must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component Ns:test_component must not be in a namespace, as React does not support them'}]
   }, {
     code: '<Ns:TestComponent />',
-    errors: [{message: 'React component Ns:TestComponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component Ns:TestComponent must not be in a namespace, as React does not support them'}]
   }, {
     code: 'React.createElement("Ns:TestComponent")',
-    errors: [{message: 'React component Ns:TestComponent must not be in a namespace as React does not support them'}]
+    errors: [{message: 'React component Ns:TestComponent must not be in a namespace, as React does not support them'}]
   }]
 });

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -9,8 +9,9 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const babelEslintVersion = require('babel-eslint/package.json').version;
 const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
+const babelEslintVersion = require('babel-eslint/package.json').version;
 const RuleTester = require('eslint').RuleTester;
 
 const rule = require('../../../lib/rules/no-unused-prop-types');
@@ -5597,7 +5598,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         message: '\'person\' PropType is defined but prop is never used'
       }],
       parser: parsers.BABEL_ESLINT
-    }, {
+    }, (semver.satisfies(eslintPkg.version, '> 3') ? [{
       code: `
         function higherOrderComponent<P: { foo: string }>() {
           return class extends React.Component<P> {
@@ -5611,7 +5612,7 @@ ruleTester.run('no-unused-prop-types', rule, {
         message: '\'foo\' PropType is defined but prop is never used'
       }],
       parser: parsers.BABEL_ESLINT
-    }, {
+    }] : []), {
       // issue #1506
       code: [
         'class MyComponent extends React.Component {',

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -9,8 +9,9 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
-const babelEslintVersion = require('babel-eslint/package.json').version;
 const semver = require('semver');
+const eslintPkg = require('eslint/package.json').version;
+const babelEslintVersion = require('babel-eslint/package.json').version;
 const RuleTester = require('eslint').RuleTester;
 
 const rule = require('../../../lib/rules/prop-types');
@@ -5456,7 +5457,7 @@ ruleTester.run('prop-types', rule, {
         data: {name: 'bar'}
       }],
       parser: parsers.BABEL_ESLINT
-    }, {
+    }, (semver.satisfies(eslintPkg.version, '> 3') ? [{
       code: `
         function higherOrderComponent<P: { foo: string }>() {
           return class extends React.Component<P> {
@@ -5490,7 +5491,7 @@ ruleTester.run('prop-types', rule, {
         data: {name: 'bar'}
       }],
       parser: parsers.BABEL_ESLINT
-    }, {
+    }] : []), {
       code: `
         type PropsA = {foo: string };
         type PropsB = { bar: string };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
     "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     "alwaysStrict": false,                 /* Parse in strict mode and emit "use strict" for each source file. */
+    "resolveJsonModule": true
   },
   "include": ["lib"],
 }


### PR DESCRIPTION
already seems do not work in ESLint v3. and CI isn't checking ESLint v3.

<details><summary>errors</summary>
4245 passing (5s)
  1 failing

  1) jsx-no-undef
       valid
         /*eslint no-undef:1*/ var React, App; React.render(<App />);:
     TypeError: Cannot read property 'variables' of null
      at checkIdentifierInJSX (lib/rules/jsx-no-undef.js:9:2040)
      at EventEmitter.JSXOpeningElement (lib/rules/jsx-no-undef.js:9:4242)
      at NodeEventGenerator.applySelector (node_modules/eslint/lib/util/node-event-generator.js:265:26)
      at NodeEventGenerator.applySelectors (node_modules/eslint/lib/util/node-event-generator.js:294:22)
      at NodeEventGenerator.enterNode (node_modules/eslint/lib/util/node-event-generator.js:308:14)
      at CodePathAnalyzer.enterNode (node_modules/eslint/lib/code-path-analysis/code-path-analyzer.js:602:23)
      at CommentEventGenerator.enterNode (node_modules/eslint/lib/util/comment-event-generator.js:98:23)
      at Traverser.enter (node_modules/eslint/lib/eslint.js:929:36)
      at Traverser.__execute (node_modules/estraverse/estraverse.js:330:31)
      at Traverser.traverse (node_modules/estraverse/estraverse.js:434:28)
      at Traverser.traverse (node_modules/eslint/lib/util/traverser.js:31:22)
      at EventEmitter.module.exports.api.verify (node_modules/eslint/lib/eslint.js:926:23)
      at runRuleForItem (node_modules/eslint/lib/testers/rule-tester.js:387:38)
      at testValidTemplate (node_modules/eslint/lib/testers/rule-tester.js:420:28)
      at Context.<anonymous> (node_modules/eslint/lib/testers/rule-tester.js:548:25)
      at processImmediate (internal/timers.js:439:21)
</details>