### PR TITLE
Small visual inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Enable the rules that you would like to use.
 * [react/jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md): Validate closing bracket location in JSX (fixable)
 * [react/jsx-closing-tag-location](docs/rules/jsx-closing-tag-location.md): Validate closing tag location for multiline JSX (fixable)
 * [react/jsx-curly-brace-presence](docs/rules/jsx-curly-brace-presence.md): Disallow unnecessary JSX expressions when literals alone are sufficient or enfore JSX expressions on literals in JSX children or attributes (fixable)
-* [react/jsx-curly-newline](docs/rules/jsx-curly-newline.md): enforce consistent line breaks inside jsx curly (fixable)
+* [react/jsx-curly-newline](docs/rules/jsx-curly-newline.md): Enforce consistent line breaks inside jsx curly (fixable)
 * [react/jsx-curly-spacing](docs/rules/jsx-curly-spacing.md): Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
 * [react/jsx-equals-spacing](docs/rules/jsx-equals-spacing.md): Disallow or enforce spaces around equal signs in JSX attributes (fixable)
 * [react/jsx-filename-extension](docs/rules/jsx-filename-extension.md): Restrict file extensions that may contain JSX

--- a/lib/rules/jsx-curly-newline.js
+++ b/lib/rules/jsx-curly-newline.js
@@ -38,7 +38,7 @@ module.exports = {
     type: 'layout',
 
     docs: {
-      description: 'enforce consistent line breaks inside jsx curly',
+      description: 'Enforce consistent line breaks inside jsx curly',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-curly-newline')


### PR DESCRIPTION
Everywhere else it starts with capital letter