### PR TITLE
[Fix] `no-unused-prop-types`: Silence false positive on `never` type in TS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,14 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Fixed
+* [`no-unused-prop-types`]: Silence false positive on `never` type in TS ([#2815][] @pcorpet)
+
+[#2815]: https://github.com/yannickcr/eslint-plugin-react/pull/2815
+
 ## [7.21.3] - 2020.10.02
 
-## Fixed
+### Fixed
 * [`prop-types`]: fix Cannot read property 'type' of undefined error when destructured param ([#2807][] @minwe)
 * [`no-typos`]: avoid crash on spread syntax in createReactClass object ([#2816][] @ljharb @Songyu-Wang)
 

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -102,6 +102,11 @@ module.exports = {
           return;
         }
 
+        if (prop.node && prop.node.typeAnnotation && prop.node.typeAnnotation.typeAnnotation
+          && prop.node.typeAnnotation.typeAnnotation.type === 'TSNeverKeyword') {
+          return;
+        }
+
         if (prop.node && !isPropUsed(component, prop)) {
           context.report({
             node: prop.node.key || prop.node,

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -3670,6 +3670,19 @@ ruleTester.run('no-unused-prop-types', rule, {
       },
       {
         code: `
+        interface Person {
+          firstname: string
+          lastname?: never
+        };
+
+        const Hello = ({firstname}: Person) => {
+          return <div><span>{firstname}</span></div>;
+        };
+        `,
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
         class App extends Component {
           static propTypes = {
             notifications: PropTypes.array.isRequired


### PR DESCRIPTION
Adding the type `never` is enforcing that the prop types is actually never set, so it's redundant to warn about this prop type not being used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/yannickcr/eslint-plugin-react/2815)
<!-- Reviewable:end -->
