### PR TITLE
[Fix] Improve error message for no-find-dom-node

### DIFF
--- a/lib/rules/no-find-dom-node.js
+++ b/lib/rules/no-find-dom-node.js
@@ -40,7 +40,7 @@ module.exports = {
 
         context.report({
           node: callee,
-          message: 'Do not use findDOMNode'
+          message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
         });
       }
     };

--- a/tests/lib/rules/no-find-dom-node.js
+++ b/tests/lib/rules/no-find-dom-node.js
@@ -76,7 +76,7 @@ ruleTester.run('no-find-dom-node', rule, {
       });
     `,
     errors: [{
-      message: 'Do not use findDOMNode'
+      message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
     }]
   }, {
     code: `
@@ -90,7 +90,7 @@ ruleTester.run('no-find-dom-node', rule, {
       });
     `,
     errors: [{
-      message: 'Do not use findDOMNode'
+      message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
     }]
   }, {
     code: `
@@ -104,7 +104,7 @@ ruleTester.run('no-find-dom-node', rule, {
       };
     `,
     errors: [{
-      message: 'Do not use findDOMNode'
+      message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
     }]
   }, {
     code: `
@@ -118,7 +118,7 @@ ruleTester.run('no-find-dom-node', rule, {
       };
     `,
     errors: [{
-      message: 'Do not use findDOMNode'
+      message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
     }]
   }]
 });


### PR DESCRIPTION
The error message for `no-find-dom-node` wasn't very informative, which makes it less likely that people will respect the rule instead of just disabling it. This PR adds a more informative message.