### PR TITLE
[Fix]: fix `prop-types` Cannot read property 'type' of undefined error when destructured param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+## Fixed
+* [`prop-types`]: fix Cannot read property 'type' of undefined error when destructured param ([#2807][] @minwe)
+
+[#2807]: https://github.com/yannickcr/eslint-plugin-react/pull/2807
+
 ## [7.21.2] - 2020.09.24
 
 ### Fixed

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -150,7 +150,7 @@ module.exports = {
           return;
         }
         param.properties.forEach((property) => {
-          if (property.type === 'RestElement') {
+          if (property.type === 'RestElement' || property.type === 'ExperimentalRestProperty') {
             return;
           }
           const type = property.value.type;

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3096,7 +3096,7 @@ ruleTester.run('prop-types', rule, {
           )
         }
 
-        const mapDispatchToProps = (dispatch: ThunkDispatch<State, null, Action>) => 
+        const mapDispatchToProps = (dispatch: ThunkDispatch<State, null, Action>) =>
           bindActionCreators<{prop1: ()=>void,prop2: ()=>string}>(
             { prop1: importedAction, prop2: anotherImportedAction },
             dispatch,
@@ -6162,6 +6162,28 @@ ruleTester.run('prop-types', rule, {
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
           message: "'bar' is missing in props validation"
+        }]
+      },
+      // fix #2804
+      {
+        code: `
+        import React from 'react'
+
+        const InputField = ({ type, ...restProps }) => {
+
+          return(
+            <input
+              type={type}
+              {...restProps}
+            />
+          )
+        }
+
+        export default InputField;
+      `,
+        parser: parsers.BABEL_ESLINT,
+        errors: [{
+          message: "'type' is missing in props validation"
         }]
       }
     ])


### PR DESCRIPTION
## Summary

This pr fixes: #2804, #2805.

Function parameter will have `ExperimentalRestProperty`(JSX) and which do not have property value.
It will cause undefined property error.