### PR TITLE
Remove invalid prop

### DIFF
--- a/docs/rules/jsx-no-literals.md
+++ b/docs/rules/jsx-no-literals.md
@@ -31,12 +31,11 @@ The supported options are:
 * `noStrings` (default: `false`) - Enforces no string literals used as children, wrapped or unwrapped.
 * `allowedStrings` - An array of unique string values that would otherwise warn, but will be ignored.
 * `ignoreProps` (default: `false`) - When `true` the rule ignores literals used in props, wrapped or unwrapped.
-* `noAttributeStrings` (default: `false`) - Enforces no string literals used in attributes when set to `true`.
 
 To use, you can specify as follows:
 
 ```js
-"react/jsx-no-literals": [<enabled>, {"noStrings": true, "allowedStrings": ["allowed"], "ignoreProps": false, "noAttributeStrings": true }]
+"react/jsx-no-literals": [<enabled>, {"noStrings": true, "allowedStrings": ["allowed"], "ignoreProps": false }]
 ```
 
 In this configuration, the following are considered warnings:


### PR DESCRIPTION
As far as I can tell, the `noAttributeStrings` property does not exist. Including it in my configuration caused my eslint to throw an error: 

> 	Configuration for rule "react/jsx-no-literals" is invalid:
	Value {"noStrings":true,"allowedStrings":[],"ignoreProps":false,"noAttributeStrings":true} should NOT have additional properties.