### PR TITLE
[fix] `prefer-stateless-function`: avoid crash on ts empty constructor

### DIFF
--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -186,6 +186,7 @@ module.exports = {
         const contextTypes = name === 'contextTypes';
         const defaultProps = name === 'defaultProps';
         const isUselessConstructor = property.kind === 'constructor' &&
+          !!property.value.body &&
           isRedundantSuperCall(property.value.body.body, property.value.params);
         const isRender = name === 'render';
         return !isDisplayName && !isPropTypes && !contextTypes && !defaultProps && !isUselessConstructor && !isRender;

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -158,6 +158,18 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `
     }, {
+      // Issue 2187
+      code: `
+        class Foo extends React.Component {
+          constructor(props)
+
+          render() {
+            return <div>{this.props.foo}</div>;
+          }
+        }
+      `,
+      parser: parsers.TYPESCRIPT_ESLINT
+    }, {
       // Use this.bar
       code: `
         class Foo extends React.Component {


### PR DESCRIPTION
fixes #2187

Typescript allows constructor without body, like
```ts
class Foo {
  constructor(a)
}
```

This PR adds a null check to avoid crash.