### PR TITLE
[fix] `displayName`: avoid a crash when using React.memo

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -483,7 +483,9 @@ function componentRule(rule, context) {
       }
       if (body.type === 'BlockStatement') {
         const jsxElement = body.body.find(item => item.type === 'ReturnStatement');
-        return jsxElement && this.getComponentNameFromJSXElement(jsxElement.argument);
+        return jsxElement &&
+          jsxElement.argument &&
+          this.getComponentNameFromJSXElement(jsxElement.argument);
       }
       return null;
     },

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -465,6 +465,14 @@ ruleTester.run('display-name', rule, {
     `
   }, {
     code: `
+      import React from 'react';
+
+      const Hello = React.memo(function Hello() {
+        return;
+      });
+    `
+  }, {
+    code: `
       import React from 'react'
 
       const ForwardRefComponentLike = React.forwardRef(function ComponentLike({ world }, ref) {


### PR DESCRIPTION
This pr adds a null check, to avoid a crash that happens when using `React.memo` plus a return statement without an argument. Like
```js
import React from 'react';
const Hello = React.memo(function Hello() {
  return;
});
```

