### PR TITLE
[New] : Avoid unsafe global window use

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Enable the rules that you would like to use.
 * [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md): Detect unescaped HTML entities, which might represent malformed tags
 * [react/no-unknown-property](docs/rules/no-unknown-property.md): Prevent usage of unknown DOM property (fixable)
 * [react/no-unsafe](docs/rules/no-unsafe.md): Prevent usage of unsafe lifecycle methods
+* [react/no-unsafe-window-use](docs/rules/no-unsafe-window-use.md): Prevent unsafe window use
 * [react/no-unused-prop-types](docs/rules/no-unused-prop-types.md): Prevent definitions of unused prop types
 * [react/no-unused-state](docs/rules/no-unused-state.md): Prevent definition of unused state fields
 * [react/no-will-update-set-state](docs/rules/no-will-update-set-state.md): Prevent usage of setState in componentWillUpdate

--- a/docs/rules/no-unsafe-window-use.md
+++ b/docs/rules/no-unsafe-window-use.md
@@ -1,1 +1,271 @@
-# Avoid unsafe global window use (react/no-unsafe-window-use)
+# Prevent unsafe window use (react/no-unsafe-window-use)
+
+Rendering React apps in Node environments has become popular with the light of tools like [Gatsby][gatsby] and [Next.js][nextjs]. But in these environments, things that we are used to in the web, like `window`, are not available.
+
+[gatsby]: http://gatsbyjs.org/
+[nextjs]: https://nextjs.org/
+
+## Rule Details
+
+The purpose of this rule is to prevent common errors related to the unsafe use of the `window` on apps intended to be rendered in environments other than the browser.
+
+The following patterns are considered warnings:
+
+```js
+window.bar = "baz"
+```
+
+```js
+if (typeof window !== 'undefined') {
+} else {
+  window.bar = "baz"
+}
+```
+
+```js
+function bar() {
+  window.something()
+}
+```
+
+```js
+class Test {
+  handle() {
+    window.bar = "baz"
+  }
+}
+```
+
+```jsx
+class Test extends React.Component {
+  render() {
+    window.bar = "baz"
+    return <button onClick={this.handleClick} />
+  }
+};
+```
+
+```jsx
+class Test extends React.Component {
+  handleClick() {
+    window.bar = "baz"
+  }
+  render() {
+    this.handleClick()
+    return <button onClick={this.handleClick} />
+  }
+};
+```
+
+```jsx
+class Test extends React.Component {
+  handleClick() {
+    window.bar = "baz"
+  }
+  otherHandler() {
+    this.handleClick()
+  }
+  render() {
+    this.otherHandler()
+    return <button onClick={this.otherHandler} />
+  }
+};
+```
+
+```jsx
+function Test() {
+  function handleClick() {
+    window.bar = "baz"
+  }
+  handleClick()
+  return (
+    <button onClick={handleClick}>
+      Click me!
+    </button>
+  )
+}
+```
+
+```jsx
+function Test() {
+  function handleClick() {
+    window.bar = "baz"
+  }
+  function otherHandler() {
+    handleClick()
+  }
+  otherHandler()
+  return (
+    <button onClick={otherHandler}>
+      Click me!
+    </button>
+  )
+}
+```
+
+```jsx
+class Test extends React.Component {
+  constructor() {
+    super()
+    window.bar = "baz"
+  }
+  render() {
+    return <div />
+  }
+};
+```
+
+```jsx
+class Test extends React.Component {
+  constructor(props) {
+    super(props)
+    this.handler()
+  }
+  handler() {
+    window.bar = "baz"
+  }
+  render() {
+    return <div />
+  }
+};
+```
+
+The following patterns are **not** considered warnings:
+
+```js
+if (typeof window !== 'undefined') {
+  console.log(window)
+}
+```
+
+```js
+typeof window !== "undefined" ? doSomething(window) : null
+```
+
+```js
+typeof window !== "undefined" && doSomething(window)
+```
+
+```jsx
+// Can use handler and window inside componentDidUpdate, componentDidMount and, componentWillUnmount
+
+class Test extends React.Component {
+  handleClick() {
+    window.bar = "baz"
+  }
+  componentDidUpdate() {
+    window.bar = "baz"
+    this.handleClick()
+  }
+  componentDidMount() {
+    window.bar = "baz"
+    this.handleClick()
+  }
+  componentWillUnmount() {
+    window.bar = "baz"
+    this.handleClick()
+  }
+  render() {
+    return <button onClick={this.handleClick} />
+  }
+};
+```
+
+```jsx
+// Can use handler and window inside useEffect, useLayoutEffect and, useCallback.
+function Test() {
+  function handleClick() {
+    window.bar = "baz"
+  }
+  useEffect(() => {
+    window.bar = "baz"
+    handleClick()
+  })
+  useLayoutEffect(() => {
+    window.bar = "baz"
+    handleClick()
+  })
+  const callback = useCallback(() => {
+    window.bar = "baz"
+    handleClick()
+  }, [])
+  return (
+    <div>
+      <button onClick={handleClick}>
+        Click me!
+      </button>
+      <button onClick={callback}>
+        Click me 2!
+      </button>
+    </div>
+  )
+}
+```
+
+```jsx
+// It is safe to use guarded handlers
+class Test extends React.Component {
+  handleClick() {
+    if (typeof window !== 'undefined') {
+      window.bar = "baz"
+    }
+  }
+  render() {
+    this.handleClick()
+    return <button onClick={this.handleClick} />
+  }
+};
+```
+
+```jsx
+// It is safe to use guarded handlers
+function Test() {
+  function handleClick() {
+    if (typeof window !== 'undefined') {
+      window.bar = "baz"
+    }
+  }
+  handleClick()
+  return (
+    <button onClick={handleClick}>
+      Click me!
+    </button>
+  )
+}
+```
+
+```jsx
+// Can use handler in other handlers as long as none of them is called directly.
+class Test extends React.Component {
+  handleClick() {
+    window.bar = "baz"
+  }
+  otherHandler() {
+    this.handleClick()
+  }
+  render() {
+    return <button onClick={this.otherHandler} />
+  }
+};
+```
+
+```jsx
+// Can use handler in other handlers as long as none of them is called directly.
+function Test() {
+  const handleClick = () => {
+    window.bar = "baz"
+  }
+  const otherHandler = () => {
+    handleClick()
+  }
+  return (
+    <button onClick={otherHandler}>
+      Click me!
+    </button>
+  )
+}
+```
+
+## When not to use
+
+If your app will be rendered only on the frontend you can disable this rule.

