### PR TITLE
[Fix] `self-closing-comp`: consider JSXMemberExpression as component too

### DIFF
--- a/docs/rules/self-closing-comp.md
+++ b/docs/rules/self-closing-comp.md
@@ -10,6 +10,8 @@ The following patterns are considered warnings:
 
 ```jsx
 var HelloJohn = <Hello name="John"></Hello>;
+
+var HelloJohnCompound = <Hello.Compound name="John"></Hello.Compound>;
 ```
 
 The following patterns are **not** considered warnings:
@@ -21,7 +23,11 @@ var intentionalSpace = <div>{' '}</div>;
 
 var HelloJohn = <Hello name="John" />;
 
+var HelloJohnCompound = <Hello.Compound name="John" />;
+
 var Profile = <Hello name="John"><img src="picture.png" /></Hello>;
+
+var ProfileCompound = <Hello.Compound name="John"><img src="picture.png" /></Hello.Compound>;
 
 var HelloSpace = <Hello>{' '}</Hello>;
 ```
@@ -58,7 +64,11 @@ var intentionalSpace = <div>{' '}</div>;
 
 var HelloJohn = <Hello name="John" />;
 
+var HelloJohnCompound = <Hello.Compound name="John" />;
+
 var Profile = <Hello name="John"><img src="picture.png" /></Hello>;
+
+var ProfileCompound = <Hello.Compound name="John"><img src="picture.png" /></Hello.Compound>;
 ```
 
 ### `html`

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -42,7 +42,11 @@ module.exports = {
 
   create(context) {
     function isComponent(node) {
-      return node.name && node.name.type === 'JSXIdentifier' && !jsxUtil.isDOMComponent(node);
+      return (
+        node.name &&
+        (node.name.type === 'JSXIdentifier' || node.name.type === 'JSXMemberExpression') &&
+        !jsxUtil.isDOMComponent(node)
+      );
     }
 
     function childrenIsEmpty(node) {

--- a/tests/lib/rules/self-closing-comp.js
+++ b/tests/lib/rules/self-closing-comp.js
@@ -31,7 +31,11 @@ ruleTester.run('self-closing-comp', rule, {
     {
       code: 'var HelloJohn = <Hello name="John" />;'
     }, {
+      code: 'var HelloJohn = <Hello.Compound name="John" />;'
+    }, {
       code: 'var Profile = <Hello name="John"><img src="picture.png" /></Hello>;'
+    }, {
+      code: 'var Profile = <Hello.Compound name="John"><img src="picture.png" /></Hello.Compound>;'
     }, {
       code: `
         <Hello>
@@ -39,9 +43,19 @@ ruleTester.run('self-closing-comp', rule, {
         </Hello>
       `
     }, {
+      code: `
+        <Hello.Compound>
+          <Hello.Compound name="John" />
+        </Hello.Compound>
+      `
+    }, {
       code: 'var HelloJohn = <Hello name="John"> </Hello>;'
     }, {
+      code: 'var HelloJohn = <Hello.Compound name="John"> </Hello.Compound>;'
+    }, {
       code: 'var HelloJohn = <Hello name="John">        </Hello>;'
+    }, {
+      code: 'var HelloJohn = <Hello.Compound name="John">        </Hello.Compound>;'
     }, {
       code: 'var HelloJohn = <div>&nbsp;</div>;'
     }, {
@@ -49,16 +63,31 @@ ruleTester.run('self-closing-comp', rule, {
     }, {
       code: 'var HelloJohn = <Hello name="John">&nbsp;</Hello>;'
     }, {
+      code: 'var HelloJohn = <Hello.Compound name="John">&nbsp;</Hello.Compound>;'
+    }, {
       code: 'var HelloJohn = <Hello name="John" />;',
       options: []
     }, {
+      code: 'var HelloJohn = <Hello.Compound name="John" />;',
+      options: []
+    }, {
       code: 'var Profile = <Hello name="John"><img src="picture.png" /></Hello>;',
+      options: []
+    }, {
+      code: 'var Profile = <Hello.Compound name="John"><img src="picture.png" /></Hello.Compound>;',
       options: []
     }, {
       code: `
         <Hello>
           <Hello name="John" />
         </Hello>
+      `,
+      options: []
+    }, {
+      code: `
+        <Hello.Compound>
+          <Hello.Compound name="John" />
+        </Hello.Compound>
       `,
       options: []
     }, {
@@ -77,13 +106,25 @@ ruleTester.run('self-closing-comp', rule, {
       code: 'var HelloJohn = <Hello name="John">&nbsp;</Hello>;',
       options: []
     }, {
+      code: 'var HelloJohn = <Hello.Compound name="John">&nbsp;</Hello.Compound>;',
+      options: []
+    }, {
       code: 'var HelloJohn = <Hello name="John"></Hello>;',
+      options: [{component: false}]
+    }, {
+      code: 'var HelloJohn = <Hello.Compound name="John"></Hello.Compound>;',
       options: [{component: false}]
     }, {
       code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
       options: [{component: false}]
     }, {
+      code: 'var HelloJohn = <Hello.Compound name="John">\n</Hello.Compound>;',
+      options: [{component: false}]
+    }, {
       code: 'var HelloJohn = <Hello name="John"> </Hello>;',
+      options: [{component: false}]
+    }, {
+      code: 'var HelloJohn = <Hello.Compound name="John"> </Hello.Compound>;',
       options: [{component: false}]
     }, {
       code: 'var contentContainer = <div className="content" />;',
@@ -122,8 +163,20 @@ ruleTester.run('self-closing-comp', rule, {
         message: 'Empty components are self-closing'
       }]
     }, {
+      code: 'var CompoundHelloJohn = <Hello.Compound name="John"></Hello.Compound>;',
+      output: 'var CompoundHelloJohn = <Hello.Compound name="John" />;',
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
       code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
       output: 'var HelloJohn = <Hello name="John" />;',
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var HelloJohn = <Hello.Compound name="John">\n</Hello.Compound>;',
+      output: 'var HelloJohn = <Hello.Compound name="John" />;',
       errors: [{
         message: 'Empty components are self-closing'
       }]
@@ -135,8 +188,22 @@ ruleTester.run('self-closing-comp', rule, {
         message: 'Empty components are self-closing'
       }]
     }, {
+      code: 'var HelloJohn = <Hello.Compound name="John"></Hello.Compound>;',
+      output: 'var HelloJohn = <Hello.Compound name="John" />;',
+      options: [],
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
       code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
       output: 'var HelloJohn = <Hello name="John" />;',
+      options: [],
+      errors: [{
+        message: 'Empty components are self-closing'
+      }]
+    }, {
+      code: 'var HelloJohn = <Hello.Compound name="John">\n</Hello.Compound>;',
+      output: 'var HelloJohn = <Hello.Compound name="John" />;',
       options: [],
       errors: [{
         message: 'Empty components are self-closing'


### PR DESCRIPTION
#### PR checklist

   * [ ]  Addresses an existing issue

   * [x]  bugfix

   * [x]  Includes tests

   * [X]  Documentation update


#### Overview of change:

[Compound components ](https://blog.bitsrc.io/understanding-compound-components-in-react-23c4b84535b5) syntax was not considered in `self-closing-comp` rule. This PR include this syntax in the rule by adding `JSXMemberExpression` as valid components to be checked.