### PR TITLE
(cosmetic) Quote this as `this` in the no-this-in-sfc rule

### DIFF
--- a/docs/rules/no-this-in-sfc.md
+++ b/docs/rules/no-this-in-sfc.md
@@ -1,9 +1,8 @@
 # Prevent `this` from being used in stateless functional components (react/no-this-in-sfc)
 
-When using a stateless functional component (SFC), props/context aren't accessed in the same way as a class component or the `create-react-class` format. Both props and context are passed as separate arguments to the component instead. Also, as the name suggests, a stateless component does not have state on `this.state`.
+In React, there are two styles of component. One is a class component: `class Foo extends React.Component {...}`, which accesses its props, context, and state as properties of `this`: `this.props.foo`, etc. The other are stateless functional components (SFCs): `function Foo(props, context) {...}`. As you can see, there's no `state` (hence the name - hooks do not change this), and the props and context are provided as its two functional arguments. In an SFC, state is usually best implements with a [React hook](https://reactjs.org/docs/hooks-overview.html) such as `React.useState()`.
 
-Attempting to access properties on `this` can be a potential error if someone is unaware of the differences when writing a SFC or missed when converting a class component to a SFC.
-
+Attempting to access properties on `this` can sometimes be valid, but it's very commonly an error caused by unfamiliarity with the differences between the two styles of components, or a missed reference when converting a class component to an SFC.
 
 ## Rule Details
 

--- a/lib/rules/no-this-in-sfc.js
+++ b/lib/rules/no-this-in-sfc.js
@@ -11,7 +11,7 @@ const docsUrl = require('../util/docsUrl');
 // Constants
 // ------------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Stateless functional components should not use this';
+const ERROR_MESSAGE = 'Stateless functional components should not use `this`';
 
 // ------------------------------------------------------------------------------
 // Rule Definition

--- a/tests/lib/rules/no-this-in-sfc.js
+++ b/tests/lib/rules/no-this-in-sfc.js
@@ -8,7 +8,7 @@
 // Constants
 // ------------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Stateless functional components should not use this';
+const ERROR_MESSAGE = 'Stateless functional components should not use `this`';
 
 // ------------------------------------------------------------------------------
 // Requirements


### PR DESCRIPTION
I had a "Who's on First?" moment looking at `no-this-in-sfc`'s error message: `Stateless functional components should not use this'.

In this case this message caused this hacker to seek the referent of "this" in this rule (that is, `no-this-in-sfc`) which was not a this or a that in general, or this line qua this, but then saw that the "this" in this line of the `no-this-in-sfc` rule that the linter was telling me to not this in an sfc was in fact the `this` on this line of this function, because the `this` of this kind of component isn't used the way the `this` of that other kind of component is, like to sometimes set the state of its `state` and such, which, to state the obvious, is the sine qua non of a stateless functional component, as a stateless functional component is a functional component without `state` (as stated in the docs).

So...

I put quotes around the word `this`, and made the error documentation a little noob-friendlier, as we are the most likely to misuse `this` thus.

hashtag nope-not-stir-crazy-at-all...