### PR TITLE
[Fix] `jsx-indent-props` : Apply indentation when using operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Fixed
+* [`jsx-indent-props`]: Apply indentation when using brackets ([#2826][] @Moong0122)
+
+[#2826]: https://github.com/yannickcr/eslint-plugin-react/issues/2826
+
 ## [7.21.4] - 2020.10.09
 
 ### Fixed

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -124,10 +124,14 @@ module.exports = {
 
       const indent = regExp.exec(src);
       const useOperator = /^([ ]|[\t])*[:]/.test(src) || /^([ ]|[\t])*[?]/.test(src);
+      const useBracket = /^([ ]|[\t])*[<]/.test(src);
+
       line.currentOperator = false;
       if (useOperator) {
         line.isUsingOperator = true;
         line.currentOperator = true;
+      } else if (useBracket) {
+        line.isUsingOperator = false;
       }
 
       return indent ? indent[0].length : 0;

--- a/tests/lib/rules/jsx-indent-props.js
+++ b/tests/lib/rules/jsx-indent-props.js
@@ -40,6 +40,23 @@ ruleTester.run('jsx-indent-props', rule, {
     options: [2]
   }, {
     code: [
+      'const Test = () => ([',
+      '  (x',
+      '    ? <div key="1" />',
+      '    : <div key="2" />),',
+      '  <div',
+      '    key="3"',
+      '    align="left"',
+      '  />,',
+      '  <div',
+      '    key="4"',
+      '    align="left"',
+      '  />,',
+      ']);'
+    ].join('\n'),
+    options: [2]
+  }, {
+    code: [
       '<App',
       'foo',
       '/>'


### PR DESCRIPTION
Since there were cases where indentation was not properly applied after https://github.com/yannickcr/eslint-plugin-react/pull/2808, 
modified `lib/rules/jsx-indent-props`, and added test case in `tests/lib/rules/jsx-indent-props`.