### PR TITLE
[Fix]: only detect functions that return JSX somewhere as components

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -420,32 +420,22 @@ function componentRule(rule, context) {
     },
 
     /**
-     * Check if the node is returning null
-     *
-     * @param {ASTNode} ASTnode The AST node being checked
-     * @returns {Boolean} True if the node is returning null, false if not
-     */
-    isReturningNull(ASTnode) {
-      const nodeAndProperty = utils.getReturnPropertyAndNode(ASTnode);
-      const property = nodeAndProperty.property;
-      const node = nodeAndProperty.node;
-
-      if (!node) {
-        return false;
-      }
-
-      return node[property] && node[property].value === null;
-    },
-
-    /**
      * Check if the node is returning JSX or null
      *
      * @param {ASTNode} ASTNode The AST node being checked
      * @param {Boolean} [strict] If true, in a ternary condition the node must return JSX in both cases
      * @returns {Boolean} True if the node is returning JSX or null, false if not
      */
-    isReturningJSXOrNull(ASTNode, strict) {
-      return utils.isReturningJSX(ASTNode, strict) || utils.isReturningNull(ASTNode);
+    isReturningJSXSomewhere(ASTNode, strict) {
+      let returnStatements = [];
+      // Arrow functions without block statements don't have return statements.
+      if (ASTNode.type === 'ArrowFunctionExpression' && ASTNode.body.type !== 'BlockStatement') {
+        returnStatements.push(ASTNode);
+      } else {
+        returnStatements = astUtil.findAllReturnStatements(ASTNode.body);
+      }
+
+      return returnStatements.some((node) => utils.isReturningJSX(node, strict));
     },
 
     getPragmaComponentWrapper(node) {
@@ -613,7 +603,8 @@ function componentRule(rule, context) {
         case 'AssignmentExpression':
         case 'Property':
         case 'ReturnStatement':
-        case 'ExportDefaultDeclaration': {
+        case 'ExportDefaultDeclaration':
+        case 'ArrowFunctionExpression': {
           return true;
         }
         case 'SequenceExpression': {
@@ -635,19 +626,19 @@ function componentRule(rule, context) {
       if (
         node.type === 'FunctionDeclaration'
         && isFirstLetterCapitalized(node.id.name)
-        && utils.isReturningJSXOrNull(node)
+        && utils.isReturningJSXSomewhere(node)
       ) {
         return node;
       }
 
       if (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
-        if (node.parent.type === 'VariableDeclarator' && utils.isReturningJSXOrNull(node)) {
+        if (node.parent.type === 'VariableDeclarator' && utils.isReturningJSXSomewhere(node)) {
           if (isFirstLetterCapitalized(node.parent.id.name)) {
             return node;
           }
           return undefined;
         }
-        if (utils.isInAllowedPositionForComponent(node) && utils.isReturningJSXOrNull(node)) {
+        if (utils.isInAllowedPositionForComponent(node) && utils.isReturningJSXSomewhere(node)) {
           return node;
         }
 

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -201,7 +201,41 @@ function unwrapTSAsExpression(node) {
   return node;
 }
 
+function findAllReturnStatements(ASTNode) {
+  const returnStatements = [];
+  function findReturnStatements(node) {
+    if (node) {
+      if (Array.isArray(node)) {
+        node.forEach((n) => findReturnStatements(n));
+      } else {
+        // eslint-disable-next-line default-case
+        switch (node.type) {
+          case 'ReturnStatement':
+            returnStatements.push(node);
+            break;
+          case 'IfStatement':
+            findReturnStatements(node.consequent);
+            findReturnStatements(node.alternate);
+            break;
+          case 'SwitchStatement':
+            findReturnStatements(node.cases);
+            break;
+          case 'SwitchCase':
+            findReturnStatements(node.consequent);
+            break;
+          case 'BlockStatement':
+            findReturnStatements(node.body);
+            break;
+        }
+      }
+    }
+  }
+  findReturnStatements(ASTNode);
+  return returnStatements;
+}
+
 module.exports = {
+  findAllReturnStatements,
   findReturnStatement,
   getFirstNodeInLine,
   getPropertyName,

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -678,7 +678,7 @@ module.exports = function propTypesInstructions(context, components, utils) {
     }
 
     // Should ignore function that not return JSXElement
-    if (!utils.isReturningJSXOrNull(node)) {
+    if (!utils.isReturningJSXSomewhere(node)) {
       return;
     }
 


### PR DESCRIPTION
Registering all functions that return JSX + null as components has bring a lot of false positives for normal functions that just happen to return `null` somewhere.

In this PR I propose a new approach to detecting components by finding all return statements in a function and only marking the function as a component if one of them returns JSX.

Fixes #2010