--- a/docs/rules/no-unsafe-window-use.md
+++ b/docs/rules/no-unsafe-window-use.md
@@ -1,0 +1,1 @@
+# Avoid unsafe global window use (react/no-unsafe-window-use)

--- a/index.js
+++ b/index.js
@@ -91,7 +91,8 @@ const allRules = {
   'state-in-constructor': require('./lib/rules/state-in-constructor'),
   'static-property-placement': require('./lib/rules/static-property-placement'),
   'style-prop-object': require('./lib/rules/style-prop-object'),
-  'void-dom-elements-no-children': require('./lib/rules/void-dom-elements-no-children')
+  'void-dom-elements-no-children': require('./lib/rules/void-dom-elements-no-children'),
+  'no-unsafe-window-use': require('./lib/rules/no-unsafe-window-use')
 };
 /* eslint-enable */
 

--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ const allRules = {
   'no-unescaped-entities': require('./lib/rules/no-unescaped-entities'),
   'no-unknown-property': require('./lib/rules/no-unknown-property'),
   'no-unsafe': require('./lib/rules/no-unsafe'),
+  'no-unsafe-window-use': require('./lib/rules/no-unsafe-window-use'),
   'no-unused-prop-types': require('./lib/rules/no-unused-prop-types'),
   'no-unused-state': require('./lib/rules/no-unused-state'),
   'no-will-update-set-state': require('./lib/rules/no-will-update-set-state'),
@@ -91,8 +92,7 @@ const allRules = {
   'state-in-constructor': require('./lib/rules/state-in-constructor'),
   'static-property-placement': require('./lib/rules/static-property-placement'),
   'style-prop-object': require('./lib/rules/style-prop-object'),
-  'void-dom-elements-no-children': require('./lib/rules/void-dom-elements-no-children'),
-  'no-unsafe-window-use': require('./lib/rules/no-unsafe-window-use')
+  'void-dom-elements-no-children': require('./lib/rules/void-dom-elements-no-children')
 };
 /* eslint-enable */
 

--- a/lib/rules/no-unsafe-window-use.js
+++ b/lib/rules/no-unsafe-window-use.js
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview Rule to avoid unsafe global window use
+ * @author Johnny Zabala
+ */
+
+'use strict';
+
+const docsUrl = require('../util/docsUrl');
+
+// ------------------------------------------------------------------------------
+// Helpers
+// ------------------------------------------------------------------------------
+
+function isMethod(node) {
+  return node.type === 'Property'
+    || node.type === 'MethodDefinition'
+    || node.type === 'ClassProperty';
+}
+
+function isAllowedLifecycle(node) {
+  return ['componentDidMount', 'componentDidUpdate', 'componentWillUnmount'].includes(node.key.name);
+}
+
+function isAllowedHook(node) {
+  return (node.type === 'CallExpression')
+  && ['useEffect', 'useLayoutEffect'].includes(node.callee.name);
+}
+
+// guard: typeof window !== 'undefined'
+function isGuard(node) {
+  return node.type === 'BinaryExpression'
+    && ['!==', '!='].includes(node.operator)
+    && node.left.type === 'UnaryExpression'
+    && node.left.operator === 'typeof'
+    && node.right.type === 'Literal'
+    && node.right.value === 'undefined';
+}
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: '',
+      category: 'Possible Errors',
+      recommended: false,
+      url: docsUrl('no-unsafe-window-use')
+    },
+    messages: {
+      unsafeWindowUse: 'Unsafe "window" use'
+    }
+  },
+  create(context) {
+    const methodsUsingWindow = [];
+    let methodCalls = [];
+    function report(node) {
+      context.report({
+        node,
+        messageId: 'unsafeWindowUse'
+      });
+    }
+    function isInsideSaveZone(node) {
+      return context
+        .getAncestors()
+        .reverse()
+        .some((ancestor, index, ancestors) => {
+          // Is protected by conditional if or ternary
+          if ((['IfStatement', 'ConditionalExpression'].includes(ancestor.type))
+            // Check the node is the consequent of the guard
+            && (ancestor.consequent === node || ancestor.consequent === ancestors[index - 1])
+          ) {
+            return isGuard(ancestor.test);
+          }
+          // Is protected by logical AND expression
+          if (ancestor.type === 'LogicalExpression' && ancestor.operator === '&&') {
+            return isGuard(ancestor.left);
+          }
+
+          if (isMethod(ancestor)) {
+            // Store method and node to check later if part of call expression
+            if (!isAllowedLifecycle(ancestor)) {
+              methodsUsingWindow.push({instance: ancestor, node});
+            }
+            return true;
+          }
+
+          if (isAllowedHook(ancestor)) {
+            return true;
+          }
+
+          return false;
+        });
+    }
+    return {
+      'Program:exit'() {
+        // Check if methods using window called inside other methods
+        methodsUsingWindow.some((method) => {
+          if (methodCalls.length > 0) {
+            const matchedMethodCalls = [];
+            const unmatchedMethodCalls = [];
+            // Check if method using window is one of the called methods
+            methodCalls.forEach((methodCall) => {
+              if (methodCall.callee.property.name === method.instance.key.name
+                && methodCall.instance.parent === method.instance.parent
+              ) {
+                matchedMethodCalls.push(methodCall);
+              } else {
+                unmatchedMethodCalls.push(methodCall);
+              }
+            });
+            if (matchedMethodCalls.length > 0) {
+              report(method.node);
+              methodCalls = unmatchedMethodCalls;
+            }
+            return false;
+          }
+          return true;
+        });
+      },
+      Identifier(node) {
+        if (
+          node.name !== 'window'
+          // is part of guard
+          || isGuard(node.parent.parent)
+          || isInsideSaveZone(node)
+        ) {
+          return;
+        }
+        report(node);
+      },
+      CallExpression(node) {
+        const {callee} = node;
+        if (callee.type === 'MemberExpression' && callee.object.type === 'ThisExpression') {
+          const method = context.getAncestors().reverse().find(isMethod);
+          if (method && !isAllowedLifecycle(method)) {
+            methodCalls.push({
+              instance: method,
+              callee
+            });
+          }
+        }
+      }
+    };
+  }
+};

