### PR TITLE
button-has-type: support trivial ternary expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 This change log adheres to standards from [Keep a CHANGELOG](http://keepachangelog.com).
 
+## Unreleased
+
+### Added
+* [`button-has-type`]: support trivial ternary expressions ([#2748][] @Hypnosphi)
+
+[#2748]: https://github.com/yannickcr/eslint-plugin-react/pull/2748
+
 ## [7.20.6] - 2020.08.12
 
 ### Fixed

--- a/docs/rules/button-has-type.md
+++ b/docs/rules/button-has-type.md
@@ -24,12 +24,14 @@ var Hello = <span type="foo">Hello</span>
 var Hello = <button type="button">Hello</button>
 var Hello = <button type="submit">Hello</button>
 var Hello = <button type="reset">Hello</button>
+var Hello = <button type={condition ? "button" : "submit"}>Hello</button>
 
 var Hello = React.createElement('span', {}, 'Hello')
 var Hello = React.createElement('span', {type: 'foo'}, 'Hello')
 var Hello = React.createElement('button', {type: 'button'}, 'Hello')
 var Hello = React.createElement('button', {type: 'submit'}, 'Hello')
 var Hello = React.createElement('button', {type: 'reset'}, 'Hello')
+var Hello = React.createElement('button', {type: condition ? 'button' : 'submit'}, 'Hello')
 ```
 
 ## Rule Options
@@ -50,8 +52,10 @@ The following patterns are considered errors when using `"react/button-has-type"
 
 ```jsx
 var Hello = <button type="reset">Hello</button>
+var Hello = <button type={condition ? "button" : "reset"}>Hello</button>
 
 var Hello = React.createElement('button', {type: 'reset'}, 'Hello')
+var Hello = React.createElement('button', {type: condition ? "button" : "reset"}, 'Hello')
 ```
 
 ## When Not To Use It

--- a/lib/rules/button-has-type.js
+++ b/lib/rules/button-has-type.js
@@ -72,6 +72,13 @@ module.exports = {
       });
     }
 
+    function reportComplex(node) {
+      context.report({
+        node,
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+      });
+    }
+
     function checkValue(node, value) {
       const q = (x) => `"${x}"`;
       if (!(value in configuration)) {
@@ -84,6 +91,27 @@ module.exports = {
           node,
           message: `${q(value)} is a forbidden value for button type attribute`
         });
+      }
+    }
+
+    function checkExpression(node, expression) {
+      switch (expression.type) {
+        case 'Literal':
+          checkValue(node, expression.value);
+          return;
+        case 'TemplateLiteral':
+          if (expression.expressions.length === 0) {
+            checkValue(node, expression.quasis[0].value.raw);
+          } else {
+            reportComplex(expression);
+          }
+          return;
+        case 'ConditionalExpression':
+          checkExpression(node, expression.consequent);
+          checkExpression(node, expression.alternate);
+          return;
+        default:
+          reportComplex(expression);
       }
     }
 
@@ -101,10 +129,7 @@ module.exports = {
         }
 
         if (typeProp.value.type === 'JSXExpressionContainer') {
-          context.report({
-            node: typeProp,
-            message: 'The button type attribute must be specified by a static string'
-          });
+          checkExpression(node, typeProp.value.expression);
           return;
         }
 
@@ -128,12 +153,12 @@ module.exports = {
         const props = node.arguments[1].properties;
         const typeProp = props.find((prop) => prop.key && prop.key.name === 'type');
 
-        if (!typeProp || typeProp.value.type !== 'Literal') {
+        if (!typeProp) {
           reportMissing(node);
           return;
         }
 
-        checkValue(node, typeProp.value.value);
+        checkExpression(node, typeProp.value);
       }
     };
   }

