### PR TITLE
[New] `jsx-handler-names`: add `checkInlineFunction` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Added
 * [`button-has-type`]: support trivial ternary expressions ([#2748][] @Hypnosphi)
+* [`jsx-handler-names`]: add `checkInlineFunction` option ([#2761][] @dididy)
 
 ### Fixed
 * [`function-component-definition`]: ignore object properties ([#2771][] @stefan-wullems)
 
 [#2771]: https://github.com/yannickcr/eslint-plugin-react/pull/2771
+[#2761]: https://github.com/yannickcr/eslint-plugin-react/pull/2761
 [#2748]: https://github.com/yannickcr/eslint-plugin-react/pull/2748
 
 ## [7.20.6] - 2020.08.12

--- a/docs/rules/jsx-handler-names.md
+++ b/docs/rules/jsx-handler-names.md
@@ -31,7 +31,8 @@ The following patterns are **not** considered warnings:
 "react/jsx-handler-names": [<enabled>, {
   "eventHandlerPrefix": <eventHandlerPrefix>,
   "eventHandlerPropPrefix": <eventHandlerPropPrefix>,
-  "checkLocalVariables": <boolean>
+  "checkLocalVariables": <boolean>,
+  "checkInlineFunction": <boolean>
 }]
 ...
 ```
@@ -39,6 +40,7 @@ The following patterns are **not** considered warnings:
 * `eventHandlerPrefix`: Prefix for component methods used as event handlers. Defaults to `handle`
 * `eventHandlerPropPrefix`: Prefix for props that are used as event handlers. Defaults to `on`
 * `checkLocalVariables`: Determines whether event handlers stored as local variables are checked. Defaults to `false`
+* `checkInlineFunction`: Determines whether event handlers set as inline functions are checked. Defaults to `false`
 
 ## When Not To Use It
 

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -27,7 +27,8 @@ module.exports = {
           properties: {
             eventHandlerPrefix: {type: 'string'},
             eventHandlerPropPrefix: {type: 'string'},
-            checkLocalVariables: {type: 'boolean'}
+            checkLocalVariables: {type: 'boolean'},
+            checkInlineFunction: {type: 'boolean'}
           },
           additionalProperties: false
         }, {
@@ -38,7 +39,8 @@ module.exports = {
               type: 'boolean',
               enum: [false]
             },
-            checkLocalVariables: {type: 'boolean'}
+            checkLocalVariables: {type: 'boolean'},
+            checkInlineFunction: {type: 'boolean'}
           },
           additionalProperties: false
         }, {
@@ -49,13 +51,20 @@ module.exports = {
               enum: [false]
             },
             eventHandlerPropPrefix: {type: 'string'},
-            checkLocalVariables: {type: 'boolean'}
+            checkLocalVariables: {type: 'boolean'},
+            checkInlineFunction: {type: 'boolean'}
           },
           additionalProperties: false
         }, {
           type: 'object',
           properties: {
             checkLocalVariables: {type: 'boolean'}
+          },
+          additionalProperties: false
+        }, {
+          type: 'object',
+          properties: {
+            checkInlineFunction: {type: 'boolean'}
           },
           additionalProperties: false
         }
@@ -66,6 +75,10 @@ module.exports = {
   create(context) {
     function isPrefixDisabled(prefix) {
       return prefix === false;
+    }
+
+    function isInlineHandler(node) {
+      return node.value.expression.type === 'ArrowFunctionExpression';
     }
 
     const configuration = context.options[0] || {};
@@ -86,14 +99,29 @@ module.exports = {
 
     const checkLocal = !!configuration.checkLocalVariables;
 
+    const checkInlineFunction = !!configuration.checkInlineFunction;
+
     return {
       JSXAttribute(node) {
-        if (!node.value || !node.value.expression || (!checkLocal && !node.value.expression.object)) {
+        if (
+          !node.value
+          || !node.value.expression
+          || (
+            !checkLocal
+            && (isInlineHandler(node)
+              ? !node.value.expression.body.callee.object
+              : !node.value.expression.object
+            )
+          )
+        ) {
           return;
         }
 
         const propKey = typeof node.name === 'object' ? node.name.name : node.name;
-        const propValue = context.getSourceCode().getText(node.value.expression).replace(/^this\.|.*::/, '');
+        const expression = node.value.expression;
+        const propValue = context.getSourceCode()
+          .getText(checkInlineFunction && isInlineHandler(node) ? expression.body.callee : expression)
+          .replace(/^this\.|.*::/, '');
 
         if (propKey === 'ref') {
           return;

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -43,6 +43,17 @@ ruleTester.run('jsx-handler-names', rule, {
       checkLocalVariables: false
     }]
   }, {
+    code: '<TestComponent onChange={() => handleChange()} />',
+    options: [{
+      checkInlineFunction: true,
+      checkLocalVariables: true
+    }]
+  }, {
+    code: '<TestComponent onChange={() => this.handleChange()} />',
+    options: [{
+      checkInlineFunction: true
+    }]
+  }, {
     code: '<TestComponent onChange={this.props.onFoo} />'
   }, {
     code: '<TestComponent isSelected={this.props.isSelected} />'
@@ -71,6 +82,24 @@ ruleTester.run('jsx-handler-names', rule, {
   }, {
     code: '<TestComponent onChange={props.foo::handleChange} />',
     parser: parsers.BABEL_ESLINT
+  }, {
+    code: '<TestComponent onChange={() => props::handleChange()} />',
+    parser: parsers.BABEL_ESLINT,
+    options: [{
+      checkInlineFunction: true
+    }]
+  }, {
+    code: '<TestComponent onChange={() => ::props.onChange()} />',
+    parser: parsers.BABEL_ESLINT,
+    options: [{
+      checkInlineFunction: true
+    }]
+  }, {
+    code: '<TestComponent onChange={() => props.foo::handleChange()} />',
+    parser: parsers.BABEL_ESLINT,
+    options: [{
+      checkInlineFunction: true
+    }]
   }, {
     code: '<TestComponent only={this.only} />'
   }, {
@@ -116,6 +145,12 @@ ruleTester.run('jsx-handler-names', rule, {
       checkLocalVariables: true
     }]
   }, {
+    code: '<TestComponent onChange={() => this.takeCareOfChange()} />',
+    errors: [{message: 'Handler function for onChange prop key must begin with \'handle\''}],
+    options: [{
+      checkInlineFunction: true
+    }]
+  }, {
     code: '<TestComponent only={this.handleChange} />',
     errors: [{message: 'Prop key for handleChange must begin with \'on\''}]
   }, {
@@ -128,9 +163,25 @@ ruleTester.run('jsx-handler-names', rule, {
       checkLocalVariables: true
     }]
   }, {
+    code: '<TestComponent whenChange={() => handleChange()} />',
+    errors: [{message: 'Prop key for handleChange must begin with \'on\''}],
+    options: [{
+      checkInlineFunction: true,
+      checkLocalVariables: true
+    }]
+  }, {
     code: '<TestComponent onChange={handleChange} />',
     errors: [{message: 'Prop key for handleChange must begin with \'when\''}],
     options: [{
+      checkLocalVariables: true,
+      eventHandlerPrefix: 'handle',
+      eventHandlerPropPrefix: 'when'
+    }]
+  }, {
+    code: '<TestComponent onChange={() => handleChange()} />',
+    errors: [{message: 'Prop key for handleChange must begin with \'when\''}],
+    options: [{
+      checkInlineFunction: true,
       checkLocalVariables: true,
       eventHandlerPrefix: 'handle',
       eventHandlerPropPrefix: 'when'


### PR DESCRIPTION
Add `checkInlineFunction` option for `jsx-handler-names` rule

PR resolve #2586 