### PR TITLE
improve es6 class detection

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -215,6 +215,7 @@ class Components {
 function componentRule(rule, context) {
   const createClass = pragmaUtil.getCreateClassFromContext(context);
   const pragma = pragmaUtil.getFromContext(context);
+  const es6ComponentRegExp = pragmaUtil.getComponentRegExpFromContext(context, pragma);
   const sourceCode = context.getSourceCode();
   const components = new Components();
 
@@ -248,7 +249,7 @@ function componentRule(rule, context) {
       if (!node.superClass) {
         return false;
       }
-      return new RegExp(`^(${pragma}\\.)?(Pure)?Component$`).test(sourceCode.getText(node.superClass));
+      return es6ComponentRegExp.test(sourceCode.getText(node.superClass));
     },
 
     /**

--- a/lib/util/pragma.js
+++ b/lib/util/pragma.js
@@ -53,7 +53,16 @@ function getFromContext(context) {
   return pragma;
 }
 
+function getComponentRegExpFromContext(context, pragma) {
+  if (context.settings.react && context.settings.react.component) {
+    return new RegExp(context.settings.react.component);
+  }
+
+  return new RegExp(`^(${pragma}\\.)?(Pure)?Component$`);
+}
+
 module.exports = {
+  getComponentRegExpFromContext,
   getCreateClassFromContext,
   getFragmentFromContext,
   getFromContext

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -976,3 +976,55 @@ ruleTester.run('sort-comp', rule, {
     }]
   }]
 });
+
+const ruleTesterCustomComponent = new RuleTester({
+  parserOptions,
+  settings: {
+    react: {
+      component: 'MyReactComponent'
+    }
+  }
+});
+ruleTesterCustomComponent.run('sort-comp. Custom component', rule, {
+  valid: [{
+    code: `
+    class MyComponent extends MyReactComponent {
+      static getDerivedStateFromProps() {}
+      render() {
+        return null;
+      }
+      static bar;
+      foo = {};
+    }`,
+    parser: parsers.BABEL_ESLINT,
+    options: [{
+      order: [
+        'static-methods',
+        'render',
+        'static-variables',
+        'instance-variables'
+      ]
+    }]
+  }],
+  invalid: [{
+    code: `
+    class MyComponent extends MyReactComponent {
+      static getDerivedStateFromProps() {}
+      static bar;
+      render() {
+        return null;
+      }
+      foo = {};
+    }`,
+    parser: parsers.BABEL_ESLINT,
+    errors: [{message: 'bar should be placed after render'}],
+    options: [{
+      order: [
+        'static-methods',
+        'render',
+        'static-variables',
+        'instance-variables'
+      ]
+    }]
+  }]
+});


### PR DESCRIPTION
Thanks for awesome eslint plugin!

Our team is using this plugin with Vue in tsx, but unfortunatelly not all rules that could be useful both for React and Vue work with Vue, because of ES6 class detection problem. Technically this could be useful for React as well.

[Example](https://github.com/wonderful-panda/vue-tsx-support#2-add-_tsx-field-to-tell-type-information-to-typescript) how component looks like.

Solution that I see is provide an option for superClass RegExp.