### PR TITLE
[Fix] `jsx-handler-names`: Skip inline handlers when checkInlineFunction=false. Fixes #2832

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 * [`jsx-indent-props`]: Apply indentation when using brackets ([#2826][] @Moong0122)
+* [`jsx-handler-names`]: Skip inline handlers when checkInlineFunction=false ([#2833][] @onigoetz)
 
+[#2833]: https://github.com/yannickcr/eslint-plugin-react/issues/2833
 [#2826]: https://github.com/yannickcr/eslint-plugin-react/issues/2826
 
 ## [7.21.4] - 2020.10.09

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -106,6 +106,7 @@ module.exports = {
         if (
           !node.value
           || !node.value.expression
+          || (!checkInlineFunction && isInlineHandler(node))
           || (
             !checkLocal
             && (isInlineHandler(node)

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -60,6 +60,11 @@ ruleTester.run('jsx-handler-names', rule, {
       checkLocalVariables: false
     }]
   }, {
+    code: '<TestComponent onChange={event => window.alert(event.target.value)} />',
+    options: [{
+      checkInlineFunction: false
+    }]
+  }, {
     code: '<TestComponent onChange={() => handleChange()} />',
     options: [{
       checkInlineFunction: true,


### PR DESCRIPTION
Hi,

This fixes the issue presented in #2832 