### PR TITLE
Disallow object destructuring via ESLint since we support Node v4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,10 @@
         "no-plusplus": 1,
         "no-param-reassign": 1,
         "no-mixed-operators": 1,
-        "no-restricted-syntax": 1,
+        "no-restricted-syntax": [2, {
+            "selector": "ObjectPattern",
+            "message": "Object destructuring is not compatible with Node v4"
+        }],
         "strict": [2, "safe"],
         "valid-jsdoc": [2, {
           "requireReturn": false,

--- a/markdown.config.js
+++ b/markdown.config.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable no-restricted-syntax */
+
 const {rules} = require('./index');
 
 const ruleListItems = Object.keys(rules)


### PR DESCRIPTION
In #2763 @dylanOshima got a cryptic CI error that only manifested in Node 4. It took a bunch of time to get the environment setup correctly to trigger that error correctly. It seems like the kind of thing that could be caught earlier with a lint rule, so I thought I'd add one.

Test plan:

Check out an early commit of #2763 and see this error:

<img width="826" alt="Screen Shot 2020-08-28 at 7 12 25 PM" src="https://user-images.githubusercontent.com/162735/91626281-7c516f80-e962-11ea-9b22-68d089202dcf.png">
