### PR TITLE
[Fix] `forbid-dom-props`, `function-component-definition`: fix schema typos

### DIFF
--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -32,7 +32,7 @@ module.exports = {
         forbid: {
           type: 'array',
           items: {
-            onfOf: [{
+            oneOf: [{
               type: 'string'
             }, {
               type: 'object',

--- a/lib/rules/function-component-definition.js
+++ b/lib/rules/function-component-definition.js
@@ -100,7 +100,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'Standardize the way function component get defined',
-      category: 'Stylistic issues',
+      category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('function-component-definition')
     },


### PR DESCRIPTION
Small typos in rule schema definitions I discovered testing my VSCode extension to manage .eslintrc files.