### PR TITLE
Add Rules of Hooks to Other useful plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Enable the rules that you would like to use.
 
 ## Other useful plugins
 
+- Rules of Hooks: [eslint-plugin-react-hooks](https://github.com/facebook/react/tree/master/packages/eslint-plugin-react-hooks)
 - JSX accessibility: [eslint-plugin-jsx-a11y](https://github.com/evcohen/eslint-plugin-jsx-a11y)
 - React Native: [eslint-plugin-react-native](https://github.com/Intellicode/eslint-plugin-react-native)
 


### PR DESCRIPTION
Added the `rules-of-hooks` plugin to the Other useful plugins-section in the README.md as it's pretty much recommended for those who use hooks