### PR TITLE
[Fix] Detect JSX returned by sequential expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`prop-types`]: Detect TypeScript types for destructured default prop values ([#2780][] @sunghyunjo)
 * [`jsx-pascal-case`]: Handle single character namespaced component ([#2791][] @daviferreira)
 * [`jsx-closing-bracket-location`]: In `tag-aligned`, made a distinction between tabs and spaces ([#2796][] @Moong0122)
-* [`jsx-handler-names`]: false positive when handler name begins with number ([#2801][] @mikol)
+* [`jsx-handler-names`]: false positive when handler name begins with number ([#1689][] @jsphstls)
+* [`prop-types`]: Detect JSX returned by sequential expression ([#2801][] @mikol)
 
 [#2801]: https://github.com/yannickcr/eslint-plugin-react/pull/2801
 [#2796]: https://github.com/yannickcr/eslint-plugin-react/pull/2796
@@ -33,6 +34,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 [#2767]: https://github.com/yannickcr/eslint-plugin-react/pull/2767
 [#2761]: https://github.com/yannickcr/eslint-plugin-react/pull/2761
 [#2748]: https://github.com/yannickcr/eslint-plugin-react/pull/2748
+[#1689]: https://github.com/yannickcr/eslint-plugin-react/pull/1689
 
 ## [7.20.6] - 2020.08.12
 

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -71,6 +71,12 @@ function isReturnsLogicalJSX(node, property, strict) {
     : (returnsLogicalJSXLeft || returnsLogicalJSXRight);
 }
 
+function isReturnsSequentialJSX(node, property) {
+  return node[property]
+    && node[property].type === 'SequenceExpression'
+    && jsxUtil.isJSX(node[property].expressions[node[property].expressions.length - 1]);
+}
+
 const Lists = new WeakMap();
 
 /**
@@ -457,6 +463,7 @@ function componentRule(rule, context) {
 
       const returnsConditionalJSX = isReturnsConditionalJSX(node, property, strict);
       const returnsLogicalJSX = isReturnsLogicalJSX(node, property, strict);
+      const returnsSequentialJSX = isReturnsSequentialJSX(node, property);
 
       const returnsJSX = node[property] && jsxUtil.isJSX(node[property]);
       const returnsPragmaCreateElement = this.isCreateElement(node[property]);
@@ -464,6 +471,7 @@ function componentRule(rule, context) {
       return !!(
         returnsConditionalJSX
         || returnsLogicalJSX
+        || returnsSequentialJSX
         || returnsJSX
         || returnsPragmaCreateElement
       );

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -2501,6 +2501,20 @@ ruleTester.run('prop-types', rule, {
       export default function() {}
       `
     },
+    {
+      code: `
+        function Component(props) {
+          return 0,
+          <div>
+            Hello, { props.name }!
+          </div>
+        }
+
+        Component.propTypes = {
+          name: PropTypes.string.isRequired
+        }
+      `
+    },
     parsers.TS([
       {
         code: `
@@ -5589,6 +5603,19 @@ ruleTester.run('prop-types', rule, {
       `,
       errors: [{
         message: '\'foo.baz\' is missing in props validation'
+      }]
+    },
+    {
+      code: `
+        function Component(props) {
+          return 0,
+          <div>
+            Hello, { props.name }!
+          </div>
+        }
+      `,
+      errors: [{
+        message: '\'name\' is missing in props validation'
       }]
     },
     parsers.TS([


### PR DESCRIPTION
Resolves #2800. Implements `isReturnsSequentialJSX()` and uses it in `isReturningJSX()` (in conjunction with `isReturnsConditionalJSX()` and `isReturnsLogicalJSX()`).