### PR TITLE
[Fix] `prop-types`: avoid crash when spreading any type

### DIFF
--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -155,7 +155,7 @@ function stripQuotes(string) {
  * Retrieve the name of a key node
  * @param {Context} context The AST node with the key.
  * @param {ASTNode} node The AST node with the key.
- * @return {string} the name of the key
+ * @return {string | undefined} the name of the key
  */
 function getKeyValue(context, node) {
   if (node.type === 'ObjectTypeProperty') {
@@ -172,6 +172,9 @@ function getKeyValue(context, node) {
     return;
   }
   const key = node.key || node.argument;
+  if (!key) {
+    return;
+  }
   return key.type === 'Identifier' ? key.name : key.value;
 }
 

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -1651,6 +1651,17 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT
     }, {
+      code: `
+        type FooProps = {
+          ...any,
+          ...42,
+        }
+        function Foo(props: FooProps) {
+          return <p />;
+        }
+      `,
+      parser: parsers.BABEL_ESLINT
+    }, {
       code: [
         'type Person = {',
         '  firstname: string',


### PR DESCRIPTION
Fixes #2605.