### PR TITLE
[Fix] `no-this-in-sfc`/component detection: add arrow function to list of allowed position for component

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -670,7 +670,8 @@ function componentRule(rule, context) {
         case 'AssignmentExpression':
         case 'Property':
         case 'ReturnStatement':
-        case 'ExportDefaultDeclaration': {
+        case 'ExportDefaultDeclaration':
+        case 'ArrowFunctionExpression': {
           return true;
         }
         case 'SequenceExpression': {

--- a/tests/lib/rules/no-this-in-sfc.js
+++ b/tests/lib/rules/no-this-in-sfc.js
@@ -115,26 +115,7 @@ ruleTester.run('no-this-in-sfc', rule, {
   }, {
     code: `
     class Foo {
-      bar() {
-        () => () => {
-          this.something();
-          return null;
-        };
-      }
-    }`
-  }, {
-    code: `
-    class Foo {
       bar = () => {
-        this.something();
-        return null;
-      };
-    }`,
-    parser: parsers.BABEL_ESLINT
-  }, {
-    code: `
-    class Foo {
-      bar = () => () => {
         this.something();
         return null;
       };
@@ -151,6 +132,21 @@ ruleTester.run('no-this-in-sfc', rule, {
       };
     };`,
     parser: parsers.BABEL_ESLINT
+  }, {
+    code: `
+      export const prepareLogin = new ValidatedMethod({
+        name: "user.prepare",
+        validate: new SimpleSchema({
+        }).validator(),
+        run({ remember }) {
+            if (Meteor.isServer) {
+                const connectionId = this.connection.id; // react/no-this-in-sfc
+                return Methods.prepareLogin(connectionId, remember);
+            }
+            return null;
+        },
+      });
+    `
   }],
   invalid: [{
     code: `
@@ -221,12 +217,44 @@ ruleTester.run('no-this-in-sfc', rule, {
     code: `
     class Foo {
       bar() {
+        return () => {
+          this.something();
+          return null;
+        }
+      }
+    }`,
+    errors: [{message: ERROR_MESSAGE}]
+  }, {
+    code: `
+    class Foo {
+      bar = () => () => {
+        this.something();
+        return null;
+      };
+    }`,
+    parser: parsers.BABEL_ESLINT,
+    errors: [{message: ERROR_MESSAGE}]
+  }, {
+    code: `
+    class Foo {
+      bar() {
         function Bar(){
           return () => {
             this.something();
             return null;
           }
         }
+      }
+    }`,
+    errors: [{message: ERROR_MESSAGE}]
+  }, {
+    code: `
+    class Foo {
+      bar() {
+        () => () => {
+          this.something();
+          return null;
+        };
       }
     }`,
     errors: [{message: ERROR_MESSAGE}]


### PR DESCRIPTION
As reported in issue #2010 comment https://github.com/yannickcr/eslint-plugin-react/issues/2010#issuecomment-545458545 there is an inconsistency in the detection of components returned from functions with and without return statements.

Since arrow functions can do a direct return without return statement, this PR adds ArrowFunctionExpression to the list of allowed position for component.

Also adds a test for #2010 to show it is fixed.

Closes #2010.