### PR TITLE
[tests] delete test cases that became parsing error after acorn-jsx@5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "object.values": "^1.1.1",
     "prop-types": "^15.7.2",
     "resolve": "^1.15.1",
+    "semver": "^6.3.0",
     "string.prototype.matchall": "^4.0.2",
     "xregexp": "^4.3.0"
   },
@@ -69,5 +70,10 @@
     "eslintplugin",
     "react"
   ],
-  "license": "MIT"
+  "license": "MIT",
+  "greenkeeper": {
+    "ignore": [
+      "semver"
+    ]
+  }
 }

--- a/tests/lib/rules/no-unescaped-entities.js
+++ b/tests/lib/rules/no-unescaped-entities.js
@@ -9,6 +9,14 @@
 // Requirements
 // ------------------------------------------------------------------------------
 
+const semver = require('semver');
+
+let allowsInvalidJSX = false;
+try {
+  // eslint-disable-next-line import/no-extraneous-dependencies, global-require
+  allowsInvalidJSX = semver.satisfies(require('acorn-jsx/package.json').version, '< 5.2');
+} catch (e) { /**/ }
+
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/no-unescaped-entities');
 
@@ -107,7 +115,7 @@ ruleTester.run('no-unescaped-entities', rule, {
   ],
 
   invalid: [
-    {
+    (allowsInvalidJSX && {
       code: `
         var Hello = createReactClass({
           render: function() {
@@ -116,7 +124,7 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       errors: [{message: '`>` can be escaped with `&gt;`.'}]
-    }, {
+    }), {
       code: `
         var Hello = createReactClass({
           render: function() {
@@ -126,7 +134,7 @@ ruleTester.run('no-unescaped-entities', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{message: '`>` can be escaped with `&gt;`.'}]
-    }, {
+    }, (allowsInvalidJSX && {
       code: `
         var Hello = createReactClass({
           render: function() {
@@ -137,7 +145,7 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       errors: [{message: '`>` can be escaped with `&gt;`.'}]
-    }, {
+    }), {
       code: `
         var Hello = createReactClass({
           render: function() {
@@ -158,7 +166,7 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       errors: [{message: '`\'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`.'}]
-    }, {
+    }, (allowsInvalidJSX && {
       code: `
         var Hello = createReactClass({
           render: function() {
@@ -171,7 +179,7 @@ ruleTester.run('no-unescaped-entities', rule, {
         {message: '`>` can be escaped with `&gt;`.'},
         {message: '`>` can be escaped with `&gt;`.'}
       ]
-    }, {
+    }), (allowsInvalidJSX && {
       code: `
         var Hello = createReactClass({
           render: function() {
@@ -180,7 +188,7 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       errors: [{message: '`}` can be escaped with `&#125;`.'}]
-    }, {
+    }), {
       code: `
         var Hello = createReactClass({
           render: function() {
@@ -231,5 +239,5 @@ ruleTester.run('no-unescaped-entities', rule, {
         }]
       }]
     }
-  ]
+  ].filter(Boolean)
 });


### PR DESCRIPTION
CI is failing after the release of acorn-jsx@5.2.0, 4 days ago, which is a dependency of espree. https://github.com/acornjs/acorn-jsx/releases/tag/5.2.0. That release introduced a breaking change that forbids `>` and `}` in JSXText. Therefore codes like `<p>></p>` became a parsing error.

This PR removed test cases that became parsing error after acorn-jsx@5.2.0.

An expensive alternative is to setup tests for both acorn-jsx < 5.2.0 and > 5.2.0. But that is expensive.
