### PR TITLE
Forbid objectof 2662

### DIFF
--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -59,6 +59,15 @@ module.exports = {
       return forbid.indexOf(type) >= 0;
     }
 
+    function reportIfForbidden(type, declaration, target) {
+      if (isForbidden(type)) {
+        context.report({
+          node: declaration,
+          message: `Prop type \`${target}\` is forbidden`
+        });
+      }
+    }
+
     function shouldCheckContextTypes(node) {
       if (checkContextTypes && propsUtil.isContextTypesDeclaration(node)) {
         return true;
@@ -93,10 +102,10 @@ module.exports = {
         ) {
           value = value.object;
         }
-        if (
-          value.type === 'CallExpression'
-          && value.callee.type === 'MemberExpression'
-        ) {
+        if (value.type === 'CallExpression') {
+          value.arguments.forEach((arg) => {
+            reportIfForbidden(arg.name, declaration, target);
+          });
           value = value.callee;
         }
         if (value.property) {
@@ -104,12 +113,7 @@ module.exports = {
         } else if (value.type === 'Identifier') {
           target = value.name;
         }
-        if (isForbidden(target)) {
-          context.report({
-            node: declaration,
-            message: `Prop type \`${target}\` is forbidden`
-          });
-        }
+        reportIfForbidden(target, declaration, target);
       });
     }
 
@@ -159,6 +163,15 @@ module.exports = {
         }
 
         checkNode(node.parent.right);
+      },
+
+      CallExpression(node) {
+        if (
+          node.arguments.length > 0
+          && (node.callee.name === 'shape' || astUtil.getPropertyName(node.callee) === 'shape')
+        ) {
+          checkProperties(node.arguments[0].properties);
+        }
       },
 
       MethodDefinition(node) {

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -572,20 +572,6 @@ ruleTester.run('forbid-prop-types', rule, {
       '  preview: PropTypes.bool,',
       '}, componentApi, teaserListProps);'
     ].join('\n')
-  }, {
-    code: [
-      'var First = createReactClass({',
-      '  propTypes: {',
-      '    s: PropTypes.shape({',
-      '      o: PropTypes.object',
-      '    })',
-      '  },',
-      '  render: function() {',
-      '    return <div />;',
-      '  }',
-      '});'
-    ].join('\n'),
-    errors: 0 // TODO: fix #1673 and move this to "invalid"
   }],
 
   invalid: [{
@@ -1459,6 +1445,87 @@ ruleTester.run('forbid-prop-types', rule, {
       forbid: ['instanceOf'],
       checkChildContextTypes: true
     }],
+    errors: 1
+  }, {
+    code: [
+      'import { object, string } from "prop-types";',
+      'function C({ a, b }) { return [a, b]; }',
+      'C.propTypes = {',
+      '  a: object,',
+      '  b: string',
+      '};'
+    ].join('\n'),
+    options: [{
+      forbid: ['object']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'import { objectOf, any } from "prop-types";',
+      'function C({ a }) { return a; }',
+      'C.propTypes = {',
+      '  a: objectOf(any)',
+      '};'
+    ].join('\n'),
+    options: [{
+      forbid: ['any']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'import { objectOf, any } from "prop-types";',
+      'function C({ a }) { return a; }',
+      'C.propTypes = {',
+      '  a: objectOf(any)',
+      '};'
+    ].join('\n'),
+    options: [{
+      forbid: ['objectOf']
+    }],
+    errors: 1
+  },
+  {
+    code: [
+      'import { shape, any } from "prop-types";',
+      'function C({ a }) { return a; }',
+      'C.propTypes = {',
+      '  a: shape({',
+      '    b: any',
+      '  })',
+      '};'
+    ].join('\n'),
+    options: [{
+      forbid: ['any']
+    }],
+    errors: 1
+  },
+  {
+    code: [
+      'import { any } from "prop-types";',
+      'function C({ a }) { return a; }',
+      'C.propTypes = {',
+      '  a: PropTypes.shape({',
+      '    b: any',
+      '  })',
+      '};'
+    ].join('\n'),
+    options: [{
+      forbid: ['any']
+    }],
+    errors: 1
+  }, {
+    code: [
+      'var First = createReactClass({',
+      '  propTypes: {',
+      '    s: PropTypes.shape({',
+      '      o: PropTypes.object',
+      '    })',
+      '  },',
+      '  render: function() {',
+      '    return <div />;',
+      '  }',
+      '});'
+    ].join('\n'),
     errors: 1
   }]
 });


### PR DESCRIPTION
In this case the type of the callee was 'Identifier' (vs 'MemberExpression'), which seems to makes sense because it is not being called as a property on PropTypes object.  I looked back at the history to see if maybe that check was added for a particular reason but it seems like it has been there from the beginning:

https://github.com/yannickcr/eslint-plugin-react/commit/00f716a990c247e844a5dba85220d3af7d6e3693

I can't think of any reason why it would be needed but if someone who knows better than me does, I'd be happy to hear it.