### PR TITLE
Remove dependency on xregexp

### DIFF
--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -6,19 +6,58 @@
 'use strict';
 
 const elementType = require('jsx-ast-utils/elementType');
-const XRegExp = require('xregexp');
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
 
-// ------------------------------------------------------------------------------
-// Constants
-// ------------------------------------------------------------------------------
+function testDigit(char) {
+  const charCode = char.charCodeAt(0);
+  return charCode >= 48 && charCode <= 57;
+}
 
-// eslint-disable-next-line no-new
-const hasU = (function hasU() { try { new RegExp('o', 'u'); return true; } catch (e) { return false; } }());
+function testUpperCase(char) {
+  const upperCase = char.toUpperCase();
+  return char === upperCase && upperCase !== char.toLowerCase();
+}
 
-const PASCAL_CASE_REGEX = XRegExp('^(.*[.])*([\\p{Lu}]|[\\p{Lu}]+[\\p{Ll}0-9]+(?:[\\p{Lu}0-9]+[\\p{Ll}0-9]*)*)$', hasU ? 'u' : '');
-const ALL_CAPS_TAG_REGEX = XRegExp('^[\\p{Lu}0-9]+([\\p{Lu}0-9_]*[\\p{Lu}0-9]+)?$', hasU ? 'u' : '');
+function testLowerCase(char) {
+  const lowerCase = char.toLowerCase();
+  return char === lowerCase && lowerCase !== char.toUpperCase();
+}
+
+function testPascalCase(name) {
+  if (!testUpperCase(name.charAt(0))) {
+    return false;
+  }
+  let atLeastOneLowerCase = false;
+  for (let i = 1; i < name.length; i += 1) {
+    const char = name.charAt(i);
+    if (!(char.toLowerCase() !== char.toUpperCase() || testDigit(char))) {
+      return false;
+    }
+    if (!atLeastOneLowerCase) {
+      atLeastOneLowerCase = testLowerCase(char);
+    }
+  }
+  return atLeastOneLowerCase;
+}
+
+function testAllCaps(name) {
+  const firstChar = name.charAt(0);
+  if (!(testUpperCase(firstChar) || testDigit(firstChar))) {
+    return false;
+  }
+  for (let i = 1; i < name.length - 1; i += 1) {
+    const char = name.charAt(i);
+    if (!(testUpperCase(char) || testDigit(char) || char === '_')) {
+      return false;
+    }
+  }
+  const lastChar = name.charAt(name.length - 1);
+  if (!(testUpperCase(lastChar) || testDigit(lastChar))) {
+    return false;
+  }
+  return true;
+}
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -67,8 +106,8 @@ module.exports = {
           name = name.substring(name.lastIndexOf('.') + 1);
         }
 
-        const isPascalCase = PASCAL_CASE_REGEX.test(name);
-        const isAllowedAllCaps = allowAllCaps && ALL_CAPS_TAG_REGEX.test(name);
+        const isPascalCase = testPascalCase(name);
+        const isAllowedAllCaps = allowAllCaps && testAllCaps(name);
         const isIgnored = ignore.indexOf(name) !== -1;
 
         if (!isPascalCase && !isAllowedAllCaps && !isIgnored) {

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "object.values": "^1.1.1",
     "prop-types": "^15.7.2",
     "resolve": "^1.15.1",
-    "string.prototype.matchall": "^4.0.2",
-    "xregexp": "^4.3.0"
+    "string.prototype.matchall": "^4.0.2"
   },
   "devDependencies": {
     "@types/eslint": "^6.8.0",


### PR DESCRIPTION
Reimplemented the logic of extended regular expressions with functions in the `jsx-pascal-case` rule in order to remove the dependency on `xregexp`. This reduced the size of `node_modules` on my machine from 150MB to 140MB.

----

The dependency on `xregexp` was introduced in #2557 to support the full Unicode range. More specifically, it allows for using the `\p{Lu}` and `\p{Ll}` character classes, which are defined as such:

> \p{Ll} or \p{Lowercase_Letter}: a lowercase letter that has an uppercase variant.
> \p{Lu} or \p{Uppercase_Letter}: an uppercase letter that has a lowercase variant.

([Source](http://www.regular-expressions.info/unicode.html))

However, this logic can be implemented in JS by the respective expressions:
- `char === char.toLowerCase() && char.toUpperCase() !== char.toLowerCase()`
- `char === char.toUpperCase() && char.toUpperCase() !== char.toLowerCase()`

I have used this to replace the regular expressions with simple loops.

----

While working on this pull request, I might have found the origin of a bug. Discussion in this issue: https://github.com/yannickcr/eslint-plugin-react/issues/1334

The code is not the most readable; I tried to strike the right balance between expressivity and performance. I also dumped everything in the rule file.
I am happy to perform any changes that would improve code quality or code organisation following the PR review.