### PR TITLE
Added support (without options) for spread arguments with keys

### DIFF
--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -45,7 +45,25 @@ module.exports = {
     const fragmentPragma = pragmaUtil.getFragmentFromContext(context);
 
     function checkIteratorElement(node) {
-      if (node.type === 'JSXElement' && !hasProp(node.openingElement.attributes, 'key')) {
+      if (node.type === 'JSXElement') {
+        const hasAKeyAttribute = hasProp(node.openingElement.attributes, 'key');
+
+        const hasASpreadArgumentWithAKeyProperty = node.openingElement
+          && node.openingElement.attributes
+          && node.openingElement.attributes.some(
+            ({argument}) => argument && argument.properties && argument.properties.some(
+              (property) => property.key.name === 'key'));
+
+        const hasAnObjectSpreadArgument = node.openingElement
+          && node.openingElement.attributes
+          && node.openingElement.attributes.some(
+            ({argument}) => argument && argument.type === 'Identifier');
+
+        const isValidElement = hasAKeyAttribute
+         || hasASpreadArgumentWithAKeyProperty
+         || hasAnObjectSpreadArgument;
+        if (isValidElement) return;
+
         context.report({
           node,
           message: 'Missing "key" prop for element in iterator'

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -15,7 +15,8 @@ const pragmaUtil = require('../util/pragma');
 // ------------------------------------------------------------------------------
 
 const defaultOptions = {
-  checkFragmentShorthand: false
+  checkFragmentShorthand: false,
+  allowSpreadKeys: true // TODO: When React separates keys from props this should become false
 };
 
 module.exports = {
@@ -32,6 +33,10 @@ module.exports = {
         checkFragmentShorthand: {
           type: 'boolean',
           default: defaultOptions.checkFragmentShorthand
+        },
+        allowSpreadKeys: {
+          type: 'boolean',
+          default: defaultOptions.allowSpreadKeys
         }
       },
       additionalProperties: false
@@ -41,6 +46,7 @@ module.exports = {
   create(context) {
     const options = Object.assign({}, defaultOptions, context.options[0]);
     const checkFragmentShorthand = options.checkFragmentShorthand;
+    const allowSpreadKeys = options.allowSpreadKeys;
     const reactPragma = pragmaUtil.getFromContext(context);
     const fragmentPragma = pragmaUtil.getFragmentFromContext(context);
 
@@ -48,13 +54,13 @@ module.exports = {
       if (node.type === 'JSXElement') {
         const hasAKeyAttribute = hasProp(node.openingElement.attributes, 'key');
 
-        const hasASpreadArgumentWithAKeyProperty = node.openingElement
+        const hasASpreadArgumentWithAKeyProperty = allowSpreadKeys && node.openingElement
           && node.openingElement.attributes
           && node.openingElement.attributes.some(
             ({argument}) => argument && argument.properties && argument.properties.some(
               (property) => property.key.name === 'key'));
 
-        const hasAnObjectSpreadArgument = node.openingElement
+        const hasAnObjectSpreadArgument = allowSpreadKeys && node.openingElement
           && node.openingElement.attributes
           && node.openingElement.attributes.some(
             ({argument}) => argument && argument.type === 'Identifier');

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -39,6 +39,8 @@ ruleTester.run('jsx-key', rule, {
     {code: 'fn()'},
     {code: '[1, 2, 3].map(function () {})'},
     {code: '<App />;'},
+    {code: '[1, 2, 3].map(x => <App {...{ key }} />);'},
+    {code: '[1, 2, 3].map(x => <App {...objectWithKey} />);'},
     {code: '[<App key={0} />, <App key={1} />];'},
     {code: '[1, 2, 3].map(function(x) { return <App key={x} /> });'},
     {code: '[1, 2, 3].map(x => <App key={x} />);'},

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -39,8 +39,14 @@ ruleTester.run('jsx-key', rule, {
     {code: 'fn()'},
     {code: '[1, 2, 3].map(function () {})'},
     {code: '<App />;'},
-    {code: '[1, 2, 3].map(x => <App {...{ key }} />);'},
-    {code: '[1, 2, 3].map(x => <App {...objectWithKey} />);'},
+    {
+      code: '[1, 2, 3].map(x => <App {...{ key }} />);',
+      options: [{allowSpreadKeys: true}]
+    },
+    {
+      code: '[1, 2, 3].map(x => <App {...objectWithKey} />);',
+      options: [{allowSpreadKeys: true}]
+    },
     {code: '[<App key={0} />, <App key={1} />];'},
     {code: '[1, 2, 3].map(function(x) { return <App key={x} /> });'},
     {code: '[1, 2, 3].map(x => <App key={x} />);'},
@@ -90,5 +96,14 @@ ruleTester.run('jsx-key', rule, {
     options: [{checkFragmentShorthand: true}],
     settings,
     errors: [{message: 'Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use Act.Frag instead'}]
+  }, {
+    code: '[1, 2, 3].map(x => <App {...{ key }} />);',
+    options: [{allowSpreadKeys: false}],
+    errors: [{message: 'Missing "key" prop for element in iterator'}]
+  },
+  {
+    code: '[1, 2, 3].map(x => <App {...objectWithKey} />);',
+    options: [{allowSpreadKeys: false}],
+    errors: [{message: 'Missing "key" prop for element in iterator'}]
   })
 });


### PR DESCRIPTION
This is just a first step to try and solve: https://github.com/yannickcr/eslint-plugin-react/issues/1753

This is ONLY a request for code review: please do not merge.  I just wanted to get feedback on what I have so far before I add in options.  Also I wanted to get your thoughts on whether we should have two options or just one.

It seems like we definitely want to guard this new flexibility with some sort of "allow spread keys" option, but then do we want just one, or do we want to allow *explicit* spread keys:

    <Foo {...{ key }} />

separately from *implicit* ones:

    <Foo {...someObjectThatPresumablyHasAKey} />

Hypothetically speaking  I could see a dev wanting to allow the former but not the latter ... but maybe that's YAGNI?