--- a/tests/lib/rules/button-has-type.js
+++ b/tests/lib/rules/button-has-type.js
@@ -32,6 +32,12 @@ ruleTester.run('button-has-type', rule, {
     {code: '<button type="button"/>'},
     {code: '<button type="submit"/>'},
     {code: '<button type="reset"/>'},
+    {code: '<button type={"button"}/>'},
+    {code: '<button type={\'button\'}/>'},
+    {code: '<button type={`button`}/>'},
+    {code: '<button type={condition ? "button" : "submit"}/>'},
+    {code: '<button type={condition ? \'button\' : \'submit\'}/>'},
+    {code: '<button type={condition ? `button` : `submit`}/>'},
     {
       code: '<button type="button"/>',
       options: [{reset: false}]
@@ -39,8 +45,17 @@ ruleTester.run('button-has-type', rule, {
     {code: 'React.createElement("span")'},
     {code: 'React.createElement("span", {type: "foo"})'},
     {code: 'React.createElement("button", {type: "button"})'},
+    {code: 'React.createElement("button", {type: \'button\'})'},
+    {code: 'React.createElement("button", {type: `button`})'},
     {code: 'React.createElement("button", {type: "submit"})'},
+    {code: 'React.createElement("button", {type: \'submit\'})'},
+    {code: 'React.createElement("button", {type: `submit`})'},
     {code: 'React.createElement("button", {type: "reset"})'},
+    {code: 'React.createElement("button", {type: \'reset\'})'},
+    {code: 'React.createElement("button", {type: `reset`})'},
+    {code: 'React.createElement("button", {type: condition ? "button" : "submit"})'},
+    {code: 'React.createElement("button", {type: condition ? \'button\' : \'submit\'})'},
+    {code: 'React.createElement("button", {type: condition ? `button` : `submit`})'},
     {
       code: 'React.createElement("button", {type: "button"})',
       options: [{reset: false}]
@@ -73,17 +88,73 @@ ruleTester.run('button-has-type', rule, {
     {
       code: '<button type={foo}/>',
       errors: [{
-        message: 'The button type attribute must be specified by a static string'
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
       }]
     },
     {
       code: '<button type={"foo"}/>',
       errors: [{
-        message: 'The button type attribute must be specified by a static string'
+        message: '"foo" is an invalid value for button type attribute'
+      }]
+    },
+    {
+      code: '<button type={\'foo\'}/>',
+      errors: [{
+        message: '"foo" is an invalid value for button type attribute'
+      }]
+    },
+    {
+      code: '<button type={`foo`}/>',
+      errors: [{
+        message: '"foo" is an invalid value for button type attribute'
+      }]
+    },
+    {
+      code: '<button type={`button${foo}`}/>',
+      errors: [{
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
       }]
     },
     {
       code: '<button type="reset"/>',
+      options: [{reset: false}],
+      errors: [{
+        message: '"reset" is a forbidden value for button type attribute'
+      }]
+    },
+    {
+      code: '<button type={condition ? "button" : foo}/>',
+      errors: [{
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+      }]
+    },
+    {
+      code: '<button type={condition ? "button" : "foo"}/>',
+      errors: [{
+        message: '"foo" is an invalid value for button type attribute'
+      }]
+    },
+    {
+      code: '<button type={condition ? "button" : "reset"}/>',
+      options: [{reset: false}],
+      errors: [{
+        message: '"reset" is a forbidden value for button type attribute'
+      }]
+    },
+    {
+      code: '<button type={condition ? foo : "button"}/>',
+      errors: [{
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+      }]
+    },
+    {
+      code: '<button type={condition ? "foo" : "button"}/>',
+      errors: [{
+        message: '"foo" is an invalid value for button type attribute'
+      }]
+    },
+    {
+      code: '<button type={condition ? "reset" : "button"}/>',
       options: [{reset: false}],
       errors: [{
         message: '"reset" is a forbidden value for button type attribute'
@@ -96,6 +167,12 @@ ruleTester.run('button-has-type', rule, {
       }]
     },
     {
+      code: 'React.createElement("button", {type: foo})',
+      errors: [{
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+      }]
+    },
+    {
       code: 'React.createElement("button", {type: "foo"})',
       errors: [{
         message: '"foo" is an invalid value for button type attribute'
@@ -103,6 +180,44 @@ ruleTester.run('button-has-type', rule, {
     },
     {
       code: 'React.createElement("button", {type: "reset"})',
+      options: [{reset: false}],
+      errors: [{
+        message: '"reset" is a forbidden value for button type attribute'
+      }]
+    },
+    {
+      code: 'React.createElement("button", {type: condition ? "button" : foo})',
+      errors: [{
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+      }]
+    },
+    {
+      code: 'React.createElement("button", {type: condition ? "button" : "foo"})',
+      errors: [{
+        message: '"foo" is an invalid value for button type attribute'
+      }]
+    },
+    {
+      code: 'React.createElement("button", {type: condition ? "button" : "reset"})',
+      options: [{reset: false}],
+      errors: [{
+        message: '"reset" is a forbidden value for button type attribute'
+      }]
+    },
+    {
+      code: 'React.createElement("button", {type: condition ? foo : "button"})',
+      errors: [{
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+      }]
+    },
+    {
+      code: 'React.createElement("button", {type: condition ? "foo" : "button"})',
+      errors: [{
+        message: '"foo" is an invalid value for button type attribute'
+      }]
+    },
+    {
+      code: 'React.createElement("button", {type: condition ? "reset" : "button"})',
       options: [{reset: false}],
       errors: [{
         message: '"reset" is a forbidden value for button type attribute'
@@ -122,7 +237,7 @@ ruleTester.run('button-has-type', rule, {
     {
       code: 'function Button({ type, ...extraProps }) { const button = type; return <button type={button} {...extraProps} />; }',
       errors: [{
-        message: 'The button type attribute must be specified by a static string'
+        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
       }]
     }
   ]


### PR DESCRIPTION
This adds support for trivial ternary expressions to `button-has-type` rule:

```jsx
<button type={condition ? 'button' : 'submit'} />
```

See https://github.com/yannickcr/eslint-plugin-react/issues/1555#issuecomment-362262866