### PR TITLE
Add a failing test for js-indent props

### DIFF
--- a/tests/lib/rules/jsx-indent-props.js
+++ b/tests/lib/rules/jsx-indent-props.js
@@ -206,6 +206,29 @@ ruleTester.run('jsx-indent-props', rule, {
     ]
   }, {
     code: [
+      'const test = true',
+      '  ? <span attr="value" />',
+      '  : (',
+      '    <span',
+      '        attr="otherValue"',
+      '    />',
+      '  )'
+    ].join('\n'),
+    output: [
+      'const test = true',
+      '  ? <span attr="value" />',
+      '  : (',
+      '    <span',
+      '      attr="otherValue"',
+      '    />',
+      '  )'
+    ].join('\n'),
+    options: [2],
+    errors: [
+      {message: 'Expected indentation of 6 space characters but found 8.'}
+    ]
+  }, {
+    code: [
       '{test.isLoading',
       '  ? <Value/>',
       '  : <OtherValue',


### PR DESCRIPTION
This adds a failing test reproducing a regression described in https://github.com/yannickcr/eslint-plugin-react/issues/1187#issuecomment-706646097