### PR TITLE
[eslint] change `operator-linebreak` option for ternary operators

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,6 @@
           "ignoreTemplateLiterals": true,
           "ignoreComments": true,
         }],
-        "operator-linebreak": [2, "after"],
         "consistent-return": 0,
 
         "prefer-destructuring": [2, { "array": false, "object": false }, { "enforceForRenamedProperties": false }],

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -117,9 +117,9 @@ module.exports = {
      */
     function flowCheck(prop) {
       return (
-        prop.type === 'ObjectTypeProperty' &&
-        prop.value.type === 'BooleanTypeAnnotation' &&
-        rule.test(getPropName(prop)) === false
+        prop.type === 'ObjectTypeProperty'
+        && prop.value.type === 'BooleanTypeAnnotation'
+        && rule.test(getPropName(prop)) === false
       );
     }
 
@@ -131,9 +131,9 @@ module.exports = {
     function regularCheck(prop) {
       const propKey = getPropKey(prop);
       return (
-        propKey &&
-        propTypeNames.indexOf(propKey) >= 0 &&
-        rule.test(getPropName(prop)) === false
+        propKey
+        && propTypeNames.indexOf(propKey) >= 0
+        && rule.test(getPropName(prop)) === false
       );
     }
 
@@ -144,8 +144,8 @@ module.exports = {
      */
     function nestedPropTypes(prop) {
       return (
-        prop.type === 'Property' &&
-        prop.value.type === 'CallExpression'
+        prop.type === 'Property'
+        && prop.value.type === 'CallExpression'
       );
     }
 
@@ -222,9 +222,9 @@ module.exports = {
           return;
         }
         if (
-          node.value &&
-          node.value.type === 'CallExpression' &&
-          propWrapperUtil.isPropWrapperFunction(
+          node.value
+          && node.value.type === 'CallExpression'
+          && propWrapperUtil.isPropWrapperFunction(
             context,
             context.getSourceCode().getText(node.value.callee)
           )
@@ -249,8 +249,8 @@ module.exports = {
         }
         const right = node.parent.right;
         if (
-          right.type === 'CallExpression' &&
-          propWrapperUtil.isPropWrapperFunction(
+          right.type === 'CallExpression'
+          && propWrapperUtil.isPropWrapperFunction(
             context,
             context.getSourceCode().getText(right.callee)
           )
@@ -292,10 +292,10 @@ module.exports = {
         Object.keys(list).forEach((component) => {
           // If this is a functional component that uses a global type, check it
           if (
-            list[component].node.type === 'FunctionDeclaration' &&
-            list[component].node.params &&
-            list[component].node.params.length &&
-            list[component].node.params[0].typeAnnotation
+            list[component].node.type === 'FunctionDeclaration'
+            && list[component].node.params
+            && list[component].node.params.length
+            && list[component].node.params[0].typeAnnotation
           ) {
             const typeNode = list[component].node.params[0].typeAnnotation;
             const annotation = typeNode.typeAnnotation;

--- a/lib/rules/button-has-type.js
+++ b/lib/rules/button-has-type.js
@@ -16,12 +16,12 @@ const pragmaUtil = require('../util/pragma');
 
 function isCreateElement(node, context) {
   const pragma = pragmaUtil.getFromContext(context);
-  return node.callee &&
-    node.callee.type === 'MemberExpression' &&
-    node.callee.property.name === 'createElement' &&
-    node.callee.object &&
-    node.callee.object.name === pragma &&
-    node.arguments.length > 0;
+  return node.callee
+    && node.callee.type === 'MemberExpression'
+    && node.callee.property.name === 'createElement'
+    && node.callee.object
+    && node.callee.object.name === pragma
+    && node.arguments.length > 0;
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -85,14 +85,14 @@ module.exports = {
     function handleClassUsage(node) {
       // this.props.Aprop || this.context.aProp || this.state.aState
       const isPropUsed = (
-        node.object.type === 'MemberExpression' && node.object.object.type === 'ThisExpression' &&
-        (node.object.property.name === 'props' || node.object.property.name === 'context' || node.object.property.name === 'state') &&
-        !isAssignmentLHS(node)
+        node.object.type === 'MemberExpression' && node.object.object.type === 'ThisExpression'
+        && (node.object.property.name === 'props' || node.object.property.name === 'context' || node.object.property.name === 'state')
+        && !isAssignmentLHS(node)
       );
 
       if (
-        isPropUsed && configuration === 'always' &&
-        !(ignoreClassFields && isInClassProperty(node))
+        isPropUsed && configuration === 'always'
+        && !(ignoreClassFields && isInClassProperty(node))
       ) {
         context.report({
           node,
@@ -140,8 +140,8 @@ module.exports = {
         }
 
         if (
-          classComponent && destructuringClass && configuration === 'never' &&
-          !(ignoreClassFields && node.parent.type === 'ClassProperty')
+          classComponent && destructuringClass && configuration === 'never'
+          && !(ignoreClassFields && node.parent.type === 'ClassProperty')
         ) {
           context.report({
             node,

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -71,45 +71,45 @@ module.exports = {
      */
     function hasTranspilerName(node) {
       const namedObjectAssignment = (
-        node.type === 'ObjectExpression' &&
-        node.parent &&
-        node.parent.parent &&
-        node.parent.parent.type === 'AssignmentExpression' &&
-        (
-          !node.parent.parent.left.object ||
-          node.parent.parent.left.object.name !== 'module' ||
-          node.parent.parent.left.property.name !== 'exports'
+        node.type === 'ObjectExpression'
+        && node.parent
+        && node.parent.parent
+        && node.parent.parent.type === 'AssignmentExpression'
+        && (
+          !node.parent.parent.left.object
+          || node.parent.parent.left.object.name !== 'module'
+          || node.parent.parent.left.property.name !== 'exports'
         )
       );
       const namedObjectDeclaration = (
-        node.type === 'ObjectExpression' &&
-        node.parent &&
-        node.parent.parent &&
-        node.parent.parent.type === 'VariableDeclarator'
+        node.type === 'ObjectExpression'
+        && node.parent
+        && node.parent.parent
+        && node.parent.parent.type === 'VariableDeclarator'
       );
       const namedClass = (
-        (node.type === 'ClassDeclaration' || node.type === 'ClassExpression') &&
-        node.id &&
-        !!node.id.name
+        (node.type === 'ClassDeclaration' || node.type === 'ClassExpression')
+        && node.id
+        && !!node.id.name
       );
 
       const namedFunctionDeclaration = (
-        (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression') &&
-        node.id &&
-        !!node.id.name
+        (node.type === 'FunctionDeclaration' || node.type === 'FunctionExpression')
+        && node.id
+        && !!node.id.name
       );
 
       const namedFunctionExpression = (
-        astUtil.isFunctionLikeExpression(node) &&
-        node.parent &&
-        (node.parent.type === 'VariableDeclarator' || node.parent.method === true) &&
-        (!node.parent.parent || !utils.isES5Component(node.parent.parent))
+        astUtil.isFunctionLikeExpression(node)
+        && node.parent
+        && (node.parent.type === 'VariableDeclarator' || node.parent.method === true)
+        && (!node.parent.parent || !utils.isES5Component(node.parent.parent))
       );
 
       if (
-        namedObjectAssignment || namedObjectDeclaration ||
-        namedClass ||
-        namedFunctionDeclaration || namedFunctionExpression
+        namedObjectAssignment || namedObjectDeclaration
+        || namedClass
+        || namedFunctionDeclaration || namedFunctionExpression
       ) {
         return true;
       }
@@ -215,8 +215,8 @@ module.exports = {
           const isWrappedInAnotherPragma = utils.getPragmaComponentWrapper(node);
 
           if (
-            !isWrappedInAnotherPragma &&
-            (ignoreTranspilerName || !hasTranspilerName(node.arguments[0]))
+            !isWrappedInAnotherPragma
+            && (ignoreTranspilerName || !hasTranspilerName(node.arguments[0]))
           ) {
             return;
           }

--- a/lib/rules/forbid-elements.js
+++ b/lib/rules/forbid-elements.js
@@ -72,11 +72,11 @@ module.exports = {
     }
 
     function isValidCreateElement(node) {
-      return node.callee &&
-        node.callee.type === 'MemberExpression' &&
-        node.callee.object.name === 'React' &&
-        node.callee.property.name === 'createElement' &&
-        node.arguments.length > 0;
+      return node.callee
+        && node.callee.type === 'MemberExpression'
+        && node.callee.object.name === 'React'
+        && node.callee.property.name === 'createElement'
+        && node.arguments.length > 0;
     }
 
     function reportIfForbidden(element, node) {

--- a/lib/rules/forbid-foreign-prop-types.js
+++ b/lib/rules/forbid-foreign-prop-types.js
@@ -70,10 +70,10 @@ module.exports = {
       const assignmentExpression = findParentAssignmentExpression(node);
 
       if (
-        assignmentExpression &&
-        assignmentExpression.left &&
-        assignmentExpression.left.property &&
-        assignmentExpression.left.property.name === 'propTypes'
+        assignmentExpression
+        && assignmentExpression.left
+        && assignmentExpression.left.property
+        && assignmentExpression.left.property.name === 'propTypes'
       ) {
         return true;
       }
@@ -81,9 +81,9 @@ module.exports = {
       const classProperty = findParentClassProperty(node);
 
       if (
-        classProperty &&
-        classProperty.key &&
-        classProperty.key.name === 'propTypes'
+        classProperty
+        && classProperty.key
+        && classProperty.key.name === 'propTypes'
       ) {
         return true;
       }
@@ -93,18 +93,18 @@ module.exports = {
     return {
       MemberExpression(node) {
         if (
-          node.property &&
-          (
-            !node.computed &&
-            node.property.type === 'Identifier' &&
-            node.property.name === 'propTypes' &&
-            !ast.isAssignmentLHS(node) &&
-            !isAllowedAssignment(node)
+          node.property
+          && (
+            !node.computed
+            && node.property.type === 'Identifier'
+            && node.property.name === 'propTypes'
+            && !ast.isAssignmentLHS(node)
+            && !isAllowedAssignment(node)
           ) || (
-            (node.property.type === 'Literal' || node.property.type === 'JSXText') &&
-            node.property.value === 'propTypes' &&
-            !ast.isAssignmentLHS(node) &&
-            !isAllowedAssignment(node)
+            (node.property.type === 'Literal' || node.property.type === 'JSXText')
+            && node.property.value === 'propTypes'
+            && !ast.isAssignmentLHS(node)
+            && !isAllowedAssignment(node)
           )
         ) {
           context.report({

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -86,16 +86,16 @@ module.exports = {
         let target;
         let value = declaration.value;
         if (
-          value.type === 'MemberExpression' &&
-          value.property &&
-          value.property.name &&
-          value.property.name === 'isRequired'
+          value.type === 'MemberExpression'
+          && value.property
+          && value.property.name
+          && value.property.name === 'isRequired'
         ) {
           value = value.object;
         }
         if (
-          value.type === 'CallExpression' &&
-          value.callee.type === 'MemberExpression'
+          value.type === 'CallExpression'
+          && value.callee.type === 'MemberExpression'
         ) {
           value = value.callee;
         }
@@ -140,9 +140,9 @@ module.exports = {
     return {
       ClassProperty(node) {
         if (
-          !propsUtil.isPropTypesDeclaration(node) &&
-          !shouldCheckContextTypes(node) &&
-          !shouldCheckChildContextTypes(node)
+          !propsUtil.isPropTypesDeclaration(node)
+          && !shouldCheckContextTypes(node)
+          && !shouldCheckChildContextTypes(node)
         ) {
           return;
         }
@@ -151,9 +151,9 @@ module.exports = {
 
       MemberExpression(node) {
         if (
-          !propsUtil.isPropTypesDeclaration(node) &&
-          !shouldCheckContextTypes(node) &&
-          !shouldCheckChildContextTypes(node)
+          !propsUtil.isPropTypesDeclaration(node)
+          && !shouldCheckContextTypes(node)
+          && !shouldCheckChildContextTypes(node)
         ) {
           return;
         }
@@ -163,9 +163,9 @@ module.exports = {
 
       MethodDefinition(node) {
         if (
-          !propsUtil.isPropTypesDeclaration(node) &&
-          !shouldCheckContextTypes(node) &&
-          !shouldCheckChildContextTypes(node)
+          !propsUtil.isPropTypesDeclaration(node)
+          && !shouldCheckContextTypes(node)
+          && !shouldCheckChildContextTypes(node)
         ) {
           return;
         }
@@ -184,9 +184,9 @@ module.exports = {
           }
 
           if (
-            !propsUtil.isPropTypesDeclaration(property) &&
-            !shouldCheckContextTypes(property) &&
-            !shouldCheckChildContextTypes(property)
+            !propsUtil.isPropTypesDeclaration(property)
+            && !shouldCheckContextTypes(property)
+            && !shouldCheckChildContextTypes(property)
           ) {
             return;
           }

--- a/lib/rules/function-component-definition.js
+++ b/lib/rules/function-component-definition.js
@@ -162,9 +162,9 @@ module.exports = {
           fixerOptions: {
             type: namedConfig,
             template: NAMED_FUNCTION_TEMPLATES[namedConfig],
-            range: node.type === 'FunctionDeclaration' ?
-              node.range :
-              node.parent.parent.range
+            range: node.type === 'FunctionDeclaration'
+              ? node.range
+              : node.parent.parent.range
           }
         });
       }

--- a/lib/rules/jsx-child-element-spacing.js
+++ b/lib/rules/jsx-child-element-spacing.js
@@ -60,15 +60,15 @@ module.exports = {
     const TEXT_PRECEDING_ELEMENT_PATTERN = /\S\s*\n\s*$/;
 
     const elementName = node => (
-      node.openingElement &&
-      node.openingElement.name &&
-      node.openingElement.name.type === 'JSXIdentifier' &&
-      node.openingElement.name.name
+      node.openingElement
+      && node.openingElement.name
+      && node.openingElement.name.type === 'JSXIdentifier'
+      && node.openingElement.name.name
     );
 
     const isInlineElement = node => (
-      node.type === 'JSXElement' &&
-      INLINE_ELEMENTS.has(elementName(node))
+      node.type === 'JSXElement'
+      && INLINE_ELEMENTS.has(elementName(node))
     );
 
     const handleJSX = (node) => {
@@ -76,11 +76,11 @@ module.exports = {
       let child = null;
       (node.children.concat([null])).forEach((nextChild) => {
         if (
-          (lastChild || nextChild) &&
-          (!lastChild || isInlineElement(lastChild)) &&
-          (child && (child.type === 'Literal' || child.type === 'JSXText')) &&
-          (!nextChild || isInlineElement(nextChild)) &&
-          true
+          (lastChild || nextChild)
+          && (!lastChild || isInlineElement(lastChild))
+          && (child && (child.type === 'Literal' || child.type === 'JSXText'))
+          && (!nextChild || isInlineElement(nextChild))
+          && true
         ) {
           if (lastChild && child.value.match(TEXT_FOLLOWING_ELEMENT_PATTERN)) {
             context.report({

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -251,8 +251,8 @@ module.exports = {
         const correctColumn = getCorrectColumn(tokens, expectedLocation);
 
         if (correctColumn !== null) {
-          expectedNextLine = tokens.lastProp &&
-            (tokens.lastProp.lastLine === tokens.closing.line);
+          expectedNextLine = tokens.lastProp
+            && (tokens.lastProp.lastLine === tokens.closing.line);
           data.details = ` (expected column ${correctColumn + 1}${expectedNextLine ? ' on the next line)' : ')'}`;
         }
 

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -34,8 +34,8 @@ module.exports = {
   meta: {
     docs: {
       description:
-        'Disallow unnecessary JSX expressions when literals alone are sufficient ' +
-          'or enfore JSX expressions on literals in JSX children or attributes',
+        'Disallow unnecessary JSX expressions when literals alone are sufficient '
+          + 'or enfore JSX expressions on literals in JSX children or attributes',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-curly-brace-presence')
@@ -64,9 +64,9 @@ module.exports = {
   create(context) {
     const HTML_ENTITY_REGEX = () => /&[A-Za-z\d#]+;/g;
     const ruleOptions = context.options[0];
-    const userConfig = typeof ruleOptions === 'string' ?
-      {props: ruleOptions, children: ruleOptions} :
-      Object.assign({}, DEFAULT_CONFIG, ruleOptions);
+    const userConfig = typeof ruleOptions === 'string'
+      ? {props: ruleOptions, children: ruleOptions}
+      : Object.assign({}, DEFAULT_CONFIG, ruleOptions);
 
     function containsLineTerminators(rawStringValue) {
       return /[\n\r\u2028\u2029]/.test(rawStringValue);
@@ -102,9 +102,9 @@ module.exports = {
 
     function needToEscapeCharacterForJSX(raw) {
       return (
-        containsBackslash(raw) ||
-        containsHTMLEntity(raw) ||
-        containsDisallowedJSXTextChars(raw)
+        containsBackslash(raw)
+        || containsHTMLEntity(raw)
+        || containsDisallowedJSXTextChars(raw)
       );
     }
 
@@ -167,17 +167,17 @@ module.exports = {
 
           let textToReplace;
           if (parentType === 'JSXAttribute') {
-            textToReplace = `"${expressionType === 'TemplateLiteral' ?
-              expression.quasis[0].value.raw :
-              expression.raw.substring(1, expression.raw.length - 1)
+            textToReplace = `"${expressionType === 'TemplateLiteral'
+              ? expression.quasis[0].value.raw
+              : expression.raw.substring(1, expression.raw.length - 1)
             }"`;
           } else if (jsxUtil.isJSX(expression)) {
             const sourceCode = context.getSourceCode();
 
             textToReplace = sourceCode.getText(expression);
           } else {
-            textToReplace = expressionType === 'TemplateLiteral' ?
-              expression.quasis[0].value.cooked : expression.value;
+            textToReplace = expressionType === 'TemplateLiteral'
+              ? expression.quasis[0].value.cooked : expression.value;
           }
 
           return fixer.replaceText(JSXExpressionNode, textToReplace);
@@ -194,18 +194,18 @@ module.exports = {
           // by either using the real character or the unicode equivalent.
           // If it contains any line terminator character, bail out as well.
           if (
-            containsOnlyHtmlEntities(literalNode.raw) ||
-            (literalNode.parent.type === 'JSXAttribute' && containsLineTerminators(literalNode.raw)) ||
-            isLineBreak(literalNode.raw)
+            containsOnlyHtmlEntities(literalNode.raw)
+            || (literalNode.parent.type === 'JSXAttribute' && containsLineTerminators(literalNode.raw))
+            || isLineBreak(literalNode.raw)
           ) {
             return null;
           }
 
-          const expression = literalNode.parent.type === 'JSXAttribute' ?
-            `{"${escapeDoubleQuotes(escapeBackslashes(
+          const expression = literalNode.parent.type === 'JSXAttribute'
+            ? `{"${escapeDoubleQuotes(escapeBackslashes(
               literalNode.raw.substring(1, literalNode.raw.length - 1)
-            ))}"}` :
-            wrapWithCurlyBraces(literalNode.raw);
+            ))}"}`
+            : wrapWithCurlyBraces(literalNode.raw);
 
           return fixer.replaceText(literalNode, expression);
         }
@@ -232,26 +232,26 @@ module.exports = {
       const expressionType = expression.type;
 
       if (
-        (expressionType === 'Literal' || expressionType === 'JSXText') &&
-          typeof expression.value === 'string' &&
-          (
-            (JSXExpressionNode.parent.type === 'JSXAttribute' && !isWhiteSpaceLiteral(expression)) ||
-            !isLiteralWithTrailingWhiteSpaces(expression)
-          ) &&
-          !needToEscapeCharacterForJSX(expression.raw) && (
-          jsxUtil.isJSX(JSXExpressionNode.parent) ||
-          !containsQuoteCharacters(expression.value)
+        (expressionType === 'Literal' || expressionType === 'JSXText')
+          && typeof expression.value === 'string'
+          && (
+            (JSXExpressionNode.parent.type === 'JSXAttribute' && !isWhiteSpaceLiteral(expression))
+            || !isLiteralWithTrailingWhiteSpaces(expression)
+          )
+          && !needToEscapeCharacterForJSX(expression.raw) && (
+          jsxUtil.isJSX(JSXExpressionNode.parent)
+          || !containsQuoteCharacters(expression.value)
         )
       ) {
         reportUnnecessaryCurly(JSXExpressionNode);
       } else if (
-        expressionType === 'TemplateLiteral' &&
-          expression.expressions.length === 0 &&
-          expression.quasis[0].value.raw.indexOf('\n') === -1 &&
-          !isStringWithTrailingWhiteSpaces(expression.quasis[0].value.raw) &&
-          !needToEscapeCharacterForJSX(expression.quasis[0].value.raw) && (
-          jsxUtil.isJSX(JSXExpressionNode.parent) ||
-          !containsQuoteCharacters(expression.quasis[0].value.cooked)
+        expressionType === 'TemplateLiteral'
+          && expression.expressions.length === 0
+          && expression.quasis[0].value.raw.indexOf('\n') === -1
+          && !isStringWithTrailingWhiteSpaces(expression.quasis[0].value.raw)
+          && !needToEscapeCharacterForJSX(expression.quasis[0].value.raw) && (
+          jsxUtil.isJSX(JSXExpressionNode.parent)
+          || !containsQuoteCharacters(expression.quasis[0].value.cooked)
         )
       ) {
         reportUnnecessaryCurly(JSXExpressionNode);
@@ -262,13 +262,13 @@ module.exports = {
 
     function areRuleConditionsSatisfied(parent, config, ruleCondition) {
       return (
-        parent.type === 'JSXAttribute' &&
-          typeof config.props === 'string' &&
-          config.props === ruleCondition
+        parent.type === 'JSXAttribute'
+          && typeof config.props === 'string'
+          && config.props === ruleCondition
       ) || (
-        jsxUtil.isJSX(parent) &&
-          typeof config.children === 'string' &&
-          config.children === ruleCondition
+        jsxUtil.isJSX(parent)
+          && typeof config.children === 'string'
+          && config.children === ruleCondition
       );
     }
 
@@ -312,11 +312,11 @@ module.exports = {
       // <App prop1={<CustomEl />} prop2={<CustomEl>...</CustomEl>} />
 
       if (
-        parent.type && parent.type === 'JSXAttribute' &&
-        (node.expression && node.expression.type &&
-          node.expression.type !== 'Literal' &&
-          node.expression.type !== 'StringLiteral' &&
-          node.expression.type !== 'TemplateLiteral')
+        parent.type && parent.type === 'JSXAttribute'
+        && (node.expression && node.expression.type
+          && node.expression.type !== 'Literal'
+          && node.expression.type !== 'StringLiteral'
+          && node.expression.type !== 'TemplateLiteral')
       ) {
         return false;
       }
@@ -330,9 +330,9 @@ module.exports = {
         return false;
       }
       if (
-        parent.children &&
-        parent.children.length === 1 &&
-        containsWhitespaceExpression(node)
+        parent.children
+        && parent.children.length === 1
+        && containsWhitespaceExpression(node)
       ) {
         return false;
       }
@@ -342,16 +342,16 @@ module.exports = {
 
     function shouldCheckForMissingCurly(node, config) {
       if (
-        isLineBreak(node.raw) ||
-        containsOnlyHtmlEntities(node.raw)
+        isLineBreak(node.raw)
+        || containsOnlyHtmlEntities(node.raw)
       ) {
         return false;
       }
       const parent = node.parent;
       if (
-        parent.children &&
-        parent.children.length === 1 &&
-        containsWhitespaceExpression(parent.children[0])
+        parent.children
+        && parent.children.length === 1
+        && containsWhitespaceExpression(parent.children[0])
       ) {
         return false;
       }

--- a/lib/rules/jsx-curly-newline.js
+++ b/lib/rules/jsx-curly-newline.js
@@ -131,9 +131,9 @@ module.exports = {
             return sourceCode
               .getText()
               .slice(leftCurly.range[1], tokenAfterLeftCurly.range[0])
-              .trim() ?
-              null : // If there is a comment between the { and the first element, don't do a fix.
-              fixer.removeRange([leftCurly.range[1], tokenAfterLeftCurly.range[0]]);
+              .trim()
+              ? null // If there is a comment between the { and the first element, don't do a fix.
+              : fixer.removeRange([leftCurly.range[1], tokenAfterLeftCurly.range[0]]);
           }
         });
       } else if (!hasLeftNewline && needsNewlines) {
@@ -152,9 +152,9 @@ module.exports = {
             return sourceCode
               .getText()
               .slice(tokenBeforeRightCurly.range[1], rightCurly.range[0])
-              .trim() ?
-              null : // If there is a comment between the last element and the }, don't do a fix.
-              fixer.removeRange([
+              .trim()
+              ? null // If there is a comment between the last element and the }, don't do a fix.
+              : fixer.removeRange([
                 tokenBeforeRightCurly.range[1],
                 rightCurly.range[0]
               ]);

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -36,9 +36,9 @@ module.exports = {
     return {
       JSXOpeningElement(node) {
         if (
-          (configuration === 'multiline' && isMultilineJSX(node)) ||
-          (configuration === 'multiline-multiprop' && isMultilineJSX(node) && node.attributes.length > 1) ||
-          (configuration === 'always')
+          (configuration === 'multiline' && isMultilineJSX(node))
+          || (configuration === 'multiline-multiprop' && isMultilineJSX(node) && node.attributes.length > 1)
+          || (configuration === 'always')
         ) {
           node.attributes.some((decl) => {
             if (decl.loc.start.line === node.loc.start.line) {

--- a/lib/rules/jsx-fragments.js
+++ b/lib/rules/jsx-fragments.js
@@ -47,8 +47,8 @@ module.exports = {
       if (!versionUtil.testReactVersion(context, '16.2.0')) {
         context.report({
           node,
-          message: 'Fragments are only supported starting from React v16.2. ' +
-            'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
+          message: 'Fragments are only supported starting from React v16.2. '
+            + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
         });
         return true;
       }
@@ -62,8 +62,8 @@ module.exports = {
         let source = sourceCode.getText();
         source = replaceNode(source, jsxFragment.closingFragment, closeFragLong);
         source = replaceNode(source, jsxFragment.openingFragment, openFragLong);
-        const lengthDiff = openFragLong.length - sourceCode.getText(jsxFragment.openingFragment).length +
-          closeFragLong.length - sourceCode.getText(jsxFragment.closingFragment).length;
+        const lengthDiff = openFragLong.length - sourceCode.getText(jsxFragment.openingFragment).length
+          + closeFragLong.length - sourceCode.getText(jsxFragment.closingFragment).length;
         const range = jsxFragment.range;
         return fixer.replaceTextRange(range, source.slice(range[0], range[1] + lengthDiff));
       };
@@ -77,12 +77,12 @@ module.exports = {
         if (jsxElement.closingElement) {
           source = replaceNode(source, jsxElement.closingElement, closeFragShort);
           source = replaceNode(source, jsxElement.openingElement, openFragShort);
-          lengthDiff = sourceCode.getText(jsxElement.openingElement).length - openFragShort.length +
-            sourceCode.getText(jsxElement.closingElement).length - closeFragShort.length;
+          lengthDiff = sourceCode.getText(jsxElement.openingElement).length - openFragShort.length
+            + sourceCode.getText(jsxElement.closingElement).length - closeFragShort.length;
         } else {
           source = replaceNode(source, jsxElement.openingElement, `${openFragShort}${closeFragShort}`);
-          lengthDiff = sourceCode.getText(jsxElement.openingElement).length - openFragShort.length -
-            closeFragShort.length;
+          lengthDiff = sourceCode.getText(jsxElement.openingElement).length - openFragShort.length
+            - closeFragShort.length;
         }
 
         const range = jsxElement.range;
@@ -103,22 +103,22 @@ module.exports = {
 
       // const Fragment = React.Fragment;
       if (
-        variableInit.type === 'MemberExpression' &&
-        variableInit.object.type === 'Identifier' &&
-        variableInit.object.name === reactPragma &&
-        variableInit.property.type === 'Identifier' &&
-        variableInit.property.name === fragmentPragma
+        variableInit.type === 'MemberExpression'
+        && variableInit.object.type === 'Identifier'
+        && variableInit.object.name === reactPragma
+        && variableInit.property.type === 'Identifier'
+        && variableInit.property.name === fragmentPragma
       ) {
         return true;
       }
 
       // const { Fragment } = require('react');
       if (
-        variableInit.callee &&
-        variableInit.callee.name === 'require' &&
-        variableInit.arguments &&
-        variableInit.arguments[0] &&
-        variableInit.arguments[0].value === 'react'
+        variableInit.callee
+        && variableInit.callee.name === 'require'
+        && variableInit.arguments
+        && variableInit.arguments[0]
+        && variableInit.arguments[0].value === 'react'
       ) {
         return true;
       }

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -70,19 +70,19 @@ module.exports = {
 
     const configuration = context.options[0] || {};
 
-    const eventHandlerPrefix = isPrefixDisabled(configuration.eventHandlerPrefix) ?
-      null :
-      configuration.eventHandlerPrefix || 'handle';
-    const eventHandlerPropPrefix = isPrefixDisabled(configuration.eventHandlerPropPrefix) ?
-      null :
-      configuration.eventHandlerPropPrefix || 'on';
+    const eventHandlerPrefix = isPrefixDisabled(configuration.eventHandlerPrefix)
+      ? null
+      : configuration.eventHandlerPrefix || 'handle';
+    const eventHandlerPropPrefix = isPrefixDisabled(configuration.eventHandlerPropPrefix)
+      ? null
+      : configuration.eventHandlerPropPrefix || 'on';
 
-    const EVENT_HANDLER_REGEX = !eventHandlerPrefix ?
-      null :
-      new RegExp(`^((props\\.${eventHandlerPropPrefix || ''})|((.*\\.)?${eventHandlerPrefix}))[A-Z].*$`);
-    const PROP_EVENT_HANDLER_REGEX = !eventHandlerPropPrefix ?
-      null :
-      new RegExp(`^(${eventHandlerPropPrefix}[A-Z].*|ref)$`);
+    const EVENT_HANDLER_REGEX = !eventHandlerPrefix
+      ? null
+      : new RegExp(`^((props\\.${eventHandlerPropPrefix || ''})|((.*\\.)?${eventHandlerPrefix}))[A-Z].*$`);
+    const PROP_EVENT_HANDLER_REGEX = !eventHandlerPropPrefix
+      ? null
+      : new RegExp(`^(${eventHandlerPropPrefix}[A-Z].*|ref)$`);
 
     const checkLocal = !!configuration.checkLocalVariables;
 
@@ -103,18 +103,18 @@ module.exports = {
         const propFnIsNamedCorrectly = EVENT_HANDLER_REGEX && EVENT_HANDLER_REGEX.test(propValue);
 
         if (
-          propIsEventHandler &&
-          propFnIsNamedCorrectly !== null &&
-          !propFnIsNamedCorrectly
+          propIsEventHandler
+          && propFnIsNamedCorrectly !== null
+          && !propFnIsNamedCorrectly
         ) {
           context.report({
             node,
             message: `Handler function for ${propKey} prop key must begin with '${eventHandlerPrefix}'`
           });
         } else if (
-          propFnIsNamedCorrectly &&
-          propIsEventHandler !== null &&
-          !propIsEventHandler
+          propFnIsNamedCorrectly
+          && propIsEventHandler !== null
+          && !propIsEventHandler
         ) {
           context.report({
             node,

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -131,8 +131,8 @@ module.exports = {
       nodes.forEach((node) => {
         const nodeIndent = getNodeIndent(node);
         if (
-          node.type !== 'ArrayExpression' && node.type !== 'ObjectExpression' &&
-          nodeIndent !== indent && astUtil.isNodeFirstInLine(context, node)
+          node.type !== 'ArrayExpression' && node.type !== 'ObjectExpression'
+          && nodeIndent !== indent && astUtil.isNodeFirstInLine(context, node)
         ) {
           report(node, indent, nodeIndent);
         }

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -183,11 +183,11 @@ module.exports = {
      */
     function isRightInLogicalExp(node) {
       return (
-        node.parent &&
-        node.parent.parent &&
-        node.parent.parent.type === 'LogicalExpression' &&
-        node.parent.parent.right === node.parent &&
-        !indentLogicalExpressions
+        node.parent
+        && node.parent.parent
+        && node.parent.parent.type === 'LogicalExpression'
+        && node.parent.parent.right === node.parent
+        && !indentLogicalExpressions
       );
     }
 
@@ -198,11 +198,11 @@ module.exports = {
      */
     function isAlternateInConditionalExp(node) {
       return (
-        node.parent &&
-        node.parent.parent &&
-        node.parent.parent.type === 'ConditionalExpression' &&
-        node.parent.parent.alternate === node.parent &&
-        context.getSourceCode().getTokenBefore(node).value !== '('
+        node.parent
+        && node.parent.parent
+        && node.parent.parent.type === 'ConditionalExpression'
+        && node.parent.parent.alternate === node.parent
+        && context.getSourceCode().getTokenBefore(node).value !== '('
       );
     }
 
@@ -253,9 +253,9 @@ module.exports = {
         })
       */
       const isInExpStmt = (
-        node.parent &&
-        node.parent.parent &&
-        node.parent.parent.type === 'ExpressionStatement'
+        node.parent
+        && node.parent.parent
+        && node.parent.parent.type === 'ExpressionStatement'
       );
       if (!isInExpStmt) {
         return false;
@@ -263,10 +263,10 @@ module.exports = {
 
       const expStmt = node.parent.parent;
       const isInBlockStmtWithinDoExp = (
-        expStmt.parent &&
-        expStmt.parent.type === 'BlockStatement' &&
-        expStmt.parent.parent &&
-        expStmt.parent.parent.type === 'DoExpression'
+        expStmt.parent
+        && expStmt.parent.type === 'BlockStatement'
+        && expStmt.parent.parent
+        && expStmt.parent.parent.type === 'DoExpression'
       );
       if (!isInBlockStmtWithinDoExp) {
         return false;
@@ -288,10 +288,10 @@ module.exports = {
       const isCorrectRightInLogicalExp = isRightInLogicalExp(node) && (nodeIndent - indent) === indentSize;
       const isCorrectAlternateInCondExp = isAlternateInConditionalExp(node) && (nodeIndent - indent) === 0;
       if (
-        nodeIndent !== indent &&
-        astUtil.isNodeFirstInLine(context, node) &&
-        !isCorrectRightInLogicalExp &&
-        !isCorrectAlternateInCondExp
+        nodeIndent !== indent
+        && astUtil.isNodeFirstInLine(context, node)
+        && !isCorrectRightInLogicalExp
+        && !isCorrectAlternateInCondExp
       ) {
         report(node, indent, nodeIndent);
       }
@@ -311,8 +311,8 @@ module.exports = {
       );
       const hasFirstInLineNode = nodeIndentsPerLine.length > 0;
       if (
-        hasFirstInLineNode &&
-        !nodeIndentsPerLine.every(actualIndent => actualIndent === indent)
+        hasFirstInLineNode
+        && !nodeIndentsPerLine.every(actualIndent => actualIndent === indent)
       ) {
         nodeIndentsPerLine.forEach((nodeIndent) => {
           report(node, indent, nodeIndent);
@@ -343,10 +343,10 @@ module.exports = {
       prevToken = prevToken.type === 'JSXExpressionContainer' ? prevToken.expression : prevToken;
       const parentElementIndent = getNodeIndent(prevToken);
       const indent = (
-        prevToken.loc.start.line === node.loc.start.line ||
-        isRightInLogicalExp(node) ||
-        isAlternateInConditionalExp(node) ||
-        isSecondOrSubsequentExpWithinDoExp(node)
+        prevToken.loc.start.line === node.loc.start.line
+        || isRightInLogicalExp(node)
+        || isAlternateInConditionalExp(node)
+        || isSecondOrSubsequentExpWithinDoExp(node)
       ) ? 0 : indentSize;
       checkNodesIndent(node, parentElementIndent + indent);
     }

--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -88,10 +88,10 @@ module.exports = {
           if (has(refs[i], 'writeExpr')) {
             const writeExpr = refs[i].writeExpr;
 
-            return jsxUtil.isJSX(writeExpr) &&
-              writeExpr ||
-              (writeExpr && writeExpr.type === 'Identifier') &&
-              findJSXElementOrFragment(variables, writeExpr.name);
+            return jsxUtil.isJSX(writeExpr)
+              && writeExpr
+              || (writeExpr && writeExpr.type === 'Identifier')
+              && findJSXElementOrFragment(variables, writeExpr.name);
           }
         }
 

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -80,18 +80,18 @@ module.exports = {
       const nodeType = node.type;
 
       if (
-        !configuration.allowBind &&
-        nodeType === 'CallExpression' &&
-        node.callee.type === 'MemberExpression' &&
-        node.callee.property.type === 'Identifier' &&
-        node.callee.property.name === 'bind'
+        !configuration.allowBind
+        && nodeType === 'CallExpression'
+        && node.callee.type === 'MemberExpression'
+        && node.callee.property.type === 'Identifier'
+        && node.callee.property.name === 'bind'
       ) {
         return 'bindCall';
       }
       if (nodeType === 'ConditionalExpression') {
-        return getNodeViolationType(node.test) ||
-               getNodeViolationType(node.consequent) ||
-               getNodeViolationType(node.alternate);
+        return getNodeViolationType(node.test)
+               || getNodeViolationType(node.consequent)
+               || getNodeViolationType(node.alternate);
       }
       if (!configuration.allowArrowFunctions && nodeType === 'ArrowFunctionExpression') {
         return 'arrowFunc';
@@ -149,9 +149,9 @@ module.exports = {
         const variableViolationType = getNodeViolationType(node.init);
 
         if (
-          blockAncestors.length > 0 &&
-          variableViolationType &&
-          node.parent.kind === 'const' // only support const right now
+          blockAncestors.length > 0
+          && variableViolationType
+          && node.parent.kind === 'const' // only support const right now
         ) {
           addVariableNameToSet(
             variableViolationType, node.id.name, blockAncestors[0].range[0]

--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -17,9 +17,9 @@ function checkText(node, context) {
   if (/^\s*\/(\/|\*)/m.test(rawValue)) {
     // inside component, e.g. <div>literal</div>
     if (
-      node.parent.type !== 'JSXAttribute' &&
-      node.parent.type !== 'JSXExpressionContainer' &&
-      node.parent.type.indexOf('JSX') !== -1
+      node.parent.type !== 'JSXAttribute'
+      && node.parent.type !== 'JSXExpressionContainer'
+      && node.parent.type.indexOf('JSX') !== -1
     ) {
       context.report({
         node,

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -51,9 +51,9 @@ module.exports = {
     const config = Object.assign({}, defaults, context.options[0] || {});
     config.allowedStrings = new Set(config.allowedStrings.map(trimIfString));
 
-    const message = config.noStrings ?
-      'Strings not allowed in JSX files' :
-      'Missing JSX expression container around literal string';
+    const message = config.noStrings
+      ? 'Strings not allowed in JSX files'
+      : 'Missing JSX expression container around literal string';
 
     function reportLiteralNode(node, customMessage) {
       const errorMessage = customMessage || message;
@@ -77,10 +77,10 @@ module.exports = {
         return false;
       }
       const parent = getParentIgnoringBinaryExpressions(node);
-      const standard = !/^[\s]+$/.test(node.value) &&
-          typeof node.value === 'string' &&
-          parent.type.indexOf('JSX') !== -1 &&
-          parent.type !== 'JSXAttribute';
+      const standard = !/^[\s]+$/.test(node.value)
+          && typeof node.value === 'string'
+          && parent.type.indexOf('JSX') !== -1
+          && parent.type !== 'JSXAttribute';
       if (config.noStrings) {
         return standard;
       }

--- a/lib/rules/jsx-no-script-url.js
+++ b/lib/rules/jsx-no-script-url.js
@@ -16,8 +16,8 @@ const docsUrl = require('../util/docsUrl');
 const isJavaScriptProtocol = /^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i;
 
 function hasJavaScriptProtocol(attr) {
-  return attr.value.type === 'Literal' &&
-    isJavaScriptProtocol.test(attr.value.value);
+  return attr.value.type === 'Literal'
+    && isJavaScriptProtocol.test(attr.value.value);
 }
 
 function shouldVerifyElement(node, config) {
@@ -81,8 +81,8 @@ module.exports = {
         if (shouldVerifyElement(parent, config) && shouldVerifyProp(node, config) && hasJavaScriptProtocol(node)) {
           context.report({
             node,
-            message: 'A future version of React will block javascript: URLs as a security precaution. ' +
-              'Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.'
+            message: 'A future version of React will block javascript: URLs as a security precaution. '
+              + 'Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.'
           });
         }
       }

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -13,44 +13,44 @@ const linkComponentsUtil = require('../util/linkComponents');
 // ------------------------------------------------------------------------------
 
 function isTargetBlank(attr) {
-  return attr.name &&
-    attr.name.name === 'target' &&
-    attr.value &&
-    ((
-      attr.value.type === 'Literal' &&
-      attr.value.value.toLowerCase() === '_blank'
+  return attr.name
+    && attr.name.name === 'target'
+    && attr.value
+    && ((
+      attr.value.type === 'Literal'
+      && attr.value.value.toLowerCase() === '_blank'
     ) || (
-      attr.value.type === 'JSXExpressionContainer' &&
-      attr.value.expression &&
-      attr.value.expression.value &&
-      attr.value.expression.value.toLowerCase() === '_blank'
+      attr.value.type === 'JSXExpressionContainer'
+      && attr.value.expression
+      && attr.value.expression.value
+      && attr.value.expression.value.toLowerCase() === '_blank'
     ));
 }
 
 function hasExternalLink(element, linkAttribute) {
-  return element.attributes.some(attr => attr.name &&
-      attr.name.name === linkAttribute &&
-      attr.value.type === 'Literal' &&
-      /^(?:\w+:|\/\/)/.test(attr.value.value));
+  return element.attributes.some(attr => attr.name
+      && attr.name.name === linkAttribute
+      && attr.value.type === 'Literal'
+      && /^(?:\w+:|\/\/)/.test(attr.value.value));
 }
 
 function hasDynamicLink(element, linkAttribute) {
-  return element.attributes.some(attr => attr.name &&
-    attr.name.name === linkAttribute &&
-    attr.value.type === 'JSXExpressionContainer');
+  return element.attributes.some(attr => attr.name
+    && attr.name.name === linkAttribute
+    && attr.value.type === 'JSXExpressionContainer');
 }
 
 function hasSecureRel(element, allowReferrer) {
   return element.attributes.find((attr) => {
     if (attr.type === 'JSXAttribute' && attr.name.name === 'rel') {
-      const value = attr.value &&
-        ((
-          attr.value.type === 'Literal' &&
-          attr.value.value
+      const value = attr.value
+        && ((
+          attr.value.type === 'Literal'
+          && attr.value.value
         ) || (
-          attr.value.type === 'JSXExpressionContainer' &&
-          attr.value.expression &&
-          attr.value.expression.value
+          attr.value.type === 'JSXExpressionContainer'
+          && attr.value.expression
+          && attr.value.expression.value
         ));
       const tags = value && value.toLowerCase && value.toLowerCase().split(' ');
       return tags && (allowReferrer ? tags.indexOf('noopener') >= 0 : tags.indexOf('noreferrer') >= 0);
@@ -90,9 +90,9 @@ module.exports = {
     return {
       JSXAttribute(node) {
         if (
-          !components.has(node.parent.name.name) ||
-          !isTargetBlank(node) ||
-          hasSecureRel(node.parent, allowReferrer)
+          !components.has(node.parent.name.name)
+          || !isTargetBlank(node)
+          || hasSecureRel(node.parent, allowReferrer)
         ) {
           return;
         }
@@ -102,8 +102,8 @@ module.exports = {
         if (hasExternalLink(node.parent, linkAttribute) || (enforceDynamicLinks === 'always' && hasDynamicLink(node.parent, linkAttribute))) {
           context.report({
             node,
-            message: 'Using target="_blank" without rel="noreferrer" ' +
-              'is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
+            message: 'Using target="_blank" without rel="noreferrer" '
+              + 'is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
           });
         }
       }

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -36,9 +36,9 @@ function isNonspaceJSXTextOrJSXCurly(node) {
  * @returns {boolean}
  */
 function isFragmentWithOnlyTextAndIsNotChild(node) {
-  return node.children.length === 1 &&
-    isJSXText(node.children[0]) &&
-    !(node.parent.type === 'JSXElement' || node.parent.type === 'JSXFragment');
+  return node.children.length === 1
+    && isJSXText(node.children[0])
+    && !(node.parent.type === 'JSXElement' || node.parent.type === 'JSXFragment');
 }
 
 /**
@@ -61,9 +61,9 @@ function trimLikeReact(text) {
  * @returns {boolean}
  */
 function isKeyedElement(node) {
-  return node.type === 'JSXElement' &&
-    node.openingElement.attributes &&
-    node.openingElement.attributes.some(jsxUtil.isJSXAttributeKey);
+  return node.type === 'JSXElement'
+    && node.openingElement.attributes
+    && node.openingElement.attributes.some(jsxUtil.isJSXAttributeKey);
 }
 
 module.exports = {
@@ -92,9 +92,9 @@ module.exports = {
      * @returns {boolean}
      */
     function isPaddingSpaces(node) {
-      return isJSXText(node) &&
-        isOnlyWhitespace(node.raw) &&
-        arrayIncludes(node.raw, '\n');
+      return isJSXText(node)
+        && isOnlyWhitespace(node.raw)
+        && arrayIncludes(node.raw, '\n');
     }
 
     /**
@@ -108,9 +108,9 @@ module.exports = {
       }
 
       return (
-        node.children.length -
-        (+isPaddingSpaces(node.children[0])) -
-        (+isPaddingSpaces(node.children[node.children.length - 1]))
+        node.children.length
+        - (+isPaddingSpaces(node.children[0]))
+        - (+isPaddingSpaces(node.children[node.children.length - 1]))
       ) < 2;
     }
 
@@ -119,9 +119,9 @@ module.exports = {
      * @returns {boolean}
      */
     function isChildOfHtmlElement(node) {
-      return node.parent.type === 'JSXElement' &&
-        node.parent.openingElement.name.type === 'JSXIdentifier' &&
-        /^[a-z]+$/.test(node.parent.openingElement.name.name);
+      return node.parent.type === 'JSXElement'
+        && node.parent.openingElement.name.type === 'JSXIdentifier'
+        && /^[a-z]+$/.test(node.parent.openingElement.name.name);
     }
 
     /**
@@ -129,9 +129,9 @@ module.exports = {
      * @return {boolean}
      */
     function isChildOfComponentElement(node) {
-      return node.parent.type === 'JSXElement' &&
-        !isChildOfHtmlElement(node) &&
-        !jsxUtil.isFragment(node.parent, reactPragma, fragmentPragma);
+      return node.parent.type === 'JSXElement'
+        && !isChildOfHtmlElement(node)
+        && !jsxUtil.isFragment(node.parent, reactPragma, fragmentPragma);
     }
 
     /**

--- a/lib/rules/jsx-one-expression-per-line.js
+++ b/lib/rules/jsx-one-expression-per-line.js
@@ -67,15 +67,15 @@ module.exports = {
       if (children.length === 1) {
         const child = children[0];
         if (
-          openingElementStartLine === openingElementEndLine &&
-          openingElementEndLine === closingElementStartLine &&
-          closingElementStartLine === closingElementEndLine &&
-          closingElementEndLine === child.loc.start.line &&
-          child.loc.start.line === child.loc.end.line
+          openingElementStartLine === openingElementEndLine
+          && openingElementEndLine === closingElementStartLine
+          && closingElementStartLine === closingElementEndLine
+          && closingElementEndLine === child.loc.start.line
+          && child.loc.start.line === child.loc.end.line
         ) {
           if (
-            options.allow === 'single-child' ||
-            options.allow === 'literal' && (child.type === 'Literal' || child.type === 'JSXText')
+            options.allow === 'single-child'
+            || options.allow === 'literal' && (child.type === 'Literal' || child.type === 'JSXText')
           ) {
             return;
           }
@@ -145,15 +145,15 @@ module.exports = {
           }
 
           function spaceBetweenPrev() {
-            return ((prevChild.type === 'Literal' || prevChild.type === 'JSXText') && / $/.test(prevChild.raw)) ||
-              ((child.type === 'Literal' || child.type === 'JSXText') && /^ /.test(child.raw)) ||
-              context.getSourceCode().isSpaceBetweenTokens(prevChild, child);
+            return ((prevChild.type === 'Literal' || prevChild.type === 'JSXText') && / $/.test(prevChild.raw))
+              || ((child.type === 'Literal' || child.type === 'JSXText') && /^ /.test(child.raw))
+              || context.getSourceCode().isSpaceBetweenTokens(prevChild, child);
           }
 
           function spaceBetweenNext() {
-            return ((nextChild.type === 'Literal' || nextChild.type === 'JSXText') && /^ /.test(nextChild.raw)) ||
-              ((child.type === 'Literal' || child.type === 'JSXText') && / $/.test(child.raw)) ||
-              context.getSourceCode().isSpaceBetweenTokens(child, nextChild);
+            return ((nextChild.type === 'Literal' || nextChild.type === 'JSXText') && /^ /.test(nextChild.raw))
+              || ((child.type === 'Literal' || child.type === 'JSXText') && / $/.test(child.raw))
+              || context.getSourceCode().isSpaceBetweenTokens(child, nextChild);
           }
 
           if (!prevChild && !nextChild) {

--- a/lib/rules/jsx-props-no-spreading.js
+++ b/lib/rules/jsx-props-no-spreading.js
@@ -97,23 +97,23 @@ module.exports = {
         const isHTMLTag = tagName && tagName[0] !== tagName[0].toUpperCase();
         const isCustomTag = tagName && (tagName[0] === tagName[0].toUpperCase() || tagName.includes('.'));
         if (
-          isHTMLTag &&
-          ((ignoreHtmlTags && !isException(tagName, exceptions)) ||
-          (!ignoreHtmlTags && isException(tagName, exceptions)))
+          isHTMLTag
+          && ((ignoreHtmlTags && !isException(tagName, exceptions))
+          || (!ignoreHtmlTags && isException(tagName, exceptions)))
         ) {
           return;
         }
         if (
-          isCustomTag &&
-          ((ignoreCustomTags && !isException(tagName, exceptions)) ||
-          (!ignoreCustomTags && isException(tagName, exceptions)))
+          isCustomTag
+          && ((ignoreCustomTags && !isException(tagName, exceptions))
+          || (!ignoreCustomTags && isException(tagName, exceptions)))
         ) {
           return;
         }
         if (
-          ignoreExplicitSpread &&
-          node.argument.type === 'ObjectExpression' &&
-          node.argument.properties.every(isProperty)
+          ignoreExplicitSpread
+          && node.argument.type === 'ObjectExpression'
+          && node.argument.properties.every(isProperty)
         ) {
           return;
         }

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -90,9 +90,9 @@ function getGroupsOfSortableAttributes(attributes) {
     // then we start a new group. Append attributes to the group until we
     // come across another JSXSpreadAttribute or exhaust the array.
     if (
-      !lastAttr ||
-      (lastAttr.type === 'JSXSpreadAttribute' &&
-        attributes[i].type !== 'JSXSpreadAttribute')
+      !lastAttr
+      || (lastAttr.type === 'JSXSpreadAttribute'
+        && attributes[i].type !== 'JSXSpreadAttribute')
     ) {
       groupCount++;
       sortableAttributeGroups[groupCount - 1] = [];
@@ -189,8 +189,8 @@ function validateReservedFirstConfig(context, reservedFirst) {
         return function report(decl) {
           context.report({
             node: decl,
-            message: 'A customized reserved first list must only contain a subset of React reserved props.' +
-              ' Remove: {{ nonReservedWords }}',
+            message: 'A customized reserved first list must only contain a subset of React reserved props.'
+              + ' Remove: {{ nonReservedWords }}',
             data: {
               nonReservedWords: nonReservedWords.toString()
             }

--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -82,9 +82,9 @@ module.exports = {
           return;
         }
 
-        log('The react/jsx-space-before-closing rule is deprecated. ' +
-            'Please use the react/jsx-tag-spacing rule with the ' +
-            '"beforeSelfClosing" option instead.');
+        log('The react/jsx-space-before-closing rule is deprecated. '
+            + 'Please use the react/jsx-tag-spacing rule with the '
+            + '"beforeSelfClosing" option instead.');
         isWarnedForDeprecation = true;
       }
     };

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -89,9 +89,9 @@ module.exports = {
       const previousToken = sourceCode.getTokenBefore(node);
       const nextToken = sourceCode.getTokenAfter(node);
 
-      return previousToken && nextToken &&
-        previousToken.value === '(' && previousToken.range[1] <= node.range[0] &&
-        nextToken.value === ')' && nextToken.range[0] >= node.range[1];
+      return previousToken && nextToken
+        && previousToken.value === '(' && previousToken.range[1] <= node.range[0]
+        && nextToken.value === ')' && nextToken.range[0] >= node.range[1];
     }
 
     function needsOpeningNewLine(node) {

--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -23,10 +23,10 @@ module.exports = {
 
   create(context) {
     function isSetStateCall(node) {
-      return node.type === 'CallExpression' &&
-        node.callee.property &&
-        node.callee.property.name === 'setState' &&
-        node.callee.object.type === 'ThisExpression';
+      return node.type === 'CallExpression'
+        && node.callee.property
+        && node.callee.property.name === 'setState'
+        && node.callee.object.type === 'ThisExpression';
     }
 
     function isFirstArgumentInSetStateCall(current, node) {
@@ -87,8 +87,8 @@ module.exports = {
 
       MemberExpression(node) {
         if (
-          node.property.name === 'state' &&
-          node.object.type === 'ThisExpression'
+          node.property.name === 'state'
+          && node.object.type === 'ThisExpression'
         ) {
           let current = node;
           while (current.type !== 'Program') {
@@ -138,8 +138,8 @@ module.exports = {
           current = current.parent;
         }
         if (
-          current.parent.value === current ||
-          current.parent.object === current
+          current.parent.value === current
+          || current.parent.object === current
         ) {
           while (current.type !== 'Program') {
             if (isFirstArgumentInSetStateCall(current, node)) {

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -45,16 +45,16 @@ module.exports = {
     const ERROR_MESSAGE = 'Do not use Array index in keys';
 
     function isArrayIndex(node) {
-      return node.type === 'Identifier' &&
-        indexParamNames.indexOf(node.name) !== -1;
+      return node.type === 'Identifier'
+        && indexParamNames.indexOf(node.name) !== -1;
     }
 
     function isUsingReactChildren(node) {
       const callee = node.callee;
       if (
-        !callee ||
-        !callee.property ||
-        !callee.object
+        !callee
+        || !callee.property
+        || !callee.object
       ) {
         return null;
       }
@@ -87,9 +87,9 @@ module.exports = {
         return null;
       }
 
-      const callbackArg = isUsingReactChildren(node) ?
-        node.arguments[1] :
-        node.arguments[0];
+      const callbackArg = isUsingReactChildren(node)
+        ? node.arguments[1]
+        : node.arguments[0];
 
       if (!callbackArg) {
         return null;
@@ -156,10 +156,10 @@ module.exports = {
     return {
       CallExpression(node) {
         if (
-          node.callee &&
-          node.callee.type === 'MemberExpression' &&
-          ['createElement', 'cloneElement'].indexOf(node.callee.property.name) !== -1 &&
-          node.arguments.length > 1
+          node.callee
+          && node.callee.type === 'MemberExpression'
+          && ['createElement', 'cloneElement'].indexOf(node.callee.property.name) !== -1
+          && node.arguments.length > 1
         ) {
           // React.createElement
           if (!indexParamNames.length) {

--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -18,11 +18,11 @@ const docsUrl = require('../util/docsUrl');
  * object literal, False if not.
 */
 function isCreateElementWithProps(node) {
-  return node.callee &&
-    node.callee.type === 'MemberExpression' &&
-    node.callee.property.name === 'createElement' &&
-    node.arguments.length > 1 &&
-    node.arguments[1].type === 'ObjectExpression';
+  return node.callee
+    && node.callee.type === 'MemberExpression'
+    && node.callee.property.name === 'createElement'
+    && node.arguments.length > 1
+    && node.arguments[1].type === 'ObjectExpression';
 }
 
 // ------------------------------------------------------------------------------

--- a/lib/rules/no-danger-with-children.js
+++ b/lib/rules/no-danger-with-children.js
@@ -98,9 +98,9 @@ module.exports = {
         }
 
         if (
-          node.openingElement.attributes &&
-          hasChildren &&
-          findJsxProp(node, 'dangerouslySetInnerHTML')
+          node.openingElement.attributes
+          && hasChildren
+          && findJsxProp(node, 'dangerouslySetInnerHTML')
         ) {
           context.report({
             node,
@@ -110,10 +110,10 @@ module.exports = {
       },
       CallExpression(node) {
         if (
-          node.callee &&
-          node.callee.type === 'MemberExpression' &&
-          node.callee.property.name === 'createElement' &&
-          node.arguments.length > 1
+          node.callee
+          && node.callee.type === 'MemberExpression'
+          && node.callee.property.name === 'createElement'
+          && node.arguments.length > 1
         ) {
           let hasChildren = false;
 

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -83,20 +83,20 @@ module.exports = {
       deprecated.componentWillMount = [
         '16.9.0',
         'UNSAFE_componentWillMount',
-        'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. ' +
-        'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+        'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+        + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
       ];
       deprecated.componentWillReceiveProps = [
         '16.9.0',
         'UNSAFE_componentWillReceiveProps',
-        'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. ' +
-        'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+        'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+        + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
       ];
       deprecated.componentWillUpdate = [
         '16.9.0',
         'UNSAFE_componentWillUpdate',
-        'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. ' +
-        'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+        'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+        + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
       ];
       return deprecated;
     }
@@ -105,10 +105,10 @@ module.exports = {
       const deprecated = getDeprecated();
 
       return (
-        deprecated &&
-        deprecated[method] &&
-        deprecated[method][0] &&
-        versionUtil.testReactVersion(context, deprecated[method][0])
+        deprecated
+        && deprecated[method]
+        && deprecated[method][0]
+        && versionUtil.testReactVersion(context, deprecated[method][0])
       );
     }
 
@@ -195,15 +195,15 @@ module.exports = {
       VariableDeclarator(node) {
         const reactModuleName = getReactModuleName(node);
         const isRequire = node.init && node.init.callee && node.init.callee.name === 'require';
-        const isReactRequire = node.init &&
-          node.init.arguments &&
-          node.init.arguments.length &&
-          typeof MODULES[node.init.arguments[0].value] !== 'undefined';
+        const isReactRequire = node.init
+          && node.init.arguments
+          && node.init.arguments.length
+          && typeof MODULES[node.init.arguments[0].value] !== 'undefined';
         const isDestructuring = node.id && node.id.type === 'ObjectPattern';
 
         if (
-          !(isDestructuring && reactModuleName) &&
-          !(isDestructuring && isRequire && isReactRequire)
+          !(isDestructuring && reactModuleName)
+          && !(isDestructuring && isRequire && isReactRequire)
         ) {
           return;
         }

--- a/lib/rules/no-find-dom-node.js
+++ b/lib/rules/no-find-dom-node.js
@@ -32,8 +32,8 @@ module.exports = {
       CallExpression(node) {
         const callee = node.callee;
 
-        const isfindDOMNode = (callee.name === 'findDOMNode') ||
-          (callee.property && callee.property.name === 'findDOMNode');
+        const isfindDOMNode = (callee.name === 'findDOMNode')
+          || (callee.property && callee.property.name === 'findDOMNode');
         if (!isfindDOMNode) {
           return;
         }

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -47,8 +47,8 @@ module.exports = {
     function isIgnored(component) {
       return (
         ignoreStateless && (
-          /Function/.test(component.node.type) ||
-          utils.isPragmaComponentWrapper(component.node)
+          /Function/.test(component.node.type)
+          || utils.isPragmaComponentWrapper(component.node)
         )
       );
     }

--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -47,19 +47,19 @@ module.exports = {
         }
 
         if (
-          callee.object.type !== 'Identifier' ||
-          !calleeObjectName.test(callee.object.name) ||
-          callee.property.name !== 'render'
+          callee.object.type !== 'Identifier'
+          || !calleeObjectName.test(callee.object.name)
+          || callee.property.name !== 'render'
         ) {
           return;
         }
 
         if (
-          parent.type === 'VariableDeclarator' ||
-          parent.type === 'Property' ||
-          parent.type === 'ReturnStatement' ||
-          parent.type === 'ArrowFunctionExpression' ||
-          parent.type === 'AssignmentExpression'
+          parent.type === 'VariableDeclarator'
+          || parent.type === 'Property'
+          || parent.type === 'ReturnStatement'
+          || parent.type === 'ArrowFunctionExpression'
+          || parent.type === 'AssignmentExpression'
         ) {
           context.report({
             node: callee,

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -57,9 +57,9 @@ module.exports = {
       CallExpression(node) {
         const callee = node.callee;
         if (
-          callee.type !== 'MemberExpression' ||
-          callee.object.type !== 'ThisExpression' ||
-          callee.property.name !== 'setState'
+          callee.type !== 'MemberExpression'
+          || callee.object.type !== 'ThisExpression'
+          || callee.property.name !== 'setState'
         ) {
           return;
         }

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -41,11 +41,11 @@ module.exports = {
     function isRefsUsage(node) {
       return Boolean(
         (
-          utils.getParentES6Component() ||
-          utils.getParentES5Component()
-        ) &&
-        node.object.type === 'ThisExpression' &&
-        node.property.name === 'refs'
+          utils.getParentES6Component()
+          || utils.getParentES5Component()
+        )
+        && node.object.type === 'ThisExpression'
+        && node.property.name === 'refs'
       );
     }
 
@@ -56,9 +56,9 @@ module.exports = {
      */
     function isRefAttribute(node) {
       return Boolean(
-        node.type === 'JSXAttribute' &&
-        node.name &&
-        node.name.name === 'ref'
+        node.type === 'JSXAttribute'
+        && node.name
+        && node.name.name === 'ref'
       );
     }
 
@@ -69,9 +69,9 @@ module.exports = {
      */
     function containsStringLiteral(node) {
       return Boolean(
-        node.value &&
-        node.value.type === 'Literal' &&
-        typeof node.value.value === 'string'
+        node.value
+        && node.value.type === 'Literal'
+        && typeof node.value.value === 'string'
       );
     }
 
@@ -82,11 +82,11 @@ module.exports = {
      */
     function containsStringExpressionContainer(node) {
       return Boolean(
-        node.value &&
-        node.value.type === 'JSXExpressionContainer' &&
-        node.value.expression &&
-        ((node.value.expression.type === 'Literal' && typeof node.value.expression.value === 'string') ||
-        (node.value.expression.type === 'TemplateLiteral' && detectTemplateLiterals))
+        node.value
+        && node.value.type === 'JSXExpressionContainer'
+        && node.value.expression
+        && ((node.value.expression.type === 'Literal' && typeof node.value.expression.value === 'string')
+        || (node.value.expression.type === 'TemplateLiteral' && detectTemplateLiterals))
       );
     }
 
@@ -101,8 +101,8 @@ module.exports = {
       },
       JSXAttribute(node) {
         if (
-          isRefAttribute(node) &&
-          (containsStringLiteral(node) || containsStringExpressionContainer(node))
+          isRefAttribute(node)
+          && (containsStringLiteral(node) || containsStringExpressionContainer(node))
         ) {
           context.report({
             node,

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -68,12 +68,12 @@ module.exports = {
 
     function isPropTypesPackage(node) {
       return (
-        node.type === 'Identifier' &&
-        node.name === propTypesPackageName
+        node.type === 'Identifier'
+        && node.name === propTypesPackageName
       ) || (
-        node.type === 'MemberExpression' &&
-        node.property.name === 'PropTypes' &&
-        node.object.name === reactPackageName
+        node.type === 'MemberExpression'
+        && node.property.name === 'PropTypes'
+        && node.object.name === reactPackageName
       );
     }
 
@@ -100,14 +100,14 @@ module.exports = {
 
       if (node.type === 'MemberExpression') {
         if (
-          node.object.type === 'MemberExpression' &&
-          isPropTypesPackage(node.object.object)
+          node.object.type === 'MemberExpression'
+          && isPropTypesPackage(node.object.object)
         ) { // PropTypes.myProp.isRequired
           checkValidPropType(node.object.property);
           checkValidPropTypeQualifier(node.property);
         } else if (
-          isPropTypesPackage(node.object) &&
-          node.property.name !== 'isRequired'
+          isPropTypesPackage(node.object)
+          && node.property.name !== 'isRequired'
         ) { // PropTypes.myProp
           checkValidPropType(node.property);
         } else if (node.object.type === 'CallExpression') {
@@ -134,9 +134,9 @@ module.exports = {
       }
       STATIC_CLASS_PROPERTIES.forEach((CLASS_PROP) => {
         if (propertyName && CLASS_PROP.toLowerCase() === propertyName.toLowerCase() && CLASS_PROP !== propertyName) {
-          const message = isClassProperty ?
-            'Typo in static class property declaration' :
-            'Typo in property declaration';
+          const message = isClassProperty
+            ? 'Typo in static class property declaration'
+            : 'Typo in property declaration';
           context.report({
             node: propertyKey,
             message
@@ -202,8 +202,8 @@ module.exports = {
         const propertyName = node.property.name;
 
         if (
-          !propertyName ||
-          STATIC_CLASS_PROPERTIES.map(prop => prop.toLocaleLowerCase()).indexOf(propertyName.toLowerCase()) === -1
+          !propertyName
+          || STATIC_CLASS_PROPERTIES.map(prop => prop.toLocaleLowerCase()).indexOf(propertyName.toLowerCase()) === -1
         ) {
           return;
         }
@@ -211,9 +211,9 @@ module.exports = {
         const relatedComponent = utils.getRelatedComponent(node);
 
         if (
-          relatedComponent &&
-          (utils.isES6Component(relatedComponent.node) || utils.isReturningJSX(relatedComponent.node)) &&
-          (node.parent && node.parent.type === 'AssignmentExpression' && node.parent.right)
+          relatedComponent
+          && (utils.isES6Component(relatedComponent.node) || utils.isReturningJSX(relatedComponent.node))
+          && (node.parent && node.parent.type === 'AssignmentExpression' && node.parent.right)
         ) {
           reportErrorIfPropertyCasingTypo(node.parent.right, node.property, true);
         }

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -156,9 +156,9 @@ function isTagName(node) {
   if (tagConvention.test(node.parent.name.name)) {
     // http://www.w3.org/TR/custom-elements/#type-extension-semantics
     return !node.parent.attributes.some(attrNode => (
-      attrNode.type === 'JSXAttribute' &&
-        attrNode.name.type === 'JSXIdentifier' &&
-        attrNode.name.name === 'is'
+      attrNode.type === 'JSXAttribute'
+        && attrNode.name.type === 'JSXIdentifier'
+        && attrNode.name.name === 'is'
     ));
   }
   return false;
@@ -184,9 +184,9 @@ function getTagName(node) {
  */
 function tagNameHasDot(node) {
   return !!(
-    node.parent &&
-    node.parent.name &&
-    node.parent.name.type === 'JSXMemberExpression'
+    node.parent
+    && node.parent.name
+    && node.parent.name.type === 'JSXMemberExpression'
   );
 }
 

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -53,8 +53,8 @@ module.exports = {
      */
     function mustBeValidated(component) {
       return Boolean(
-        component &&
-        !component.ignoreUnusedPropTypesValidation
+        component
+        && !component.ignoreUnusedPropTypesValidation
       );
     }
 
@@ -69,9 +69,9 @@ module.exports = {
       for (let i = 0, l = usedPropTypes.length; i < l; i++) {
         const usedProp = usedPropTypes[i];
         if (
-          prop.type === 'shape' ||
-          prop.name === '__ANY_KEY__' ||
-          usedProp.name === prop.name
+          prop.type === 'shape'
+          || prop.name === '__ANY_KEY__'
+          || usedProp.name === prop.name
         ) {
           return true;
         }

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -66,9 +66,9 @@ function isSetStateCall(node) {
   const unwrappedCalleeNode = ast.unwrapTSAsExpression(node.callee);
 
   return (
-    unwrappedCalleeNode.type === 'MemberExpression' &&
-    isThisExpression(unwrappedCalleeNode.object) &&
-    getName(unwrappedCalleeNode.property) === 'setState'
+    unwrappedCalleeNode.type === 'MemberExpression'
+    && isThisExpression(unwrappedCalleeNode.object)
+    && getName(unwrappedCalleeNode.property) === 'setState'
   );
 }
 
@@ -103,14 +103,14 @@ module.exports = {
       while (scope) {
         const parent = scope.block && scope.block.parent;
         if (
-          parent &&
-          parent.type === 'MethodDefinition' && (
-            parent.static && parent.key.name === 'getDerivedStateFromProps' ||
-            classMethods.indexOf(parent.key.name) !== -1
-          ) &&
-          parent.value.type === 'FunctionExpression' &&
-          parent.value.params[1] &&
-          parent.value.params[1].name === node.name
+          parent
+          && parent.type === 'MethodDefinition' && (
+            parent.static && parent.key.name === 'getDerivedStateFromProps'
+            || classMethods.indexOf(parent.key.name) !== -1
+          )
+          && parent.value.type === 'FunctionExpression'
+          && parent.value.params[1]
+          && parent.value.params[1].name === node.name
         ) {
           return true;
         }
@@ -125,13 +125,13 @@ module.exports = {
     function isStateReference(node) {
       node = uncast(node);
 
-      const isDirectStateReference = node.type === 'MemberExpression' &&
-        isThisExpression(node.object) &&
-        node.property.name === 'state';
+      const isDirectStateReference = node.type === 'MemberExpression'
+        && isThisExpression(node.object)
+        && node.property.name === 'state';
 
-      const isAliasedStateReference = node.type === 'Identifier' &&
-        classInfo.aliases &&
-        classInfo.aliases.has(node.name);
+      const isAliasedStateReference = node.type === 'Identifier'
+        && classInfo.aliases
+        && classInfo.aliases.has(node.name);
 
       return isDirectStateReference || isAliasedStateReference || isStateParameterReference(node);
     }
@@ -143,11 +143,11 @@ module.exports = {
         const key = prop.key;
 
         if (
-          prop.type === 'Property' &&
-          (key.type === 'Literal' ||
-          (key.type === 'TemplateLiteral' && key.expressions.length === 0) ||
-          (prop.computed === false && key.type === 'Identifier')) &&
-          getName(prop.key) !== null
+          prop.type === 'Property'
+          && (key.type === 'Literal'
+          || (key.type === 'TemplateLiteral' && key.expressions.length === 0)
+          || (prop.computed === false && key.type === 'Identifier'))
+          && getName(prop.key) !== null
         ) {
           classInfo.stateFields.add(prop);
         }
@@ -170,8 +170,8 @@ module.exports = {
         if (prop.type === 'Property') {
           addUsedStateField(prop.key);
         } else if (
-          (prop.type === 'ExperimentalRestProperty' || prop.type === 'RestElement') &&
-          classInfo.aliases
+          (prop.type === 'ExperimentalRestProperty' || prop.type === 'RestElement')
+          && classInfo.aliases
         ) {
           classInfo.aliases.add(getName(prop.argument));
         }
@@ -266,15 +266,15 @@ module.exports = {
         // If we're looking at a `this.setState({})` invocation, record all the
         // properties as state fields.
         if (
-          isSetStateCall(unwrappedNode) &&
-          unwrappedNode.arguments.length > 0 &&
-          unwrappedArgumentNode.type === 'ObjectExpression'
+          isSetStateCall(unwrappedNode)
+          && unwrappedNode.arguments.length > 0
+          && unwrappedArgumentNode.type === 'ObjectExpression'
         ) {
           addStateFields(unwrappedArgumentNode);
         } else if (
-          isSetStateCall(unwrappedNode) &&
-          unwrappedNode.arguments.length > 0 &&
-          unwrappedArgumentNode.type === 'ArrowFunctionExpression'
+          isSetStateCall(unwrappedNode)
+          && unwrappedNode.arguments.length > 0
+          && unwrappedArgumentNode.type === 'ArrowFunctionExpression'
         ) {
           const unwrappedBodyNode = ast.unwrapTSAsExpression(unwrappedArgumentNode.body);
 
@@ -301,18 +301,18 @@ module.exports = {
         const unwrappedValueNode = ast.unwrapTSAsExpression(node.value);
 
         if (
-          getName(node.key) === 'state' &&
-          !node.static &&
-          unwrappedValueNode &&
-          unwrappedValueNode.type === 'ObjectExpression'
+          getName(node.key) === 'state'
+          && !node.static
+          && unwrappedValueNode
+          && unwrappedValueNode.type === 'ObjectExpression'
         ) {
           addStateFields(unwrappedValueNode);
         }
 
         if (
-          !node.static &&
-          unwrappedValueNode &&
-          unwrappedValueNode.type === 'ArrowFunctionExpression'
+          !node.static
+          && unwrappedValueNode
+          && unwrappedValueNode.type === 'ArrowFunctionExpression'
         ) {
           // Create a new set for this.state aliases local to this method.
           classInfo.aliases = new Set();
@@ -321,10 +321,10 @@ module.exports = {
 
       'ClassProperty:exit'(node) {
         if (
-          classInfo &&
-          !node.static &&
-          node.value &&
-          node.value.type === 'ArrowFunctionExpression'
+          classInfo
+          && !node.static
+          && node.value
+          && node.value.type === 'ArrowFunctionExpression'
         ) {
           // Forget our set of local aliases.
           classInfo.aliases = null;
@@ -362,8 +362,8 @@ module.exports = {
           const lastBodyNode = body[body.length - 1];
 
           if (
-            lastBodyNode.type === 'ReturnStatement' &&
-            lastBodyNode.argument.type === 'ObjectExpression'
+            lastBodyNode.type === 'ReturnStatement'
+            && lastBodyNode.argument.type === 'ObjectExpression'
           ) {
             addStateFields(lastBodyNode.argument);
           }
@@ -383,10 +383,10 @@ module.exports = {
 
         // Check for assignments like `this.state = {}`
         if (
-          unwrappedLeft.type === 'MemberExpression' &&
-          isThisExpression(unwrappedLeft.object) &&
-          getName(unwrappedLeft.property) === 'state' &&
-          unwrappedRight.type === 'ObjectExpression'
+          unwrappedLeft.type === 'MemberExpression'
+          && isThisExpression(unwrappedLeft.object)
+          && getName(unwrappedLeft.property) === 'state'
+          && unwrappedRight.type === 'ObjectExpression'
         ) {
           // Find the nearest function expression containing this assignment.
           let fn = node;
@@ -396,9 +396,9 @@ module.exports = {
           // If the nearest containing function is the constructor, then we want
           // to record all the assigned properties as state fields.
           if (
-            fn.parent &&
-            fn.parent.type === 'MethodDefinition' &&
-            fn.parent.kind === 'constructor'
+            fn.parent
+            && fn.parent.type === 'MethodDefinition'
+            && fn.parent.kind === 'constructor'
           ) {
             addStateFields(unwrappedRight);
           }

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -52,10 +52,10 @@ module.exports = {
      */
     function isSingleSuperCall(body) {
       return (
-        body.length === 1 &&
-        body[0].type === 'ExpressionStatement' &&
-        body[0].expression.type === 'CallExpression' &&
-        body[0].expression.callee.type === 'Super'
+        body.length === 1
+        && body[0].type === 'ExpressionStatement'
+        && body[0].expression.type === 'CallExpression'
+        && body[0].expression.callee.type === 'Super'
       );
     }
 
@@ -79,10 +79,10 @@ module.exports = {
      */
     function isSpreadArguments(superArgs) {
       return (
-        superArgs.length === 1 &&
-        superArgs[0].type === 'SpreadElement' &&
-        superArgs[0].argument.type === 'Identifier' &&
-        superArgs[0].argument.name === 'arguments'
+        superArgs.length === 1
+        && superArgs[0].type === 'SpreadElement'
+        && superArgs[0].argument.type === 'Identifier'
+        && superArgs[0].argument.name === 'arguments'
       );
     }
 
@@ -96,9 +96,9 @@ module.exports = {
      */
     function isValidIdentifierPair(ctorParam, superArg) {
       return (
-        ctorParam.type === 'Identifier' &&
-        superArg.type === 'Identifier' &&
-        ctorParam.name === superArg.name
+        ctorParam.type === 'Identifier'
+        && superArg.type === 'Identifier'
+        && ctorParam.name === superArg.name
       );
     }
 
@@ -112,9 +112,9 @@ module.exports = {
      */
     function isValidRestSpreadPair(ctorParam, superArg) {
       return (
-        ctorParam.type === 'RestElement' &&
-        superArg.type === 'SpreadElement' &&
-        isValidIdentifierPair(ctorParam.argument, superArg.argument)
+        ctorParam.type === 'RestElement'
+        && superArg.type === 'SpreadElement'
+        && isValidIdentifierPair(ctorParam.argument, superArg.argument)
       );
     }
 
@@ -127,8 +127,8 @@ module.exports = {
      */
     function isValidPair(ctorParam, superArg) {
       return (
-        isValidIdentifierPair(ctorParam, superArg) ||
-        isValidRestSpreadPair(ctorParam, superArg)
+        isValidIdentifierPair(ctorParam, superArg)
+        || isValidRestSpreadPair(ctorParam, superArg)
       );
     }
 
@@ -163,11 +163,11 @@ module.exports = {
      */
     function isRedundantSuperCall(body, ctorParams) {
       return (
-        isSingleSuperCall(body) &&
-        ctorParams.every(isSimple) &&
-        (
-          isSpreadArguments(body[0].expression.arguments) ||
-          isPassingThrough(ctorParams, body[0].expression.arguments)
+        isSingleSuperCall(body)
+        && ctorParams.every(isSimple)
+        && (
+          isSpreadArguments(body[0].expression.arguments)
+          || isPassingThrough(ctorParams, body[0].expression.arguments)
         )
       );
     }
@@ -185,9 +185,9 @@ module.exports = {
         const isPropTypes = name === 'propTypes' || name === 'props' && property.typeAnnotation;
         const contextTypes = name === 'contextTypes';
         const defaultProps = name === 'defaultProps';
-        const isUselessConstructor = property.kind === 'constructor' &&
-          !!property.value.body &&
-          isRedundantSuperCall(property.value.body.body, property.value.params);
+        const isUselessConstructor = property.kind === 'constructor'
+          && !!property.value.body
+          && isRedundantSuperCall(property.value.body.body, property.value.params);
         const isRender = name === 'render';
         return !isDisplayName && !isPropTypes && !contextTypes && !defaultProps && !isUselessConstructor && !isRender;
       });
@@ -309,8 +309,8 @@ module.exports = {
         // Ignore calls to `this.props` and `this.context`
         }
         if (
-          (node.property.name || node.property.value) === 'props' ||
-          (node.property.name || node.property.value) === 'context'
+          (node.property.name || node.property.value) === 'props'
+          || (node.property.name || node.property.value) === 'context'
         ) {
           markPropsOrContextAsUsed(node);
           return;
@@ -343,9 +343,9 @@ module.exports = {
         const isReturningJSX = utils.isReturningJSX(node, !allowNull);
         const isReturningNull = node.argument && (node.argument.value === null || node.argument.value === false);
         if (
-          !isRender ||
-          (allowNull && (isReturningJSX || isReturningNull)) ||
-          (!allowNull && isReturningJSX)
+          !isRender
+          || (allowNull && (isReturningJSX || isReturningNull))
+          || (!allowNull && isReturningJSX)
         ) {
           return;
         }
@@ -356,13 +356,13 @@ module.exports = {
         const list = components.list();
         Object.keys(list).forEach((component) => {
           if (
-            hasOtherProperties(list[component].node) ||
-            list[component].useThis ||
-            list[component].useRef ||
-            list[component].invalidReturn ||
-            list[component].hasChildContextTypes ||
-            list[component].useDecorators ||
-            (!utils.isES5Component(list[component].node) && !utils.isES6Component(list[component].node))
+            hasOtherProperties(list[component].node)
+            || list[component].useThis
+            || list[component].useRef
+            || list[component].invalidReturn
+            || list[component].hasChildContextTypes
+            || list[component].useDecorators
+            || (!utils.isES5Component(list[component].node) && !utils.isES6Component(list[component].node))
           ) {
             return;
           }

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -71,10 +71,10 @@ module.exports = {
     function mustBeValidated(component) {
       const isSkippedByConfig = skipUndeclared && typeof component.declaredPropTypes === 'undefined';
       return Boolean(
-        component &&
-        component.usedPropTypes &&
-        !component.ignorePropsValidation &&
-        !isSkippedByConfig
+        component
+        && component.usedPropTypes
+        && !component.ignorePropsValidation
+        && !isSkippedByConfig
       );
     }
 
@@ -90,8 +90,8 @@ module.exports = {
         const propType = (
           declaredPropTypes && (
             // Check if this key is declared
-            (declaredPropTypes[key] || // If not, check if this type accepts any key
-            declaredPropTypes.__ANY_KEY__) // eslint-disable-line no-underscore-dangle
+            (declaredPropTypes[key] // If not, check if this type accepts any key
+            || declaredPropTypes.__ANY_KEY__) // eslint-disable-line no-underscore-dangle
           )
         );
 
@@ -147,8 +147,8 @@ module.exports = {
       while (node) {
         const component = components.get(node);
 
-        const isDeclared = component && component.confidence === 2 &&
-          internalIsDeclaredInComponent(component.declaredPropTypes || {}, names);
+        const isDeclared = component && component.confidence === 2
+          && internalIsDeclaredInComponent(component.declaredPropTypes || {}, names);
         if (isDeclared) {
           return true;
         }
@@ -163,9 +163,9 @@ module.exports = {
      */
     function reportUndeclaredPropTypes(component) {
       const undeclareds = component.usedPropTypes.filter(propType => (
-        propType.node &&
-        !isIgnored(propType.allNames[0]) &&
-        !isDeclaredInComponent(component.node, propType.allNames)
+        propType.node
+        && !isIgnored(propType.allNames[0])
+        && !isDeclaredInComponent(component.node, propType.allNames)
       ));
       undeclareds.forEach((propType) => {
         context.report({

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -87,8 +87,8 @@ module.exports = {
         const list = components.list();
 
         Object.keys(list).filter((component) => {
-          if (ignoreFunctionalComponents &&
-            (astUtil.isFunction(list[component].node) || astUtil.isFunctionLikeExpression(list[component].node))) {
+          if (ignoreFunctionalComponents
+            && (astUtil.isFunction(list[component].node) || astUtil.isFunctionLikeExpression(list[component].node))) {
             return false;
           }
           return list[component].declaredPropTypes;

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -45,15 +45,15 @@ module.exports = {
       if (node.decorators && node.decorators.length) {
         for (let i = 0, l = node.decorators.length; i < l; i++) {
           if (
-            node.decorators[i].expression &&
-            node.decorators[i].expression.callee &&
-            node.decorators[i].expression.callee.object &&
-            node.decorators[i].expression.callee.object.name === 'reactMixin' &&
-            node.decorators[i].expression.callee.property &&
-            node.decorators[i].expression.callee.property.name === 'decorate' &&
-            node.decorators[i].expression.arguments &&
-            node.decorators[i].expression.arguments.length &&
-            node.decorators[i].expression.arguments[0].name === 'PureRenderMixin'
+            node.decorators[i].expression
+            && node.decorators[i].expression.callee
+            && node.decorators[i].expression.callee.object
+            && node.decorators[i].expression.callee.object.name === 'reactMixin'
+            && node.decorators[i].expression.callee.property
+            && node.decorators[i].expression.callee.property.name === 'decorate'
+            && node.decorators[i].expression.arguments
+            && node.decorators[i].expression.arguments.length
+            && node.decorators[i].expression.arguments[0].name === 'PureRenderMixin'
           ) {
             return true;
           }
@@ -75,8 +75,8 @@ module.exports = {
         for (let i = 0; i < allowLength; i++) {
           for (let j = 0, l = node.decorators.length; j < l; j++) {
             if (
-              node.decorators[j].expression &&
-              node.decorators[j].expression.name === allowDecorators[i]
+              node.decorators[j].expression
+              && node.decorators[j].expression.name === allowDecorators[i]
             ) {
               return true;
             }
@@ -94,8 +94,8 @@ module.exports = {
      */
     function isSCUDeclared(node) {
       return Boolean(
-        node &&
-        node.name === 'shouldComponentUpdate'
+        node
+        && node.name === 'shouldComponentUpdate'
       );
     }
 
@@ -116,9 +116,9 @@ module.exports = {
       }
 
       return Boolean(
-        node &&
-        node.key.name === 'mixins' &&
-        hasPR
+        node
+        && node.key.name === 'mixins'
+        && hasPR
       );
     }
 
@@ -209,8 +209,8 @@ module.exports = {
       ObjectExpression(node) {
         // Search for the shouldComponentUpdate declaration
         const found = node.properties.some(property => (
-          property.key &&
-          (isSCUDeclared(property.key) || isPureRenderDeclared(property))
+          property.key
+          && (isSCUDeclared(property.key) || isPureRenderDeclared(property))
         ));
         if (found) {
           markSCUAsDeclared(node);

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -56,9 +56,9 @@ module.exports = {
             depth++;
           }
           if (
-            /(MethodDefinition|(Class)?Property)$/.test(ancestor.type) &&
-            astUtil.getPropertyName(ancestor) === 'render' &&
-            depth <= 1
+            /(MethodDefinition|(Class)?Property)$/.test(ancestor.type)
+            && astUtil.getPropertyName(ancestor) === 'render'
+            && depth <= 1
           ) {
             markReturnStatementPresent(node);
           }
@@ -76,9 +76,9 @@ module.exports = {
         const list = components.list();
         Object.keys(list).forEach((component) => {
           if (
-            !findRenderMethod(list[component].node) ||
-            list[component].hasReturnStatement ||
-            (!utils.isES5Component(list[component].node) && !utils.isES6Component(list[component].node))
+            !findRenderMethod(list[component].node)
+            || list[component].hasReturnStatement
+            || (!utils.isES5Component(list[component].node) && !utils.isES6Component(list[component].node))
           ) {
             return;
           }

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -43,9 +43,9 @@ module.exports = {
   create(context) {
     function isComponent(node) {
       return (
-        node.name &&
-        (node.name.type === 'JSXIdentifier' || node.name.type === 'JSXMemberExpression') &&
-        !jsxUtil.isDOMComponent(node)
+        node.name
+        && (node.name.type === 'JSXIdentifier' || node.name.type === 'JSXMemberExpression')
+        && !jsxUtil.isDOMComponent(node)
       );
     }
 
@@ -57,18 +57,18 @@ module.exports = {
       const childrens = node.parent.children;
 
       return (
-        childrens.length === 1 &&
-        (childrens[0].type === 'Literal' || childrens[0].type === 'JSXText') &&
-        childrens[0].value.indexOf('\n') !== -1 &&
-        childrens[0].value.replace(/(?!\xA0)\s/g, '') === ''
+        childrens.length === 1
+        && (childrens[0].type === 'Literal' || childrens[0].type === 'JSXText')
+        && childrens[0].value.indexOf('\n') !== -1
+        && childrens[0].value.replace(/(?!\xA0)\s/g, '') === ''
       );
     }
 
     function isShouldBeSelfClosed(node) {
       const configuration = Object.assign({}, optionDefaults, context.options[0]);
       return (
-        configuration.component && isComponent(node) ||
-        configuration.html && jsxUtil.isDOMComponent(node)
+        configuration.component && isComponent(node)
+        || configuration.html && jsxUtil.isDOMComponent(node)
       ) && !node.selfClosing && (childrenIsEmpty(node) || childrenIsMultilineSpaces(node));
     }
 

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -352,11 +352,11 @@ module.exports = {
 
           if (
             // Comparing the same properties
-            refIndexA === refIndexB ||
+            refIndexA === refIndexB
             // 1st property is placed before the 2nd one in reference and in current component
-            refIndexA < refIndexB && classIndexA < classIndexB ||
+            || refIndexA < refIndexB && classIndexA < classIndexB
             // 1st property is placed after the 2nd one in reference and in current component
-            refIndexA > refIndexB && classIndexA > classIndexB
+            || refIndexA > refIndexB && classIndexA > classIndexB
           ) {
             return {
               correct: true,
@@ -384,20 +384,20 @@ module.exports = {
         name: getPropertyName(node),
         getter: node.kind === 'get',
         setter: node.kind === 'set',
-        staticVariable: node.static &&
-          node.type === 'ClassProperty' &&
-          (!node.value || !astUtil.isFunctionLikeExpression(node.value)),
-        staticMethod: node.static &&
-          (node.type === 'ClassProperty' || node.type === 'MethodDefinition') &&
-          node.value &&
-          (astUtil.isFunctionLikeExpression(node.value)),
-        instanceVariable: !node.static &&
-          node.type === 'ClassProperty' &&
-          (!node.value || !astUtil.isFunctionLikeExpression(node.value)),
-        instanceMethod: !node.static &&
-          node.type === 'ClassProperty' &&
-          node.value &&
-          (astUtil.isFunctionLikeExpression(node.value)),
+        staticVariable: node.static
+          && node.type === 'ClassProperty'
+          && (!node.value || !astUtil.isFunctionLikeExpression(node.value)),
+        staticMethod: node.static
+          && (node.type === 'ClassProperty' || node.type === 'MethodDefinition')
+          && node.value
+          && (astUtil.isFunctionLikeExpression(node.value)),
+        instanceVariable: !node.static
+          && node.type === 'ClassProperty'
+          && (!node.value || !astUtil.isFunctionLikeExpression(node.value)),
+        instanceMethod: !node.static
+          && node.type === 'ClassProperty'
+          && node.value
+          && (astUtil.isFunctionLikeExpression(node.value)),
         typeAnnotation: !!node.typeAnnotation && node.value === null
       }));
 

--- a/lib/rules/state-in-constructor.js
+++ b/lib/rules/state-in-constructor.js
@@ -30,10 +30,10 @@ module.exports = {
     return {
       ClassProperty(node) {
         if (
-          option === 'always' &&
-          !node.static &&
-          node.key.name === 'state' &&
-          utils.getParentES6Component()
+          option === 'always'
+          && !node.static
+          && node.key.name === 'state'
+          && utils.getParentES6Component()
         ) {
           context.report({
             node,
@@ -43,10 +43,10 @@ module.exports = {
       },
       AssignmentExpression(node) {
         if (
-          option === 'never' &&
-          utils.isStateMemberExpression(node.left) &&
-          utils.inConstructor() &&
-          utils.getParentES6Component()
+          option === 'never'
+          && utils.isStateMemberExpression(node.left)
+          && utils.inConstructor()
+          && utils.getParentES6Component()
         ) {
           context.report({
             node,

--- a/lib/rules/style-prop-object.js
+++ b/lib/rules/style-prop-object.js
@@ -69,10 +69,10 @@ module.exports = {
     return {
       CallExpression(node) {
         if (
-          node.callee &&
-          node.callee.type === 'MemberExpression' &&
-          node.callee.property.name === 'createElement' &&
-          node.arguments.length > 1
+          node.callee
+          && node.callee.type === 'MemberExpression'
+          && node.callee.property.name === 'createElement'
+          && node.arguments.length > 1
         ) {
           if (node.arguments[0].name) {
             // store name of component

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -47,27 +47,27 @@ function mergeUsedPropTypes(propsList, newPropsList) {
 }
 
 function isReturnsConditionalJSX(node, property, strict) {
-  const returnsConditionalJSXConsequent = node[property] &&
-    node[property].type === 'ConditionalExpression' &&
-    jsxUtil.isJSX(node[property].consequent);
-  const returnsConditionalJSXAlternate = node[property] &&
-    node[property].type === 'ConditionalExpression' &&
-    jsxUtil.isJSX(node[property].alternate);
-  return strict ?
-    (returnsConditionalJSXConsequent && returnsConditionalJSXAlternate) :
-    (returnsConditionalJSXConsequent || returnsConditionalJSXAlternate);
+  const returnsConditionalJSXConsequent = node[property]
+    && node[property].type === 'ConditionalExpression'
+    && jsxUtil.isJSX(node[property].consequent);
+  const returnsConditionalJSXAlternate = node[property]
+    && node[property].type === 'ConditionalExpression'
+    && jsxUtil.isJSX(node[property].alternate);
+  return strict
+    ? (returnsConditionalJSXConsequent && returnsConditionalJSXAlternate)
+    : (returnsConditionalJSXConsequent || returnsConditionalJSXAlternate);
 }
 
 function isReturnsLogicalJSX(node, property, strict) {
-  const returnsLogicalJSXLeft = node[property] &&
-    node[property].type === 'LogicalExpression' &&
-    jsxUtil.isJSX(node[property].left);
-  const returnsLogicalJSXRight = node[property] &&
-    node[property].type === 'LogicalExpression' &&
-    jsxUtil.isJSX(node[property].right);
-  return strict ?
-    (returnsLogicalJSXLeft && returnsLogicalJSXRight) :
-    (returnsLogicalJSXLeft || returnsLogicalJSXRight);
+  const returnsLogicalJSXLeft = node[property]
+    && node[property].type === 'LogicalExpression'
+    && jsxUtil.isJSX(node[property].left);
+  const returnsLogicalJSXRight = node[property]
+    && node[property].type === 'LogicalExpression'
+    && jsxUtil.isJSX(node[property].right);
+  return strict
+    ? (returnsLogicalJSXLeft && returnsLogicalJSXRight)
+    : (returnsLogicalJSXLeft || returnsLogicalJSXRight);
 }
 
 const Lists = new WeakMap();
@@ -313,18 +313,18 @@ function componentRule(rule, context) {
      */
     isCreateElement(node) {
       const calledOnPragma = (
-        node &&
-        node.callee &&
-        node.callee.object &&
-        node.callee.object.name === pragma &&
-        node.callee.property &&
-        node.callee.property.name === 'createElement'
+        node
+        && node.callee
+        && node.callee.object
+        && node.callee.object.name === pragma
+        && node.callee.property
+        && node.callee.property.name === 'createElement'
       );
 
       const calledDirectly = (
-        node &&
-        node.callee &&
-        node.callee.name === 'createElement'
+        node
+        && node.callee
+        && node.callee.name === 'createElement'
       );
 
       if (this.isDestructuredFromPragmaImport('createElement')) {
@@ -404,10 +404,10 @@ function componentRule(rule, context) {
       const returnsPragmaCreateElement = this.isCreateElement(node[property]);
 
       return !!(
-        returnsConditionalJSX ||
-        returnsLogicalJSX ||
-        returnsJSX ||
-        returnsPragmaCreateElement
+        returnsConditionalJSX
+        || returnsLogicalJSX
+        || returnsJSX
+        || returnsPragmaCreateElement
       );
     },
 
@@ -483,9 +483,9 @@ function componentRule(rule, context) {
       }
       if (body.type === 'BlockStatement') {
         const jsxElement = body.body.find(item => item.type === 'ReturnStatement');
-        return jsxElement &&
-          jsxElement.argument &&
-          this.getComponentNameFromJSXElement(jsxElement.argument);
+        return jsxElement
+          && jsxElement.argument
+          && this.getComponentNameFromJSXElement(jsxElement.argument);
       }
       return null;
     },
@@ -501,10 +501,10 @@ function componentRule(rule, context) {
           return true;
         }
         if (
-          val.node.type === 'ArrowFunctionExpression' &&
-          val.node.parent &&
-          val.node.parent.type === 'VariableDeclarator' &&
-          val.node.parent.id
+          val.node.type === 'ArrowFunctionExpression'
+          && val.node.parent
+          && val.node.parent.type === 'VariableDeclarator'
+          && val.node.parent.id
         ) {
           return true;
         }
@@ -534,9 +534,9 @@ function componentRule(rule, context) {
       const propertyNames = ['forwardRef', 'memo'];
       const calleeObject = node.callee.object;
       if (calleeObject && node.callee.property) {
-        return arrayIncludes(propertyNames, node.callee.property.name) &&
-          calleeObject.name === pragma &&
-          !this.nodeWrapsComponent(node);
+        return arrayIncludes(propertyNames, node.callee.property.name)
+          && calleeObject.name === pragma
+          && !this.nodeWrapsComponent(node);
       }
       return arrayIncludes(propertyNames, node.callee.name) && this.isDestructuredFromPragmaImport(node.callee.name);
     },
@@ -555,9 +555,9 @@ function componentRule(rule, context) {
      */
     getParentComponent() {
       return (
-        utils.getParentES6Component() ||
-        utils.getParentES5Component() ||
-        utils.getParentStatelessComponent()
+        utils.getParentES6Component()
+        || utils.getParentES5Component()
+        || utils.getParentStatelessComponent()
       );
     },
 
@@ -609,8 +609,8 @@ function componentRule(rule, context) {
           return true;
         }
         case 'SequenceExpression': {
-          return utils.isInAllowedPositionForComponent(node.parent) &&
-            node === node.parent.expressions[node.parent.expressions.length - 1];
+          return utils.isInAllowedPositionForComponent(node.parent)
+            && node === node.parent.expressions[node.parent.expressions.length - 1];
         }
         default:
           return false;
@@ -719,10 +719,10 @@ function componentRule(rule, context) {
         if (refId.type === 'MemberExpression') {
           componentNode = refId.parent.right;
         } else if (
-          refId.parent &&
-          refId.parent.type === 'VariableDeclarator' &&
-          refId.parent.init &&
-          refId.parent.init.type !== 'Identifier'
+          refId.parent
+          && refId.parent.type === 'VariableDeclarator'
+          && refId.parent.init
+          && refId.parent.init.type !== 'Identifier'
         ) {
           componentNode = refId.parent.init;
         }
@@ -737,9 +737,9 @@ function componentRule(rule, context) {
       // Try to find the component using variable declarations
       const defs = variableInScope.defs;
       const defInScope = defs.find(def => (
-        def.type === 'ClassName' ||
-        def.type === 'FunctionName' ||
-        def.type === 'Variable'
+        def.type === 'ClassName'
+        || def.type === 'FunctionName'
+        || def.type === 'Variable'
       ));
       if (!defInScope || !defInScope.node) {
         return null;
@@ -815,8 +815,8 @@ function componentRule(rule, context) {
       }
       const component = utils.getParentComponent();
       if (
-        !component ||
-        (component.parent && component.parent.type === 'JSXExpressionContainer')
+        !component
+        || (component.parent && component.parent.type === 'JSXExpressionContainer')
       ) {
         // Ban the node if we cannot find a parent component
         components.add(node, 0);
@@ -844,8 +844,8 @@ function componentRule(rule, context) {
       }
       const component = utils.getParentComponent();
       if (
-        !component ||
-        (component.parent && component.parent.type === 'JSXExpressionContainer')
+        !component
+        || (component.parent && component.parent.type === 'JSXExpressionContainer')
       ) {
         // Ban the node if we cannot find a parent component
         components.add(node, 0);

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -12,8 +12,8 @@
  */
 function findReturnStatement(node) {
   if (
-    (!node.value || !node.value.body || !node.value.body.body) &&
-    (!node.body || !node.body.body)
+    (!node.value || !node.value.body || !node.value.body.body)
+    && (!node.body || !node.body.body)
   ) {
     return false;
   }
@@ -92,12 +92,12 @@ function getFirstNodeInLine(context, node) {
   let lines;
   do {
     token = sourceCode.getTokenBefore(token);
-    lines = token.type === 'JSXText' ?
-      token.value.split('\n') :
-      null;
+    lines = token.type === 'JSXText'
+      ? token.value.split('\n')
+      : null;
   } while (
-    token.type === 'JSXText' &&
-        /^\s*$/.test(lines[lines.length - 1])
+    token.type === 'JSXText'
+        && /^\s*$/.test(lines[lines.length - 1])
   );
   return token;
 }
@@ -160,9 +160,9 @@ function stripQuotes(string) {
 function getKeyValue(context, node) {
   if (node.type === 'ObjectTypeProperty') {
     const tokens = context.getFirstTokens(node, 2);
-    return (tokens[0].value === '+' || tokens[0].value === '-' ?
-      tokens[1].value :
-      stripQuotes(tokens[0].value)
+    return (tokens[0].value === '+' || tokens[0].value === '-'
+      ? tokens[1].value
+      : stripQuotes(tokens[0].value)
     );
   }
   if (node.type === 'GenericTypeAnnotation') {
@@ -185,9 +185,9 @@ function getKeyValue(context, node) {
  */
 function isAssignmentLHS(node) {
   return (
-    node.parent &&
-    node.parent.type === 'AssignmentExpression' &&
-    node.parent.left === node
+    node.parent
+    && node.parent.type === 'AssignmentExpression'
+    && node.parent.left === node
   );
 }
 

--- a/lib/util/defaultProps.js
+++ b/lib/util/defaultProps.js
@@ -26,9 +26,9 @@ module.exports = function defaultPropsInstructions(context, components, utils) {
       return variableUtil.findVariableByName(context, node.name);
     }
     if (
-      node.type === 'CallExpression' &&
-      propWrapperUtil.isPropWrapperFunction(context, node.callee.name) &&
-      node.arguments && node.arguments[0]
+      node.type === 'CallExpression'
+      && propWrapperUtil.isPropWrapperFunction(context, node.callee.name)
+      && node.arguments && node.arguments[0]
     ) {
       return resolveNodeValue(node.arguments[0]);
     }
@@ -141,8 +141,8 @@ module.exports = function defaultPropsInstructions(context, components, utils) {
 
       // e.g.:
       // MyComponent.propTypes.baz = React.PropTypes.string;
-      if (node.parent.type === 'MemberExpression' && node.parent.parent &&
-        node.parent.parent.type === 'AssignmentExpression') {
+      if (node.parent.type === 'MemberExpression' && node.parent.parent
+        && node.parent.parent.type === 'AssignmentExpression') {
         addDefaultPropsToComponent(component, [{
           name: node.parent.property.name,
           node: node.parent.parent

--- a/lib/util/jsx.js
+++ b/lib/util/jsx.js
@@ -37,11 +37,11 @@ function isFragment(node, reactPragma, fragmentPragma) {
 
   // <React.Fragment>
   if (
-    name.type === 'JSXMemberExpression' &&
-    name.object.type === 'JSXIdentifier' &&
-    name.object.name === reactPragma &&
-    name.property.type === 'JSXIdentifier' &&
-    name.property.name === fragmentPragma
+    name.type === 'JSXMemberExpression'
+    && name.object.type === 'JSXIdentifier'
+    && name.object.name === reactPragma
+    && name.property.type === 'JSXIdentifier'
+    && name.property.name === fragmentPragma
   ) {
     return true;
   }
@@ -64,10 +64,10 @@ function isJSX(node) {
  * @returns {boolean}
  */
 function isJSXAttributeKey(node) {
-  return node.type === 'JSXAttribute' &&
-    node.name &&
-    node.name.type === 'JSXIdentifier' &&
-    node.name.name === 'key';
+  return node.type === 'JSXAttribute'
+    && node.name
+    && node.name.type === 'JSXIdentifier'
+    && node.name.name === 'key';
 }
 
 /**

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -63,9 +63,9 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
         CallExpression(node) {
           const callee = node.callee;
           if (
-            callee.type !== 'MemberExpression' ||
-            callee.object.type !== 'ThisExpression' ||
-            callee.property.name !== 'setState'
+            callee.type !== 'MemberExpression'
+            || callee.object.type !== 'ThisExpression'
+            || callee.property.name !== 'setState'
           ) {
             return;
           }
@@ -76,9 +76,9 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
               depth++;
             }
             if (
-              (ancestor.type !== 'Property' && ancestor.type !== 'MethodDefinition' && ancestor.type !== 'ClassProperty') ||
-              !nameMatches(ancestor.key.name) ||
-              (mode !== 'disallow-in-func' && depth > 1)
+              (ancestor.type !== 'Property' && ancestor.type !== 'MethodDefinition' && ancestor.type !== 'ClassProperty')
+              || !nameMatches(ancestor.key.name)
+              || (mode !== 'disallow-in-func' && depth > 1)
             ) {
               return false;
             }

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -328,33 +328,33 @@ module.exports = function propTypesInstructions(context, components, utils) {
    */
   function buildReactDeclarationTypes(value, parentName) {
     if (
-      value &&
-      value.callee &&
-      value.callee.object &&
-      hasCustomValidator(value.callee.object.name)
+      value
+      && value.callee
+      && value.callee.object
+      && hasCustomValidator(value.callee.object.name)
     ) {
       return {};
     }
 
     if (
-      value &&
-      value.type === 'MemberExpression' &&
-      value.property &&
-      value.property.name &&
-      value.property.name === 'isRequired'
+      value
+      && value.type === 'MemberExpression'
+      && value.property
+      && value.property.name
+      && value.property.name === 'isRequired'
     ) {
       value = value.object;
     }
 
     // Verify PropTypes that are functions
     if (
-      value &&
-      value.type === 'CallExpression' &&
-      value.callee &&
-      value.callee.property &&
-      value.callee.property.name &&
-      value.arguments &&
-      value.arguments.length > 0
+      value
+      && value.type === 'CallExpression'
+      && value.callee
+      && value.callee.property
+      && value.callee.property.name
+      && value.arguments
+      && value.arguments.length > 0
     ) {
       const callName = value.callee.property.name;
       const argument = value.arguments[0];
@@ -396,8 +396,8 @@ module.exports = function propTypesInstructions(context, components, utils) {
         }
         case 'oneOfType': {
           if (
-            !argument.elements ||
-            !argument.elements.length
+            !argument.elements
+            || !argument.elements.length
           ) {
             // Invalid proptype or cannot analyse statically
             return {};
@@ -459,11 +459,11 @@ module.exports = function propTypesInstructions(context, components, utils) {
         // Walk the list of properties, until we reach the assignment
         // ie: ClassX.propTypes.a.b.c = ...
         while (
-          propTypes &&
-          propTypes.parent &&
-          propTypes.parent.type !== 'AssignmentExpression' &&
-          propTypes.property &&
-          curDeclaredPropTypes
+          propTypes
+          && propTypes.parent
+          && propTypes.parent.type !== 'AssignmentExpression'
+          && propTypes.property
+          && curDeclaredPropTypes
         ) {
           const propName = propTypes.property.name;
           if (propName in curDeclaredPropTypes) {
@@ -495,8 +495,8 @@ module.exports = function propTypesInstructions(context, components, utils) {
           let isUsedInPropTypes = false;
           let n = propTypes;
           while (n) {
-            if (n.type === 'AssignmentExpression' && propsUtil.isPropTypesDeclaration(n.left) ||
-              (n.type === 'ClassProperty' || n.type === 'Property') && propsUtil.isPropTypesDeclaration(n)) {
+            if (n.type === 'AssignmentExpression' && propsUtil.isPropTypesDeclaration(n.left)
+              || (n.type === 'ClassProperty' || n.type === 'Property') && propsUtil.isPropTypesDeclaration(n)) {
               // Found a propType used inside of another propType. This is not considered usage, we'll still validate
               // this component.
               isUsedInPropTypes = true;
@@ -527,8 +527,8 @@ module.exports = function propTypesInstructions(context, components, utils) {
           propWrapperUtil.isPropWrapperFunction(
             context,
             context.getSourceCode().getText(propTypes.callee)
-          ) &&
-          propTypes.arguments && propTypes.arguments[0]
+          )
+          && propTypes.arguments && propTypes.arguments[0]
         ) {
           markPropTypesAsDeclared(node, propTypes.arguments[0]);
           return;
@@ -626,8 +626,8 @@ module.exports = function propTypesInstructions(context, components, utils) {
       const tokens = context.getFirstTokens(node, 2);
       if (
         node.typeAnnotation && (
-          tokens[0].value === 'props' ||
-          (tokens[1] && tokens[1].value === 'props')
+          tokens[0].value === 'props'
+          || (tokens[1] && tokens[1].value === 'props')
         )
       ) {
         return true;

--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -145,14 +145,14 @@ function isInLifeCycleMethod(node, checkAsyncSafeLifeCycles) {
  * @return {boolean}
  */
 function isSetStateUpdater(node) {
-  const unwrappedParentCalleeNode = node.parent.type === 'CallExpression' &&
-    ast.unwrapTSAsExpression(node.parent.callee);
+  const unwrappedParentCalleeNode = node.parent.type === 'CallExpression'
+    && ast.unwrapTSAsExpression(node.parent.callee);
 
-  return unwrappedParentCalleeNode &&
-    unwrappedParentCalleeNode.property &&
-    unwrappedParentCalleeNode.property.name === 'setState' &&
+  return unwrappedParentCalleeNode
+    && unwrappedParentCalleeNode.property
+    && unwrappedParentCalleeNode.property.name === 'setState'
     // Make sure we are in the updater not the callback
-    node.parent.arguments[0] === node;
+    && node.parent.arguments[0] === node;
 }
 
 function isPropArgumentInSetStateUpdater(context, name) {
@@ -161,18 +161,18 @@ function isPropArgumentInSetStateUpdater(context, name) {
   }
   let scope = context.getScope();
   while (scope) {
-    const unwrappedParentCalleeNode =
-      scope.block && scope.block.parent &&
-      scope.block.parent.type === 'CallExpression' &&
-      ast.unwrapTSAsExpression(scope.block.parent.callee);
+    const unwrappedParentCalleeNode = scope.block
+      && scope.block.parent
+      && scope.block.parent.type === 'CallExpression'
+      && ast.unwrapTSAsExpression(scope.block.parent.callee);
     if (
-      unwrappedParentCalleeNode &&
-      unwrappedParentCalleeNode.property &&
-      unwrappedParentCalleeNode.property.name === 'setState' &&
+      unwrappedParentCalleeNode
+      && unwrappedParentCalleeNode.property
+      && unwrappedParentCalleeNode.property.name === 'setState'
       // Make sure we are in the updater not the callback
-      scope.block.parent.arguments[0].range[0] === scope.block.range[0] &&
-      scope.block.parent.arguments[0].params &&
-      scope.block.parent.arguments[0].params.length > 1
+      && scope.block.parent.arguments[0].range[0] === scope.block.range[0]
+      && scope.block.parent.arguments[0].params
+      && scope.block.parent.arguments[0].params.length > 1
     ) {
       return scope.block.parent.arguments[0].params[1].name === name;
     }
@@ -191,10 +191,10 @@ function isInClassComponent(utils) {
  * @returns {boolean}
  */
 function isThisDotProps(node) {
-  return !!node &&
-    node.type === 'MemberExpression' &&
-    ast.unwrapTSAsExpression(node.object).type === 'ThisExpression' &&
-    node.property.name === 'props';
+  return !!node
+    && node.type === 'MemberExpression'
+    && ast.unwrapTSAsExpression(node.object).type === 'ThisExpression'
+    && node.property.name === 'props';
 }
 
 /**
@@ -257,8 +257,8 @@ function isPropTypesUsageByMemberExpression(node, context, utils, checkAsyncSafe
     }
     // props.* or prevProps.* or nextProps.*
     if (
-      isCommonVariableNameForProps(unwrappedObjectNode.name) &&
-      (inLifeCycleMethod(context, checkAsyncSafeLifeCycles) || utils.inConstructor())
+      isCommonVariableNameForProps(unwrappedObjectNode.name)
+      && (inLifeCycleMethod(context, checkAsyncSafeLifeCycles) || utils.inConstructor())
     ) {
       return true;
     }
@@ -297,15 +297,15 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
           allNames = parentNames.concat(name);
           if (
             // Match props.foo.bar, don't match bar[props.foo]
-            node.parent.type === 'MemberExpression' &&
-            node.parent.object === node
+            node.parent.type === 'MemberExpression'
+            && node.parent.object === node
           ) {
             markPropTypesAsUsed(node.parent, allNames);
           }
           // Handle the destructuring part of `const {foo} = props.a.b`
           if (
-            node.parent.type === 'VariableDeclarator' &&
-            node.parent.id.type === 'ObjectPattern'
+            node.parent.type === 'VariableDeclarator'
+            && node.parent.id.type === 'ObjectPattern'
           ) {
             node.parent.id.parent = node.parent; // patch for bug in eslint@4 in which ObjectPattern has no parent
             markPropTypesAsUsed(node.parent.id, allNames);
@@ -313,8 +313,8 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
 
           // const a = props.a
           if (
-            node.parent.type === 'VariableDeclarator' &&
-            node.parent.id.type === 'Identifier'
+            node.parent.type === 'VariableDeclarator'
+            && node.parent.id.type === 'Identifier'
           ) {
             propVariables.set(node.parent.id.name, allNames);
           }
@@ -330,9 +330,9 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
         }
         type = 'destructuring';
         const propParam = isSetStateUpdater(node) ? node.params[1] : node.params[0];
-        properties = propParam.type === 'AssignmentPattern' ?
-          propParam.left.properties :
-          propParam.properties;
+        properties = propParam.type === 'AssignmentPattern'
+          ? propParam.left.properties
+          : propParam.properties;
         break;
       }
       case 'ObjectPattern':
@@ -408,8 +408,8 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
     const param = node.params && isSetStateUpdater(node) ? node.params[1] : node.params[0];
 
     const destructuring = param && (
-      param.type === 'ObjectPattern' ||
-      param.type === 'AssignmentPattern' && param.left.type === 'ObjectPattern'
+      param.type === 'ObjectPattern'
+      || param.type === 'AssignmentPattern' && param.left.type === 'ObjectPattern'
     );
 
     if (destructuring && (components.get(node) || components.get(node.parent))) {
@@ -466,8 +466,8 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
 
       // let {props: {firstname}} = this
       const propsProperty = node.id.properties.find(property => (
-        property.key &&
-        (property.key.name === 'props' || property.key.value === 'props')
+        property.key
+        && (property.key.name === 'props' || property.key.value === 'props')
       ));
 
       if (unwrappedInitNode.type === 'ThisExpression' && propsProperty && propsProperty.value.type === 'ObjectPattern') {
@@ -483,8 +483,8 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
 
       // let {firstname} = props
       if (
-        isCommonVariableNameForProps(unwrappedInitNode.name) &&
-        (utils.getParentStatelessComponent() || isInLifeCycleMethod(node, checkAsyncSafeLifeCycles))
+        isCommonVariableNameForProps(unwrappedInitNode.name)
+        && (utils.getParentStatelessComponent() || isInLifeCycleMethod(node, checkAsyncSafeLifeCycles))
       ) {
         markPropTypesAsUsed(node.id);
         return;

--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -22,8 +22,8 @@ function detectReactVersion() {
   } catch (e) {
     if (e.code === 'MODULE_NOT_FOUND') {
       if (!warnedForMissingVersion) {
-        error('Warning: React version was set to "detect" in eslint-plugin-react settings, ' +
-        'but the "react" package is not installed. Assuming latest React version for linting.');
+        error('Warning: React version was set to "detect" in eslint-plugin-react settings, '
+        + 'but the "react" package is not installed. Assuming latest React version for linting.');
         warnedForMissingVersion = true;
       }
       return '999.999.999';
@@ -41,13 +41,13 @@ function getReactVersionFromContext(context) {
       settingsVersion = detectReactVersion();
     }
     if (typeof settingsVersion !== 'string') {
-      error('Warning: React version specified in eslint-plugin-react-settings must be a string; ' +
-        `got “${typeof settingsVersion}”`);
+      error('Warning: React version specified in eslint-plugin-react-settings must be a string; '
+        + `got “${typeof settingsVersion}”`);
     }
     confVer = String(settingsVersion);
   } else if (!warnedForMissingVersion) {
-    error('Warning: React version not specified in eslint-plugin-react settings. ' +
-      'See https://github.com/yannickcr/eslint-plugin-react#configuration .');
+    error('Warning: React version not specified in eslint-plugin-react settings. '
+      + 'See https://github.com/yannickcr/eslint-plugin-react#configuration .');
     warnedForMissingVersion = true;
   }
   confVer = /^[0-9]+\.[0-9]+$/.test(confVer) ? `${confVer}.0` : confVer;
@@ -61,8 +61,8 @@ function detectFlowVersion() {
     return flowPackageJson.version;
   } catch (e) {
     if (e.code === 'MODULE_NOT_FOUND') {
-      error('Warning: Flow version was set to "detect" in eslint-plugin-react settings, ' +
-        'but the "flow-bin" package is not installed. Assuming latest Flow version for linting.');
+      error('Warning: Flow version was set to "detect" in eslint-plugin-react settings, '
+        + 'but the "flow-bin" package is not installed. Assuming latest Flow version for linting.');
       return '999.999.999';
     }
     throw e;
@@ -78,8 +78,8 @@ function getFlowVersionFromContext(context) {
       flowVersion = detectFlowVersion();
     }
     if (typeof flowVersion !== 'string') {
-      error('Warning: Flow version specified in eslint-plugin-react-settings must be a string; ' +
-        `got “${typeof flowVersion}”`);
+      error('Warning: Flow version specified in eslint-plugin-react-settings must be a string; '
+        + `got “${typeof flowVersion}”`);
     }
     confVer = String(flowVersion);
   } else {
@@ -98,9 +98,9 @@ function test(context, methodVer, confVer) {
   const confVers = normalizeParts(confVer);
   const higherMajor = methodVers[0] < confVers[0];
   const higherMinor = methodVers[0] === confVers[0] && methodVers[1] < confVers[1];
-  const higherOrEqualPatch = methodVers[0] === confVers[0] &&
-    methodVers[1] === confVers[1] &&
-    methodVers[2] <= confVers[2];
+  const higherOrEqualPatch = methodVers[0] === confVers[0]
+    && methodVers[1] === confVers[1]
+    && methodVers[2] <= confVers[2];
 
   return higherMajor || higherMinor || higherOrEqualPatch;
 }

--- a/tests/lib/rules/jsx-fragments.js
+++ b/tests/lib/rules/jsx-fragments.js
@@ -99,22 +99,22 @@ ruleTester.run('jsx-fragments', rule, {
     parser: parsers.BABEL_ESLINT,
     settings: settingsOld,
     errors: [{
-      message: 'Fragments are only supported starting from React v16.2. ' +
-        'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
+      message: 'Fragments are only supported starting from React v16.2. '
+        + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
     }]
   }, {
     code: '<Act.Frag><Foo /></Act.Frag>',
     settings: settingsOld,
     errors: [{
-      message: 'Fragments are only supported starting from React v16.2. ' +
-        'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
+      message: 'Fragments are only supported starting from React v16.2. '
+        + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
     }]
   }, {
     code: '<Act.Frag />',
     settings: settingsOld,
     errors: [{
-      message: 'Fragments are only supported starting from React v16.2. ' +
-        'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
+      message: 'Fragments are only supported starting from React v16.2. '
+        + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
     }]
   }, {
     code: '<><Foo /></>',

--- a/tests/lib/rules/jsx-no-script-url.js
+++ b/tests/lib/rules/jsx-no-script-url.js
@@ -25,8 +25,8 @@ const parserOptions = {
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({parserOptions});
-const message = 'A future version of React will block javascript: URLs as a security precaution. ' +
-  'Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.';
+const message = 'A future version of React will block javascript: URLs as a security precaution. '
+  + 'Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.';
 const defaultErrors = [{message}];
 
 ruleTester.run('jsx-no-script-url', rule, {

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -26,8 +26,8 @@ const parserOptions = {
 
 const ruleTester = new RuleTester({parserOptions});
 const defaultErrors = [{
-  message: 'Using target="_blank" without rel="noreferrer" is a security risk:' +
-  ' see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
+  message: 'Using target="_blank" without rel="noreferrer" is a security risk:'
+  + ' see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
 }];
 
 ruleTester.run('jsx-no-target-blank', rule, {

--- a/tests/lib/rules/no-adjacent-inline-elements.js
+++ b/tests/lib/rules/no-adjacent-inline-elements.js
@@ -74,8 +74,8 @@ ruleTester.run('no-adjacent-inline-elements', rule, {
       parserOptions
     },
     {
-      code: ('React.createElement("div", undefined, [React.createElement("a"), ' +
-        '" some text ", React.createElement("a")]);'),
+      code: ('React.createElement("div", undefined, [React.createElement("a"), '
+        + '" some text ", React.createElement("a")]);'),
       parserOptions
     },
     {

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -223,8 +223,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 3,
@@ -233,8 +233,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 4,
@@ -242,8 +242,8 @@ ruleTester.run('no-deprecated', rule, {
         },
         {
           message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 5,
@@ -265,8 +265,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 4,
@@ -275,8 +275,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 5,
@@ -284,8 +284,8 @@ ruleTester.run('no-deprecated', rule, {
         },
         {
           message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 6,
@@ -305,8 +305,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 3,
@@ -315,8 +315,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 4,
@@ -324,8 +324,8 @@ ruleTester.run('no-deprecated', rule, {
         },
         {
           message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 5,
@@ -345,8 +345,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 3,
@@ -355,8 +355,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 4,
@@ -364,8 +364,8 @@ ruleTester.run('no-deprecated', rule, {
         },
         {
           message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 5,
@@ -385,8 +385,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 3,
@@ -395,8 +395,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 4,
@@ -404,8 +404,8 @@ ruleTester.run('no-deprecated', rule, {
         },
         {
           message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 5,
@@ -425,8 +425,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 3,
@@ -435,8 +435,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 4,
@@ -444,8 +444,8 @@ ruleTester.run('no-deprecated', rule, {
         },
         {
           message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 5,
@@ -466,8 +466,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 4,
@@ -476,8 +476,8 @@ ruleTester.run('no-deprecated', rule, {
         {
           message: errorMessage(
             'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 5,
@@ -485,8 +485,8 @@ ruleTester.run('no-deprecated', rule, {
         },
         {
           message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. ' +
-            'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
+            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
           ),
           type: 'Identifier',
           line: 6,


### PR DESCRIPTION
Current configuration enforces ternary expressions to be written like:
```
a ?
b :
c
```
This is the opposite of the popular style. It is probably a mistake introduced during the time when this project was being converted to Airbnb style.