### PR TITLE
[Fix] `prop-types`: handle anonymous functions

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -689,7 +689,7 @@ function componentRule(rule, context) {
     getStatelessComponent(node) {
       if (
         node.type === 'FunctionDeclaration'
-        && isFirstLetterCapitalized(node.id.name)
+        && (!node.id || isFirstLetterCapitalized(node.id.name))
         && utils.isReturningJSXOrNull(node)
       ) {
         return node;

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -2569,6 +2569,11 @@ ruleTester.run('prop-types', rule, {
         return null;
       }`,
       parser: parsers.TYPESCRIPT_ESLINT
+    },
+    {
+      code: `
+      export default function() {}
+      `
     }
   ],
 
@@ -5158,6 +5163,16 @@ ruleTester.run('prop-types', rule, {
         return null;
       }`,
       parser: parsers.TYPESCRIPT_ESLINT,
+      errors: [{
+        message: '\'value\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
+        export default function ({ value = 'World' }) {
+          return <h1>Hello {value}</h1>
+        }
+      `,
       errors: [{
         message: '\'value\' is missing in props validation'
       }]


### PR DESCRIPTION
For 7.20.4 version of `eslint-plugin-react` I receive TypeError when I lint [this file](https://github.com/wKich/creevey/blob/master/src/server/master/index.ts#L37). I added additional check for anonymous functions where error was raised.