### PR TITLE
[Tests] `jsx-indent-props` : Apply indentation when used expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 * [`no-unused-prop-types`]: Silence false positive on `never` type in TS ([#2815][] @pcorpet)
-* [`jsx-indent-props`]: Apply indentation when operator is used in front of the upper line ([#2808][] @Moong0122)
+* [`jsx-indent-props`]: Apply indentation when operator is used in front of the upper line ([#2808][], [#2820][] @Moong0122)
 * [Deps] update `jsx-ast-utils` ([#2822][] [jsx-eslint/jsx-ast-utils#102][] @ljharb)
 
 [#2822]: https://github.com/yannickcr/eslint-plugin-react/issues/2822
+[#2820]: https://github.com/yannickcr/eslint-plugin-react/pull/2820
 [#2815]: https://github.com/yannickcr/eslint-plugin-react/pull/2815
 [#2808]: https://github.com/yannickcr/eslint-plugin-react/pull/2808
 [jsx-eslint/jsx-ast-utils#102]: https://github.com/jsx-eslint/jsx-ast-utils/pull/102

--- a/tests/lib/rules/jsx-indent-props.js
+++ b/tests/lib/rules/jsx-indent-props.js
@@ -230,6 +230,28 @@ ruleTester.run('jsx-indent-props', rule, {
     ]
   }, {
     code: [
+      '{this.props.test',
+      '  ? <span',
+      '    className="value"',
+      '    some={{aaa}}',
+      '    />',
+      '  : null}'
+    ].join('\n'),
+    output: [
+      '{this.props.test',
+      '  ? <span',
+      '      className="value"',
+      '      some={{aaa}}',
+      '    />',
+      '  : null}'
+    ].join('\n'),
+    options: [2],
+    errors: [
+      {message: 'Expected indentation of 6 space characters but found 4.'},
+      {message: 'Expected indentation of 6 space characters but found 4.'}
+    ]
+  }, {
+    code: [
       '<App',
       '    foo',
       '/>'


### PR DESCRIPTION
This problem seems to be the same as https://github.com/yannickcr/eslint-plugin-react/issues/647 where I sent pr, 
so I added a test case in `tests/lib/rules/jsx-indent-props` to make sure it passes all the test cases.

PR fixes #1187 