### PR TITLE
[Fix] `prop-types`: handle RestElement in destructured param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Fixed
+* [`prop-types`]: handle RestElement in destructured param ([#2805][] @hank121314)
+
+[#2805]: https://github.com/yannickcr/eslint-plugin-react/pull/2805
+
 ## [7.21.1] - 2020.09.23
 
 ### Fixed

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -150,6 +150,9 @@ module.exports = {
           return;
         }
         param.properties.forEach((property) => {
+          if (property.type === 'RestElement') {
+            return;
+          }
           const type = property.value.type;
           const right = property.value.right;
           if (type !== 'AssignmentPattern') {

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3109,6 +3109,40 @@ ruleTester.run('prop-types', rule, {
         type StateProps = ReturnType<typeof mapStateToProps>
         type DispatchProps = ReturnType<typeof mapDispatchToProps>`,
         parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+        import React from 'react'
+
+        interface Meta {
+          touched: boolean,
+          error: string;
+        }
+
+        interface Props {
+          input: string,
+          meta: Meta,
+          cssClasses: object
+        }
+        const InputField = ({ input, meta: { touched, error }, cssClasses = {}, ...restProps }: Props) => {
+          restProps.className = cssClasses.base
+
+          if (cssClasses.custom) {
+            restProps.className += 'cssClasses.custom'
+          }
+          if (touched && error) {
+            restProps.className += 'cssClasses.error'
+          }
+
+          return(
+            <input
+              {...input}
+              {...restProps}
+            />
+          )
+        }
+        export default InputField`,
+        parser: parsers['@TYPESCRIPT_ESLINT']
       }
     ])
   ),


### PR DESCRIPTION
## Summary

This pr fixes: #2804 .

Function parameter will have `RestElement` which do not have property value.
It will cause undefined property error.