### PR TITLE
Cache detected React version

### DIFF
--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -14,11 +14,22 @@ function resetWarningFlag() {
   warnedForMissingVersion = false;
 }
 
+let cachedDetectedReactVersion;
+
+function resetDetectedVersion() {
+  cachedDetectedReactVersion = undefined;
+}
+
 function detectReactVersion() {
+  if (cachedDetectedReactVersion) {
+    return cachedDetectedReactVersion;
+  }
+
   try {
     const reactPath = resolve.sync('react', {basedir: process.cwd()});
     const react = require(reactPath); // eslint-disable-line global-require, import/no-dynamic-require
-    return react.version;
+    cachedDetectedReactVersion = react.version;
+    return cachedDetectedReactVersion;
   } catch (e) {
     if (e.code === 'MODULE_NOT_FOUND') {
       if (!warnedForMissingVersion) {
@@ -26,7 +37,8 @@ function detectReactVersion() {
         + 'but the "react" package is not installed. Assuming latest React version for linting.');
         warnedForMissingVersion = true;
       }
-      return '999.999.999';
+      cachedDetectedReactVersion = '999.999.999';
+      return cachedDetectedReactVersion;
     }
     throw e;
   }
@@ -116,5 +128,6 @@ function testFlowVersion(context, methodVer) {
 module.exports = {
   testReactVersion,
   testFlowVersion,
-  resetWarningFlag
+  resetWarningFlag,
+  resetDetectedVersion
 };

--- a/tests/util/version.js
+++ b/tests/util/version.js
@@ -16,6 +16,7 @@ describe('Version', () => {
     sinon.stub(console, 'error');
     expectedErrorArgs = [];
     versionUtil.resetWarningFlag();
+    versionUtil.resetDetectedVersion();
   });
 
   afterEach(() => {


### PR DESCRIPTION
I've been timing and profiling ESLint runs at Airbnb and noticed that
react/no-unknown-property is particularly slow for us when using the
"detect" setting for React version.

When running ESLint using TIMING=1 on a directory that contains about
500 files to be linted in it, react/no-unknown-property shows up as
taking about 1700ms.

Looking at the callstacks in the profiler, it seems that when this rule
calls getStandardName for every JSXAttribute here, it will actually do
all of the work to detect the React version every time to determine the
correct set of DOM property names. Since there may be a lot of
JSXAttribute nodes in a codebase, this adds up to quite a bit of work.

By specifying the react version in our ESLint config, the
no-unkown-property rule drops out of the top 10 slowest rules entirely,
with the 10th slowest clocking in at 180ms.

I think it would be a good idea to cache the React version when using
detect instead of looking it up every time.

Fixes #2671 