### PR TITLE
[New] version: detect-no-warn

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You should also specify settings that will be shared across all the plugin rules
                            // You can also use `16.0`, `16.3`, etc, if you want to override the detected value.
                            // default to latest and warns if missing
                            // It will default to "detect" in the future
+                           // You can also set it to `"detect-no-warn"`, which is the same as "detect", but does not give a warning
       "flowVersion": "0.53" // Flow version
     },
     "propWrapperFunctions": [

--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -10,6 +10,8 @@ const error = require('./error');
 
 let warnedForMissingVersion = false;
 
+let detectNoWarn = false;
+
 function resetWarningFlag() {
   warnedForMissingVersion = false;
 }
@@ -33,8 +35,10 @@ function detectReactVersion() {
   } catch (e) {
     if (e.code === 'MODULE_NOT_FOUND') {
       if (!warnedForMissingVersion) {
-        error('Warning: React version was set to "detect" in eslint-plugin-react settings, '
-        + 'but the "react" package is not installed. Assuming latest React version for linting.');
+        if (!detectNoWarn) {
+          error('Warning: React version was set to "detect" in eslint-plugin-react settings, '
+          + 'but the "react" package is not installed. Assuming latest React version for linting.');
+        }
         warnedForMissingVersion = true;
       }
       cachedDetectedReactVersion = '999.999.999';
@@ -51,6 +55,9 @@ function getReactVersionFromContext(context) {
     let settingsVersion = context.settings.react.version;
     if (settingsVersion === 'detect') {
       settingsVersion = detectReactVersion();
+    } else if (settingsVersion === 'detect-no-warn') {
+      settingsVersion = detectReactVersion();
+      detectNoWarn = true;
     }
     if (typeof settingsVersion !== 'string') {
       error('Warning: React version specified in eslint-plugin-react-settings must be a string; '


### PR DESCRIPTION
Fixes #2717 

This adds an option to set the version to `"version": "detect-no-warn"`, which is the same as "detect", but does not give a warning. 

This is useful if someone wants to use a single Eslint preset for multiple projects no matter if they are using react or not (common in organizations).

```json
  "settings": {
    "react": {
      "version": "detect-no-warn"
    }
  }
```

