### PR TITLE
[Fix] jsx-no-literals with allowStrings doesn't work in props

### DIFF
--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -120,7 +120,7 @@ module.exports = {
       },
 
       JSXAttribute(node) {
-        const isNodeValueString = node.value && node.value && node.value.type === 'Literal' && typeof node.value.value === 'string';
+        const isNodeValueString = node && node.value && node.value.type === 'Literal' && typeof node.value.value === 'string' && !config.allowedStrings.has(node.value.value);
 
         if (config.noStrings && !config.ignoreProps && isNodeValueString) {
           const customMessage = 'Invalid prop value';

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -42,8 +42,63 @@ function invalidProp(str) {
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('jsx-no-literals', rule, {
 
-  valid: [
+  valid: [].concat(
     {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                <button type="button"></button>
+              </div>
+            );
+          }
+        }
+      `,
+      options: [{noStrings: true, allowedStrings: ['button', 'submit']}]
+    }, {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                <button type="button"></button>
+              </div>
+            );
+          }
+        }
+      `,
+      options: [{noStrings: true, allowedStrings: ['button', 'submit']}],
+      parser: parsers.BABEL_ESLINT
+    }, parsers.TS([{
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                <button type="button"></button>
+              </div>
+            );
+          }
+        }
+      `,
+      options: [{noStrings: true, allowedStrings: ['button', 'submit']}],
+      parser: parsers.TYPESCRIPT_ESLINT
+    }, {
+      code: `
+        class Comp1 extends Component {
+          render() {
+            return (
+              <div>
+                <button type="button"></button>
+              </div>
+            );
+          }
+        }
+      `,
+      options: [{noStrings: true, allowedStrings: ['button', 'submit']}],
+      parser: parsers['@TYPESCRIPT_ESLINT']
+    }]), {
       code: `
         class Comp1 extends Component {
           render() {
@@ -277,7 +332,7 @@ ruleTester.run('jsx-no-literals', rule, {
       parser: parsers.BABEL_ESLINT,
       options: [{noStrings: true, ignoreProps: false}]
     }
-  ],
+  ),
 
   invalid: [
     {


### PR DESCRIPTION
Checks if props string is included in `allowedStrings` option

Fixes #2720.