### PR TITLE
[closes] jsx-one-expression-per-line fix option inserts blank lines 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,11 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`jsx-handler-names`]: false positive when handler name begins with number ([#1689][] @jsphstls)
 * [`prop-types`]: Detect JSX returned by sequential expression ([#2801][] @mikol)
 
+### Changed
+* [Tests] [`jsx-one-expression-per-line`]: add passing tests ([#2799][] @TaLeaMonet)
+
 [#2801]: https://github.com/yannickcr/eslint-plugin-react/pull/2801
+[#2799]: https://github.com/yannickcr/eslint-plugin-react/pull/2799
 [#2796]: https://github.com/yannickcr/eslint-plugin-react/pull/2796
 [#2791]: https://github.com/yannickcr/eslint-plugin-react/pull/2791
 [#2789]: https://github.com/yannickcr/eslint-plugin-react/pull/2789

--- a/tests/lib/rules/jsx-one-expression-per-line.js
+++ b/tests/lib/rules/jsx-one-expression-per-line.js
@@ -1029,5 +1029,28 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
     errors: [{message: '`Foo` must be placed on a new line'}],
     parser: parsers.BABEL_ESLINT,
     parserOptions
+  }, {
+    code: [
+      '<div>',
+      '<MyComponent>a</MyComponent>',
+      '<MyOther>{a}</MyOther>',
+      '</div>'
+    ].join('\n'),
+    output: [
+      '<div>',
+      '<MyComponent>',
+      'a',
+      '</MyComponent>',
+      '<MyOther>',
+      '{a}',
+      '</MyOther>',
+      '</div>'
+    ].join('\n'),
+    errors: [
+      {message: '`a` must be placed on a new line'},
+      {message: '`{a}` must be placed on a new line'}
+    ],
+    parser: parsers.BABEL_ESLINT,
+    parserOptions
   }]
 });


### PR DESCRIPTION
This issue has been resolved, added test to confirm that the bug has been fixed.

Closes #1835.