### PR TITLE
[Fix] `no-multi-comp`: improve component detection

### DIFF
--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -708,6 +708,14 @@ function componentRule(rule, context) {
         }
         if (utils.isInAllowedPositionForComponent(node) && utils.isReturningJSXOrNull(node)) {
           if (!node.id || isFirstLetterCapitalized(node.id.name)) {
+            if (
+              node.body
+              && node.body.openingElement
+              && node.body.openingElement.name
+              && !isFirstLetterCapitalized(node.body.openingElement.name.name)
+            ) {
+              return undefined;
+            }
             return node;
           }
           return undefined;

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -265,7 +265,7 @@ ruleTester.run('destructuring-assignment', rule, {
     errors: [{message: 'Must use destructuring props assignment'}]
   }, {
     code: `
-      function hof() {
+      function HOF() {
         return (props) => <p>{props.a}</p>;
       }
     `,

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -31,6 +31,80 @@ ruleTester.run('no-multi-comp', rule, {
 
   valid: [{
     code: [
+      'import { FormattedMessage } from \'react-intl\';',
+      'export function App() {',
+      '  return (',
+      '    <FormattedMessage',
+      '      values={{',
+      '        link:',
+      '        (text) => <a>{text}</a>,',
+      '      }}',
+      '    />',
+      '  );',
+      '}'
+    ].join('\r')
+  }, {
+    code: [
+      'import { FormattedMessage } from \'react-intl\';',
+      'const App = () => {',
+      '  return (',
+      '    <FormattedMessage',
+      '      values={{',
+      '        link:',
+      '        (text) => <a>{text}</a>,',
+      '      }}',
+      '    />',
+      '  );',
+      '}'
+    ].join('\r')
+  }, {
+    code: [
+      'import { FormattedMessage } from \'react-intl\';',
+      'const App = function() {',
+      '  return (',
+      '    <FormattedMessage',
+      '      values={{',
+      '        link:',
+      '        (text) => <a>{text}</a>,',
+      '      }}',
+      '    />',
+      '  );',
+      '}'
+    ].join('\r')
+  }, {
+    code: [
+      'import { FormattedMessage } from \'react-intl\';',
+      'class Hello extends React.Component {',
+      '  render() {',
+      '    return (',
+      '      <FormattedMessage',
+      '        values={{',
+      '          link:',
+      '          (text) => <a>{text}</a>,',
+      '        }}',
+      '      />',
+      '    );',
+      '  }',
+      '};'
+    ].join('\r')
+  }, {
+    code: [
+      'import { FormattedMessage } from \'react-intl\';',
+      'var HelloJohn = createReactClass({',
+      '  render: function() {',
+      '    return (',
+      '      <FormattedMessage',
+      '        values={{',
+      '          link:',
+      '          (text) => <a>{text}</a>,',
+      '        }}',
+      '      />',
+      '    );',
+      '  }',
+      '});'
+    ].join('\r')
+  }, {
+    code: [
       'var Hello = require(\'./components/Hello\');',
       'var HelloJohn = createReactClass({',
       '  render: function() {',


### PR DESCRIPTION
Fixes #2842. 

As explained by @ljharb, the issue there isn’t that it’s nested - it’s that it’s treated as a component despite being used in an object literal with a key name that can’t be a custom component name.

Our component detection should be improved here.