### PR TITLE
[Fix]: Functional components first letter capitalization check

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -70,6 +70,14 @@ function isReturnsLogicalJSX(node, property, strict) {
     : (returnsLogicalJSXLeft || returnsLogicalJSXRight);
 }
 
+function isFirstLetterCapitalized(word) {
+  if (!word) {
+    return false;
+  }
+  const firstLetter = word.charAt(0);
+  return firstLetter.toUpperCase() === firstLetter;
+}
+
 const Lists = new WeakMap();
 
 /**
@@ -624,13 +632,21 @@ function componentRule(rule, context) {
      * @returns {ASTNode | undefined}
      */
     getStatelessComponent(node) {
-      if (node.type === 'FunctionDeclaration') {
-        if (utils.isReturningJSXOrNull(node)) {
-          return node;
-        }
+      if (
+        node.type === 'FunctionDeclaration'
+        && isFirstLetterCapitalized(node.id.name)
+        && utils.isReturningJSXOrNull(node)
+      ) {
+        return node;
       }
 
       if (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
+        if (node.parent.type === 'VariableDeclarator' && utils.isReturningJSXOrNull(node)) {
+          if (isFirstLetterCapitalized(node.parent.id.name)) {
+            return node;
+          }
+          return undefined;
+        }
         if (utils.isInAllowedPositionForComponent(node) && utils.isReturningJSXOrNull(node)) {
           return node;
         }

--- a/tests/lib/rules/function-component-definition.js
+++ b/tests/lib/rules/function-component-definition.js
@@ -69,6 +69,32 @@ ruleTester.run('function-component-definition', rule, {
     code: 'var Foo = React.memo(function Foo() { return <p/> })',
     options: [{namedComponents: 'function-declaration'}]
   }, {
+    // shouldn't trigger this rule since functions stating with a lowercase
+    // letter are not considered components
+    code: `
+    const selectAvatarByUserId = (state, id) => {
+      const user = selectUserById(state, id)
+      return null
+    }
+    `,
+    options: [{namedComponents: 'function-declaration'}]
+  }, {
+    // shouldn't trigger this rule since functions stating with a lowercase
+    // letter are not considered components
+    code: `
+      function ensureValidSourceType(sourceType: string) {
+        switch (sourceType) {
+          case 'ALBUM':
+          case 'PLAYLIST':
+            return sourceType;
+          default:
+            return null;
+        }
+      }
+    `,
+    options: [{namedComponents: 'arrow-function'}],
+    parser: parsers.TYPESCRIPT_ESLINT
+  }, {
     code: 'function Hello(props: Test) { return <p/> }',
     options: [{namedComponents: 'function-declaration'}],
     parser: parsers.TYPESCRIPT_ESLINT

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -2504,7 +2504,27 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       parser: parsers.TYPESCRIPT_ESLINT
-    }
+    },
+    // shouldn't trigger this rule since functions stating with a lowercase
+    // letter are not considered components
+    `
+      function noAComponent(props) {
+        return <div>{props.text}</div>
+      }
+    `,
+    // shouldn't trigger this rule for 'render' since functions stating with a lowercase
+    // letter are not considered components
+    `
+      const MyComponent = (props) => {
+        const render = () => {
+          return <test>{props.hello}</test>;
+        }
+        return render();
+      };
+      MyComponent.propTypes = {
+        hello: PropTypes.string.isRequired,
+      };
+    `
   ],
 
   invalid: [


### PR DESCRIPTION
As stated by @ljharb in https://github.com/yannickcr/eslint-plugin-react/issues/2554#issuecomment-596631942, functions starting with a lowercase letter are not components.

This PR adds a check for the capitalization of the first letter in functional components detection.

With this change all the reported cases in the issue work properly.

Fixes #2554. Fixes #2495. Fixes #2607. Fixes #2352