--- a/lib/rules/no-unsafe-window-use.js
+++ b/lib/rules/no-unsafe-window-use.js
@@ -1,41 +1,187 @@
 /**
- * @fileoverview Rule to avoid unsafe global window use
+ * @fileoverview Prevent unsafe window use
  * @author Johnny Zabala
  */
 
 'use strict';
 
+const arrayIncludes = require('array-includes');
 const docsUrl = require('../util/docsUrl');
+const Components = require('../util/Components');
+const getNodeAncestors = require('../util/getNodeAncestors');
 
 // ------------------------------------------------------------------------------
 // Helpers
 // ------------------------------------------------------------------------------
 
 function isMethod(node) {
-  return node.type === 'Property'
-    || node.type === 'MethodDefinition'
-    || node.type === 'ClassProperty';
+  return arrayIncludes(
+    ['Property', 'MethodDefinition', 'ClassProperty'],
+    node.type
+  );
 }
 
-function isAllowedLifecycle(node) {
-  return ['componentDidMount', 'componentDidUpdate', 'componentWillUnmount'].includes(node.key.name);
-}
-
-function isAllowedHook(node) {
-  return (node.type === 'CallExpression')
-  && ['useEffect', 'useLayoutEffect'].includes(node.callee.name);
+function isAllowedLifecycleMethod(methodNote) {
+  return arrayIncludes(
+    ['componentDidMount', 'componentDidUpdate', 'componentWillUnmount'],
+    methodNote.key.name
+  );
 }
 
 // guard: typeof window !== 'undefined'
 function isGuard(node) {
-  return node.type === 'BinaryExpression'
-    && ['!==', '!='].includes(node.operator)
+  return (
+    node.type === 'BinaryExpression'
+    && (node.operator === '!==' || node.operator === '!=')
     && node.left.type === 'UnaryExpression'
     && node.left.operator === 'typeof'
     && node.right.type === 'Literal'
-    && node.right.value === 'undefined';
+    && node.right.value === 'undefined'
+  );
 }
 
+class Program {
+  constructor(context, utils) {
+    this.context = context;
+    this.utils = utils;
+    this.functionsUsingWindow = [];
+    this.methodsUsingWindow = [];
+    this.methodCalls = [];
+    this.currentEventHandler = null;
+
+    this.verifierFor = this.verifierFor.bind(this);
+  }
+
+  injectVerifier(fn) {
+    this.currentEventHandler = null;
+    const that = this;
+    return function verifier() {
+      return fn.apply(null, [that.verifierFor].concat(Array.from(arguments)));
+    };
+  }
+
+  isInsideSafeZone(node) {
+    const functionalComponent = this.utils.getParentStatelessComponent();
+    const classComponent = !functionalComponent ? (
+      this.utils.getParentES6Component() || this.utils.getParentES5Component()
+    ) : null;
+    return this.context
+      .getAncestors()
+      .reverse()
+      .some(this.injectVerifier((verifierFor, ancestor, i, ancestors) => {
+        const verifier = verifierFor({
+          node: ancestor,
+          reportNode: node,
+          component: functionalComponent || classComponent
+        });
+
+        if (verifier.isGuard() || verifier.isAllowedHook() || verifier.isGuarded(ancestors[i - 1])) {
+          return true;
+        }
+
+        if (functionalComponent) {
+          return verifier.isSafeInsideFunctionalComponent();
+        }
+
+        if (classComponent) {
+          return verifier.isSafeInsideClassComponent();
+        }
+
+        return false;
+      }));
+  }
+
+  verifierFor(params) {
+    params = params || {};
+    const node = params.node;
+    const reportNode = params.reportNode;
+    const component = params.component;
+    return {
+      isGuard: () => isGuard(node),
+      isAllowedHook: () => (
+        node.type === 'CallExpression'
+        && (arrayIncludes(['useEffect', 'useLayoutEffect', 'useCallback'], node.callee.name))
+      ),
+      isGuarded: (consequent) => {
+        // Is protected by conditional
+        if (
+          (node.type === 'IfStatement' || node.type === 'ConditionalExpression')
+          && isGuard(node.test)
+          && (node.consequent === consequent)
+        ) {
+          return true;
+        }
+        // Is protected by logical AND expression
+        if (
+          node.type === 'LogicalExpression'
+          && node.operator === '&&'
+          && isGuard(node.left)) {
+          return true;
+        }
+        return false;
+      },
+      isSafeInsideFunctionalComponent: () => {
+        if (node === component) {
+          if (this.currentEventHandler) {
+            // Inside components we only care about handlers being called.
+            // The last function before the component is the eventHandler.
+            this.functionsUsingWindow.push({
+              instance: this.currentEventHandler,
+              node: reportNode,
+              component
+            });
+            return true;
+          }
+          return false;
+        }
+
+        if (node.type === 'FunctionDeclaration') {
+          this.currentEventHandler = node;
+        } else if (
+          node.type === 'ArrowFunctionExpression'
+          && node.parent.type === 'VariableDeclarator'
+        ) {
+          this.currentEventHandler = node.parent;
+        }
+
+        return false;
+      },
+      isSafeInsideClassComponent: () => {
+        if (node === component) {
+          if (this.currentEventHandler) {
+            // Inside components we only care about handlers being called.
+            // The last method before the component is the eventHandler.
+            this.methodsUsingWindow.push({
+              instance: this.currentEventHandler,
+              component,
+              node: reportNode
+            });
+            return true;
+          }
+          return false;
+        }
+
+        if (isMethod(node)) {
+          if (node.key.name === 'render' || node.key.name === 'constructor') {
+            return false;
+          }
+          if (isAllowedLifecycleMethod(node)) {
+            return true;
+          }
+          this.currentEventHandler = node;
+        }
+        return false;
+      }
+    };
+  }
+
+  report(node) {
+    this.context.report({
+      node,
+      message: 'Unsafe "window" use'
+    });
+  }
+}
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -44,105 +190,111 @@ module.exports = {
   meta: {
     type: 'problem',
     docs: {
-      description: '',
+      description: 'Prevent unsafe window use',
       category: 'Possible Errors',
       recommended: false,
       url: docsUrl('no-unsafe-window-use')
-    },
-    messages: {
-      unsafeWindowUse: 'Unsafe "window" use'
     }
   },
-  create(context) {
-    const methodsUsingWindow = [];
-    let methodCalls = [];
-    function report(node) {
-      context.report({
-        node,
-        messageId: 'unsafeWindowUse'
-      });
-    }
-    function isInsideSaveZone(node) {
-      return context
-        .getAncestors()
-        .reverse()
-        .some((ancestor, index, ancestors) => {
-          // Is protected by conditional if or ternary
-          if ((['IfStatement', 'ConditionalExpression'].includes(ancestor.type))
-            // Check the node is the consequent of the guard
-            && (ancestor.consequent === node || ancestor.consequent === ancestors[index - 1])
-          ) {
-            return isGuard(ancestor.test);
-          }
-          // Is protected by logical AND expression
-          if (ancestor.type === 'LogicalExpression' && ancestor.operator === '&&') {
-            return isGuard(ancestor.left);
-          }
+  create: Components.detect((context, _, utils) => {
+    const program = new Program(context, utils);
 
-          if (isMethod(ancestor)) {
-            // Store method and node to check later if part of call expression
-            if (!isAllowedLifecycle(ancestor)) {
-              methodsUsingWindow.push({instance: ancestor, node});
-            }
-            return true;
-          }
-
-          if (isAllowedHook(ancestor)) {
-            return true;
-          }
-
-          return false;
-        });
-    }
     return {
       'Program:exit'() {
-        // Check if methods using window called inside other methods
-        methodsUsingWindow.some((method) => {
-          if (methodCalls.length > 0) {
-            const matchedMethodCalls = [];
+        // Check if component methods using 'window' were called by other methods safely.
+        // eslint-disable-next-line no-cond-assign
+        for (let method = null; method = program.methodsUsingWindow.pop();) {
+          if (program.methodCalls.length > 0) {
             const unmatchedMethodCalls = [];
-            // Check if method using window is one of the called methods
-            methodCalls.forEach((methodCall) => {
-              if (methodCall.callee.property.name === method.instance.key.name
-                && methodCall.instance.parent === method.instance.parent
+            // eslint-disable-next-line no-cond-assign
+            for (let methodCall = null; methodCall = program.methodCalls.pop();) {
+              // Check if the called method and the method using 'window'
+              // have the same name and belong to the same component.
+              if (
+                methodCall.callee.property.name === method.instance.key.name
+                && methodCall.component === method.component
               ) {
-                matchedMethodCalls.push(methodCall);
+                // If the handler was called from another handler, add the new handler
+                // to the list of methods using window so that we can find if the new
+                // handler was called from another place.
+                if (!getNodeAncestors(methodCall.callee)
+                  .some(program.injectVerifier((verifierFor, ancestor, i, ancestors) => {
+                    const verifier = verifierFor({
+                      node: ancestor,
+                      reportNode: method.node,
+                      component: methodCall.component
+                    });
+
+                    if (verifier.isGuarded(ancestors[i - 1])) {
+                      return true;
+                    }
+
+                    return verifier.isSafeInsideClassComponent();
+                  }))) {
+                  program.report(method.node);
+                }
               } else {
                 unmatchedMethodCalls.push(methodCall);
               }
-            });
-            if (matchedMethodCalls.length > 0) {
-              report(method.node);
-              methodCalls = unmatchedMethodCalls;
             }
-            return false;
+            program.methodCalls = unmatchedMethodCalls;
           }
-          return true;
-        });
-      },
-      Identifier(node) {
-        if (
-          node.name !== 'window'
-          // is part of guard
-          || isGuard(node.parent.parent)
-          || isInsideSaveZone(node)
-        ) {
-          return;
         }
-        report(node);
+
+        // Check if component functions using 'window' were called by other functions safely.
+        // eslint-disable-next-line no-cond-assign
+        for (let fn = null; fn = program.functionsUsingWindow.pop();) {
+          const variable = context.getDeclaredVariables(fn.instance)[0];
+          variable.references.forEach(
+            (reference) => {
+              const node = reference.identifier.parent;
+              if (
+                node.type === 'CallExpression'
+                // Check the called function is the function using window
+                && node.callee.name === reference.identifier.name
+              ) {
+                // If the handler was called from another handler, add the new handler
+                // to the list of functions using window so that we can find if the new
+                // handler was called from another place.
+                if (!getNodeAncestors(node)
+                  .some(program.injectVerifier((verifierFor, ancestor, i, ancestors) => {
+                    const verifier = verifierFor({
+                      node: ancestor,
+                      reportNode: fn.node,
+                      component: fn.component
+                    });
+
+                    if (verifier.isAllowedHook() || verifier.isGuarded(ancestors[i - 1])) {
+                      return true;
+                    }
+
+                    return verifier.isSafeInsideFunctionalComponent();
+                  }))) {
+                  program.report(fn.node);
+                }
+              }
+            }
+          );
+        }
       },
-      CallExpression(node) {
-        const {callee} = node;
-        if (callee.type === 'MemberExpression' && callee.object.type === 'ThisExpression') {
+      'Identifier[name="window"]'(node) {
+        if (!program.isInsideSafeZone(node)) {
+          program.report(node);
+        }
+      },
+      'CallExpression[callee.type="MemberExpression"][callee.object.type="ThisExpression"]'(node) {
+        const component = utils.getParentES6Component() || utils.getParentES5Component();
+        if (component) {
           const method = context.getAncestors().reverse().find(isMethod);
-          if (method && !isAllowedLifecycle(method)) {
-            methodCalls.push({
+          if (method && !isAllowedLifecycleMethod(method)) {
+            program.methodCalls.push({
               instance: method,
-              callee
+              component,
+              callee: node.callee
             });
           }
         }
       }
     };
-  }
+  })
 };

--- a/lib/util/getNodeAncestors.js
+++ b/lib/util/getNodeAncestors.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Returns the list of parents for the node, starting from the closest parent.
+ * @param {ASTNode} node - root node to start parent traversal
+ * @returns {Array.<ASTNode>} List of nodes or empty
+ */
+function getNodeAncestors(node) {
+  const ancestors = [];
+  if (!node) {
+    return ancestors;
+  }
+
+  // eslint-disable-next-line no-cond-assign
+  for (let parent = node; parent = parent.parent;) {
+    ancestors.push(parent);
+  }
+  return ancestors;
+}
+
+module.exports = getNodeAncestors;

--- a/tests/lib/rules/no-unsafe-window-use.js
+++ b/tests/lib/rules/no-unsafe-window-use.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to avoid unsafe global window use
+ * @fileoverview Prevent unsafe window use
  * @author Johnny Zabala
  */
 
@@ -22,91 +22,181 @@ const parserOptions = {
 };
 
 // ------------------------------------------------------------------------------
-// Tests
+// Helpers
 // ------------------------------------------------------------------------------
 
-function invalid(code, extra = {}) {
+function invalid(code, extra) {
   return Object.assign({
     code,
     errors: [{message: 'Unsafe "window" use'}]
   }, extra);
 }
 
-const ruleTester = new RuleTester({parserOptions});
-ruleTester.run('no-unsafe-window-use', rule, {
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const tests = {
   valid: [
-    `if (typeof window !== 'undefined') {
-      console.log(window)
-    }`,
-    'typeof window !== "undefined" ? doSomething(window) : null',
-    'typeof window !== "undefined" && window',
     `
-      var Test = createReactClass({
-        componentDidUpdate: function() {
-          window
-        },
-        componentDidMount: function() {
-          window
-        },
-        componentWillUnmount: function() {
-          window
-        },
-      });
-    `,
-    `
-      class Test extends React.Component {
-        componentDidUpdate() {
-          window
-        }
-        componentDidMount() {
-          window
-        }
-        componentWillUnmount() {
-          window
-        }
-      };
-    `,
-    {
-      code: `
-        class Test extends React.Component {
-          componentDidUpdate = () => {
-            window
-          }
-          componentDidMount = () => {
-            window
-          }
-          componentWillUnmount = () => {
-            window
-          }
-        };
-      `,
-      parser: parsers.BABEL_ESLINT
-    },
-    `
-      function Render() {
-        useEffect(() => {
-          window
-        })
-        return null;
+      if (typeof window !== 'undefined') {
+        console.log(window)
       }
     `,
     `
-      function Render() {
-        useLayoutEffect(() => {
-          window
-        })
-        return null;
+      if (typeof window !== 'undefined') {
+        if (true) {
+          function baz() {
+            console.log(window)
+          }
+        }
+      }
+    `,
+    'typeof window !== "undefined" ? doSomething(window) : null',
+    'typeof window !== "undefined" && doSomething(window)',
+    `
+      class Test {
+        doSomething() {
+          if (typeof window !== "undefined") {
+            window.bar = baz
+          }
+        }
       }
     `,
     `
       var Test = createReactClass({
         handleClick: function() {
-          window
+          window.bar = "baz"
         },
-        otherHandler: function() {
-          this.handleClick
+        componentDidUpdate: function() {
+          window.bar = "baz"
+          this.handleClick()
+        },
+        componentDidMount: function() {
+          window.bar = "baz"
+          this.handleClick()
+        },
+        componentWillUnmount: function() {
+          window.bar = "baz"
+          this.handleClick()
         },
         render: function() {
+          return <button onClick={this.handleClick}>Click me!</button>
+        }
+      });
+    `,
+    `
+      class Test extends React.Component {
+        handleClick() {
+          window.bar = "baz"
+        }
+        componentDidUpdate() {
+          window.bar = "baz"
+          this.handleClick()
+        }
+        componentDidMount() {
+          window.bar = "baz"
+          this.handleClick()
+        }
+        componentWillUnmount() {
+          window.bar = "baz"
+          this.handleClick()
+        }
+        render() {
+          return <button onClick={this.handleClick} />
+        }
+      };
+    `,
+    `
+      function Test() {
+        function handleClick() {
+          window.bar = "baz"
+        }
+        useEffect(() => {
+          window.bar = "baz"
+          handleClick()
+        })
+        useLayoutEffect(() => {
+          window.bar = "baz"
+          handleClick()
+        })
+        const callback = useCallback(() => {
+          window.bar = "baz"
+          handleClick()
+        }, [])
+        return (
+          <div>
+            <button onClick={handleClick}>
+              Click me!
+            </button>
+            <button onClick={callback}>
+              Click me 2!
+            </button>
+          </div>
+        )
+      }
+    `,
+    `
+      var Test = createReactClass({
+        handleClick: function() {
+          window.bar = "baz"
+        },
+        otherHandler: function() {
+          this.handlerClick()
+        },
+        render: function() {
+          return (
+            <div>
+              <button onClick={this.handleClick}>Click me!</button>
+              <button onClick={this.otherHandler}>Click me 2!</button>
+            </div>
+          )
+        }
+      });
+    `,
+    `
+      class Test extends React.Component {
+        handleClick() {
+          window.bar = "baz"
+        }
+        otherHandler() {
+          this.handlerClick()
+        }
+        render() {
+          return (
+            <div>
+              <button onClick={this.handleClick}>Click me!</button>
+              <button onClick={this.otherHandler}>Click me 2!</button>
+            </div>
+          )
+        }
+      };
+    `,
+    `
+      const Test = () => {
+        const handleClick = () => {
+          window.bar = "baz"
+        }
+        const otherHandler = () => {
+          handlerClick()
+        }
+        return (
+          <div>
+            <button onClick={handleClick}>Click me!</button>
+            <button onClick={otherHandler}>Click me 2!</button>
+          </div>
+        )
+      };
+    `,
+    `
+      const Test = React.createReactClass({
+        handleClick() {
+          function some() {
+            window.bar = "baz"
+          }
+          some()
+        },
+        render() {
           return <button onClick={this.handleClick} />
         }
       });
@@ -114,81 +204,262 @@ ruleTester.run('no-unsafe-window-use', rule, {
     `
       class Test extends React.Component {
         handleClick() {
-          window
-        }
-        componentDidMount() {
-          this.handleClick()
-        }
-        otherHandler() {
-          this.handleClick
+          function some() {
+            window.bar = "baz"
+          }
+          some()
         }
         render() {
           return <button onClick={this.handleClick} />
         }
       };
+    `,
+    `
+      function Test() {
+        const handleClick = () => {
+          function some() {
+            window.bar = "baz"
+          }
+          some()
+        }
+        return <button onClick={handleClick} />
+      };
+    `,
+    `
+      const Test = React.createReactClass({
+        handleClick() {
+          if (typeof window !== 'undefined') {
+            window.bar = "baz"
+          }
+        },
+        render() {
+          this.handleClick()
+          return <button onClick={this.handleClick} />
+        }
+      });
+    `,
+    `
+      class Test extends React.Component {
+        handleClick() {
+          if (typeof window !== 'undefined') {
+            window.bar = "baz"
+          }
+        }
+        render() {
+          this.handleClick()
+          return <button onClick={this.handleClick} />
+        }
+      };
+    `,
+    `
+      const Test = () => {
+        function handleClick() {
+          if (typeof window !== 'undefined') {
+            window.bar = "baz"
+          }
+        }
+        handleClick()
+        return (
+          <button onClick={handleClick}>
+            Click me!
+          </button>
+        )
+      }
+    `,
+    `
+      const Test = React.createReactClass({
+        handleClick: function() {
+          window.bar = "baz"
+        },
+        otherHandler: function() {
+          if (typeof window !== 'undefined') {
+            this.handleClick()
+          }
+        },
+        render() {
+          this.otherHandler()
+          return <button onClick={this.otherHandler} />
+        }
+      });
+    `,
+    `
+      class Test extends React.Component {
+        handleClick() {
+          window.bar = "baz"
+        }
+        otherHandler() {
+          if (typeof window !== 'undefined') {
+            this.handleClick()
+          }
+        }
+        render() {
+          this.otherHandler()
+          return <button onClick={this.otherHandler} />
+        }
+      };
+    `,
+    `
+      function Test() {
+        const handleClick = () => {
+          window.bar = "baz"
+        }
+        const otherHandler = () => {
+          if (typeof window !== 'undefined') {
+            handleClick()
+          }
+        }
+        otherHandler()
+        return <button onClick={otherHandler} />
+      };
+    `,
+    `
+      const Test = React.createReactClass({
+        render() {
+          if (typeof window !== 'undefined') {
+            window.bar = "baz"
+          }
+          return <div />
+        }
+      })
+    `,
+    `
+      class Test extends React.Component {
+        render() {
+          if (typeof window !== 'undefined') {
+            window.bar = "baz"
+          }
+          return <div />
+        }
+      }
+    `,
+    `
+      function Test() {
+        if (typeof window !== 'undefined') {
+          window.bar = "baz"
+        }
+        return <div />
+      }
+    `,
+    `
+      function Test() {
+        useEffect(() => {
+          window.bar = "baz"
+        })
+        useLayoutEffect(() => {
+          window.bar = "baz"
+        })
+      }
+    `,
+    `
+      class Test extends React.Component {
+        constructor() {
+          super()
+          if (typeof window !== 'undefined') {
+            window.bar = "baz"
+          }
+        }
+        render() {
+          return <div />
+        }
+      }
+    `,
+    `
+      if (typeof window !== 'undefined') {
+        function Test() {
+          window.bar = "baz"
+
+          return null;
+        }
+      }
     `
   ],
   invalid: [
-    invalid('if (window === blue) {}'),
+    invalid('console.log(window)'),
+    invalid('window.bar = "baz"'),
     invalid(`
       if (typeof window !== 'undefined') {
       } else {
-        window
+        window.bar = "baz"
       }
     `),
-    invalid('typeof window !== "undefined" ? null : window'),
-    invalid('typeof window !== "undefined" || window'),
-    invalid('window'),
+    invalid(`
+      function bar() {
+        if (true) {
+          window.something()
+        }
+      }
+    `),
+    invalid(`
+      class Test {
+        handle() {
+          window.bar = "baz"
+        }
+      }
+    `),
+    invalid(`
+      class Test {
+        componentDidMount() {
+          window.bar = "baz"
+        }
+      }
+    `),
+    invalid('typeof window !== "undefined" ? null : window.thing'),
+    invalid('typeof window !== "undefined" || window.bar'),
+    invalid(`
+      class Test {
+        doSomething() {
+          window.bar = baz
+        }
+      }
+    `),
     invalid(`
       var Test = createReactClass({
         handleClick: function() {
-          window
-        },
-        otherHandler: function() {
-          this.handleClick()
+          window.bar = "baz"
         },
         render: function() {
+          this.handleClick()
           return <button onClick={this.handleClick} />
         }
       });
     `),
     invalid(`
-      class Test extends React.Component {
-        handleClick() {
-          window
-        }
-        otherHandler() {
+      var Test = createReactClass({
+        handleClick: function() {
+          window.bar = "baz"
+        },
+        otherHandler: function() {
           this.handleClick()
+        },
+        render: function() {
+          this.otherHandler()
+          return <button onClick={this.otherHandler} />
         }
-        render() {
-          return <button onClick={this.handleClick} />
-        }
-      }
+      });
     `),
     {
       code: `
-        class Test extends React.Component {
-          handleClick() {
-            window
-          }
-          otherHandler() {
+        var Test = createReactClass({
+          handleClick: function() {
+            window.bar = "baz"
+          },
+          render: function() {
             this.handleClick()
-          }
-          render() {
             return <button onClick={this.handleClick} />
           }
-        };
-        class Test1 extends React.Component {
-          handleClick() {
-            window
-          }
-          otherHandler() {
+        });
+        var Test1 = createReactClass({
+          handleClick: function() {
+            window.bar = "baz"
+          },
+          otherHandler: function() {
             this.handleClick()
+          },
+          render: function() {
+            this.otherHandler()
+            return <button onClick={this.otherHandler} />
           }
-          render() {
-            return <button onClick={this.handleClick} />
-          }
-        };
+        });
       `,
       errors: [
         {message: 'Unsafe "window" use'},
@@ -198,26 +469,247 @@ ruleTester.run('no-unsafe-window-use', rule, {
     invalid(`
       class Test extends React.Component {
         handleClick() {
-          window
-        }
-        otherHandler() {
-          this.handleClick
+          window.bar = "baz"
         }
         render() {
+          this.handleClick()
           return <button onClick={this.handleClick} />
         }
       };
-      class Test1 extends React.Component {
+    `),
+    invalid(`
+      class Test extends React.Component {
         handleClick() {
-          window
+          window.bar = "baz"
         }
         otherHandler() {
+          this.handleClick()
+        }
+        render() {
+          this.otherHandler()
+          return <button onClick={this.otherHandler} />
+        }
+      };
+    `),
+    {
+      code: `
+        class Test1 extends React.Component {
+          handleClick() {
+            window.bar = "baz"
+          }
+          render() {
+            this.handleClick()
+            return <button onClick={this.handleClick} />
+          }
+        };
+        class Test extends React.Component {
+          handleClick() {
+            window.bar = "baz"
+          }
+          otherHandler() {
+            this.handleClick()
+          }
+          render() {
+            this.otherHandler()
+            return <button onClick={this.otherHandler} />
+          }
+        };
+      `,
+      errors: [
+        {message: 'Unsafe "window" use'},
+        {message: 'Unsafe "window" use'}
+      ]
+    },
+    invalid(`
+      function Test() {
+        function handleClick() {
+          window.bar = "baz"
+        }
+        handleClick()
+        return (
+          <button onClick={handleClick}>
+            Click me!
+          </button>
+        )
+      }
+    `),
+    invalid(`
+      function Test1() {
+        function handleClick() {
+          window.bar = "baz"
+        }
+        function otherHandler() {
+          handleClick()
+        }
+        otherHandler()
+        return (
+          <button onClick={otherHandler}>
+            Click me!
+          </button>
+        )
+      }
+    `),
+    {
+      code: `
+        function Test() {
+          function handleClick() {
+            window.bar = "baz"
+          }
+          handleClick()
+          return (
+            <button onClick={handleClick}>
+              Click me!
+            </button>
+          )
+        }
+        function Test1() {
+          function handleClick() {
+            window.bar = "baz"
+          }
+          function otherHandler() {
+            handleClick()
+          }
+          otherHandler()
+          return (
+            <button onClick={otherHandler}>
+              Click me!
+            </button>
+          )
+        }
+      `,
+      errors: [
+        {message: 'Unsafe "window" use'},
+        {message: 'Unsafe "window" use'}
+      ]
+    },
+    invalid(`
+      function Test() {
+        const val = useMemo(() => window.baz, [])
+        return val
+      }
+    `),
+    invalid(`
+      function Test() {
+        const val = useMemo(() => window.baz, [])
+        return <div>{val}</div>
+      }
+    `),
+    invalid(`
+      class Test extends React.Component {
+        constructor() {
+          super()
+          window.bar = "baz"
+        }
+        render() {
+          return <div />
+        }
+      };
+    `),
+    invalid(`
+      class Test extends React.Component {
+        render() {
+          window.bar = "baz";
+          return <div />
+        }
+      };
+    `),
+    invalid(`
+      class Test extends React.Component {
+        constructor(props) {
+          super(props)
+          this.handler()
+        }
+        handler() {
+          window.bar = "baz"
+        }
+        render() {
+          return <div />
+        }
+      };
+    `),
+    invalid(`
+      const Test = () => window && <div />
+    `)
+  ]
+};
+
+const advanceFeatTests = {
+  valid: [
+    `
+      class Test extends React.Component {
+        handleClick = () => {
+          window.bar = "baz"
+        }
+        componentDidUpdate = () => {
+          window.bar = "baz"
+          this.handleClick()
+        }
+        componentDidMount = () => {
+          window.bar = "baz"
+          this.handleClick()
+        }
+        componentWillUnmount = () => {
+          window.bar = "baz"
           this.handleClick()
         }
         render() {
           return <button onClick={this.handleClick} />
         }
       };
+    `,
+    `
+      class Test extends React.Component {
+        handleClick = () => {
+          window.bar = "baz"
+        }
+        otherHandler = () => {
+          this.handleClick()
+        }
+        render() {
+          return <button onClick={this.otherHandler} />
+        }
+      };
+    `
+  ],
+  invalid: [
+    invalid(`
+      class Test extends React.Component {
+        handleClick = () => {
+          window.bar = "baz"
+        }
+        otherHandler = () => {
+          this.handleClick()
+        }
+        render() {
+          this.otherHandler()
+          return <button onClick={this.otherHandler} />
+        }
+      };
     `)
   ]
+};
+
+// Run tests with default parser
+new RuleTester({parserOptions}).run('no-unsafe-window-use', rule, tests);
+
+// Run tests with babel parser
+let ruleTester = new RuleTester({parserOptions, parser: parsers.BABEL_ESLINT});
+ruleTester.run('no-unsafe-window-use', rule, tests);
+ruleTester.run('no-unsafe-window-use', rule, advanceFeatTests);
+
+// Run tests with typescript parser
+// For some reason ESLint doesn't call the visitor for detecting 'window'
+// when the class property initializer syntax is used with the TypeScript parser.
+// Advance feature tests skipped.
+new RuleTester({parserOptions, parser: parsers.TYPESCRIPT_ESLINT})
+  .run('no-unsafe-window-use', rule, tests);
+
+ruleTester = new RuleTester({parserOptions, parser: parsers['@TYPESCRIPT_ESLINT']});
+ruleTester.run('no-unsafe-window-use', rule, {
+  valid: parsers.TS(tests.valid),
+  invalid: parsers.TS(tests.invalid)
+});
+ruleTester.run('no-unsafe-window-use', rule, {
+  valid: parsers.TS(advanceFeatTests.valid),
+  invalid: parsers.TS(advanceFeatTests.invalid)
 });

--- a/tests/lib/rules/no-unsafe-window-use.js
+++ b/tests/lib/rules/no-unsafe-window-use.js
@@ -1,0 +1,223 @@
+/**
+ * @fileoverview Rule to avoid unsafe global window use
+ * @author Johnny Zabala
+ */
+
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/no-unsafe-window-use');
+const parsers = require('../../helpers/parsers');
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+function invalid(code, extra = {}) {
+  return Object.assign({
+    code,
+    errors: [{message: 'Unsafe "window" use'}]
+  }, extra);
+}
+
+const ruleTester = new RuleTester({parserOptions});
+ruleTester.run('no-unsafe-window-use', rule, {
+  valid: [
+    `if (typeof window !== 'undefined') {
+      console.log(window)
+    }`,
+    'typeof window !== "undefined" ? doSomething(window) : null',
+    'typeof window !== "undefined" && window',
+    `
+      var Test = createReactClass({
+        componentDidUpdate: function() {
+          window
+        },
+        componentDidMount: function() {
+          window
+        },
+        componentWillUnmount: function() {
+          window
+        },
+      });
+    `,
+    `
+      class Test extends React.Component {
+        componentDidUpdate() {
+          window
+        }
+        componentDidMount() {
+          window
+        }
+        componentWillUnmount() {
+          window
+        }
+      };
+    `,
+    {
+      code: `
+        class Test extends React.Component {
+          componentDidUpdate = () => {
+            window
+          }
+          componentDidMount = () => {
+            window
+          }
+          componentWillUnmount = () => {
+            window
+          }
+        };
+      `,
+      parser: parsers.BABEL_ESLINT
+    },
+    `
+      function Render() {
+        useEffect(() => {
+          window
+        })
+        return null;
+      }
+    `,
+    `
+      function Render() {
+        useLayoutEffect(() => {
+          window
+        })
+        return null;
+      }
+    `,
+    `
+      var Test = createReactClass({
+        handleClick: function() {
+          window
+        },
+        otherHandler: function() {
+          this.handleClick
+        },
+        render: function() {
+          return <button onClick={this.handleClick} />
+        }
+      });
+    `,
+    `
+      class Test extends React.Component {
+        handleClick() {
+          window
+        }
+        componentDidMount() {
+          this.handleClick()
+        }
+        otherHandler() {
+          this.handleClick
+        }
+        render() {
+          return <button onClick={this.handleClick} />
+        }
+      };
+    `
+  ],
+  invalid: [
+    invalid('if (window === blue) {}'),
+    invalid(`
+      if (typeof window !== 'undefined') {
+      } else {
+        window
+      }
+    `),
+    invalid('typeof window !== "undefined" ? null : window'),
+    invalid('typeof window !== "undefined" || window'),
+    invalid('window'),
+    invalid(`
+      var Test = createReactClass({
+        handleClick: function() {
+          window
+        },
+        otherHandler: function() {
+          this.handleClick()
+        },
+        render: function() {
+          return <button onClick={this.handleClick} />
+        }
+      });
+    `),
+    invalid(`
+      class Test extends React.Component {
+        handleClick() {
+          window
+        }
+        otherHandler() {
+          this.handleClick()
+        }
+        render() {
+          return <button onClick={this.handleClick} />
+        }
+      }
+    `),
+    {
+      code: `
+        class Test extends React.Component {
+          handleClick() {
+            window
+          }
+          otherHandler() {
+            this.handleClick()
+          }
+          render() {
+            return <button onClick={this.handleClick} />
+          }
+        };
+        class Test1 extends React.Component {
+          handleClick() {
+            window
+          }
+          otherHandler() {
+            this.handleClick()
+          }
+          render() {
+            return <button onClick={this.handleClick} />
+          }
+        };
+      `,
+      errors: [
+        {message: 'Unsafe "window" use'},
+        {message: 'Unsafe "window" use'}
+      ]
+    },
+    invalid(`
+      class Test extends React.Component {
+        handleClick() {
+          window
+        }
+        otherHandler() {
+          this.handleClick
+        }
+        render() {
+          return <button onClick={this.handleClick} />
+        }
+      };
+      class Test1 extends React.Component {
+        handleClick() {
+          window
+        }
+        otherHandler() {
+          this.handleClick()
+        }
+        render() {
+          return <button onClick={this.handleClick} />
+        }
+      };
+    `)
+  ]
+});

--- a/tests/util/getNodeAncestors.js
+++ b/tests/util/getNodeAncestors.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const assert = require('assert');
+const getNodeAncestors = require('../../lib/util/getNodeAncestors');
+
+describe('getNodeAncestors', () => {
+  it('returns empty array for null node', () => {
+    assert.deepEqual(getNodeAncestors(null), []);
+  });
+  it('returns list of parents', () => {
+    const node = {
+      type: 'Identifier',
+      parent: {
+        type: 'FunctionDeclaration',
+        parent: {
+          type: 'Program'
+        }
+      }
+    };
+    const actual = getNodeAncestors(node);
+    const expected = ['FunctionDeclaration', 'Program'];
+
+    actual.forEach((parent, i) => assert.equal(parent.type, expected[i]));
+  });
+});


### PR DESCRIPTION
This rule will prevent the unsafe use on `window` resulting from rendering React apps in environments where the global is not available.

I'll be grateful for getting all your comments and suggestions before summiting the final version.

### Tested Conditions

- [x] used in a guard
- [x] used in componentDidMount, componentDidUpdate and componentWillUnmount
- [x] used in useEffect, useLayoutEffect and useCallback
- [x] used in an event handler

### Considerations

The issue talks about disabling the use of various globals variables aside from `window`. I think an easier solution would be to use the rule [no-restricted-globals](https://eslint.org/docs/rules/no-restricted-globals) to force the use of `window` in the variables that we want.

Another solution would be to have the option of setting what globals will be disabled directly in this plugin with `window` as default. And to change the name of the rule to something like: `no-unsafe-globals-use`.

Let me know your opinion about this or if you have other ideas 

Closes #2057