### PR TITLE
[Tests] `no-typos`:  move a valid case into valid section

### DIFF
--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -8,6 +8,8 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
+const semver = require('semver');
+const eslintPkg = require('eslint/package.json');
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/no-typos');
 
@@ -1286,7 +1288,7 @@ ruleTester.run('no-typos', rule, {
     }, {
       message: 'Typo in prop type chain qualifier: isrequired'
     }]
-  }, {
+  }].concat(semver.satisfies(eslintPkg.version, '>= 7.3') ? [] : {
     code: `
      import 'react';
      class Component extends React.Component {};
@@ -1294,7 +1296,7 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: []
-  }, {
+  }, [{
     code: `
       import { PropTypes } from 'react';
       class Component extends React.Component {};
@@ -1698,5 +1700,5 @@ ruleTester.run('no-typos', rule, {
         parserOptions: parserOptions
       },
     */
-  }]
+  }])
 });


### PR DESCRIPTION
It seems CI is failing.

```
  4345 passing (12s)
  1 failing
  1) no-typos
       invalid
         
     import 'react';
     class Component extends React.Component {};
   :
     AssertionError [ERR_ASSERTION]: Invalid cases must have at least one error
      at testInvalidTemplate (node_modules/eslint/lib/rule-tester/rule-tester.js:648:24)
      at Context.RuleTester.it (node_modules/eslint/lib/rule-tester/rule-tester.js:883:25)
      at processImmediate (internal/timers.js:443:21)
```

I moved a valid case into a valid section.