### PR TITLE
Added a new rule to allow linting of spread prop declarations in JSX to ensure alphabetical ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Enable the rules that you would like to use.
 * [react/jsx-props-no-multi-spaces](docs/rules/jsx-props-no-multi-spaces.md): Disallow multiple spaces between inline JSX props (fixable)
 * [react/jsx-props-no-spreading](docs/rules/jsx-props-no-spreading.md): Prevent JSX prop spreading
 * [react/jsx-sort-default-props](docs/rules/jsx-sort-default-props.md): Enforce default props alphabetical sorting
+* [react/jsx-sort-functional-props](docs/rules/jsx-sort-functional-props.md): Enforce props of functional components to be sorted alphabetically
 * [react/jsx-sort-props](docs/rules/jsx-sort-props.md): Enforce props alphabetical sorting (fixable)
 * [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md): Validate spacing before closing bracket in JSX (fixable)
 * [react/jsx-tag-spacing](docs/rules/jsx-tag-spacing.md): Validate whitespace in and around the JSX opening and closing brackets (fixable)

--- a/docs/rules/jsx-sort-functional-props.md
+++ b/docs/rules/jsx-sort-functional-props.md
@@ -1,0 +1,75 @@
+# Enforce spread parameters of functional components to be sorted alphabetically (react/jsx-sort-functional-props)
+
+Some developers prefer to sort spread `{ one, two ... }` declarations alphabetically to be able to find necessary declarations easier at a later time. Others feel that it adds complexity and becomes a burden to maintain.
+
+## Rule Details
+
+This rule checks all functional components and verifies that their spread props declarations are sorted alphabetically. The default configuration of the rule is case-sensitive.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+// as short arrow function declarations
+const First = ({ one, two, three }) => {
+  return <div />;
+};
+const First = ({ One, two, Three }) => {
+  return <div />;
+};
+
+// as full function declarations
+function First({ one, two, three }) {
+  return <div />;
+}
+function First({ One, Txo, two }) {
+  return <div />;
+}
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+// as short arrow function declarations
+const First = ({ one, three, two }) => {
+  return <div />;
+};
+
+const Second = ({ One, Three, Two }) => {
+  return <div />;
+};
+
+const Third = ({ One, two, West }) => {
+  return <div />;
+};
+
+// as full function declarations
+function Fourth({ one, three, two }) {
+  return <div />;
+}
+
+function Fifth({ One, Three, Two }) {
+  return <div />;
+}
+
+function Sixth({ tWO, two, Two }) {
+  return <div />;
+}
+```
+
+## Rule Options
+
+```js
+...
+"react/jsx-sort-functional-props": [<enabled>, {
+  "ignoreCase": <boolean>,
+}]
+...
+```
+
+### `ignoreCase`
+
+When `true` the rule ignores the case-sensitivity of the spread properties order.
+
+## When not to use
+
+This rule is a formatting preference and not following it won't negatively affect the quality of your code. If alphabetizing spread declarations of your components isn't a part of your coding standards, then you can leave this rule off.

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ const allRules = {
   'jsx-props-no-multi-spaces': require('./lib/rules/jsx-props-no-multi-spaces'),
   'jsx-props-no-spreading': require('./lib/rules/jsx-props-no-spreading'),
   'jsx-sort-default-props': require('./lib/rules/jsx-sort-default-props'),
+  'jsx-sort-functional-props': require('./lib/rules/jsx-sort-functional-props'),
   'jsx-sort-props': require('./lib/rules/jsx-sort-props'),
   'jsx-space-before-closing': require('./lib/rules/jsx-space-before-closing'),
   'jsx-tag-spacing': require('./lib/rules/jsx-tag-spacing'),

--- a/lib/rules/jsx-sort-functional-props.js
+++ b/lib/rules/jsx-sort-functional-props.js
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Enforce props of functional components to be sorted alphabetically
+ * @author IRoninCoder
+ */
+
+'use strict';
+
+const docsUrl = require('../util/docsUrl');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Enforce props of functional components to be sorted alphabetically',
+      category: 'Stylistic Issues',
+      recommended: false,
+      url: docsUrl('jsx-sort-functional-props')
+    },
+
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          ignoreCase: {
+            type: 'boolean'
+          }
+        },
+        additionalProperties: false
+      }
+    ]
+  },
+
+  create(context) {
+    const configuration = context.options[0] || {};
+    const ignoreCase = configuration.ignoreCase || false;
+
+    function getKey(node) {
+      return context.getSourceCode().getText(node.key || node.argument);
+    }
+
+    /**
+     * Checks if spread prop declarations are sorted
+     * @param {Array} properties The array of AST nodes being checked.
+     * @returns {void}
+     */
+    function checkSorted(properties) {
+      properties.reduce((prev, curr) => {
+        let prevPropName = getKey(prev);
+        let currentPropName = getKey(curr);
+
+        if (ignoreCase) {
+          prevPropName = prevPropName.toLowerCase();
+          currentPropName = currentPropName.toLowerCase();
+        }
+
+        if (currentPropName < prevPropName) {
+          context.report({
+            node: curr,
+            message:
+              'Functional component prop declarations should be sorted alphabetically'
+          });
+
+          return prev;
+        }
+
+        return curr;
+      }, properties[0]);
+    }
+
+    function checkNode(node) {
+      switch (node && node.type) {
+        case 'FunctionDeclaration': {
+          // only match a `function Something ({ one, two })` pattern.
+          if (
+            node.id.name[0] === node.id.name[0].toUpperCase()
+            && node.params.length === 1
+            && node.params[0].type === 'ObjectPattern'
+          ) {
+            checkSorted(node.params[0].properties);
+          }
+          break;
+        }
+        case 'VariableDeclaration': {
+          // only match a `var/const/let Something = ({ one, two }) =>` pattern
+          if (
+            node.declarations.length === 1
+            && node.declarations[0].type === 'VariableDeclarator'
+            && node.declarations[0].id.name[0] === node.declarations[0].id.name[0].toUpperCase()
+            && node.declarations[0].init
+            && node.declarations[0].init.type === 'ArrowFunctionExpression'
+            && node.declarations[0].init.params.length === 1
+            && node.declarations[0].init.params[0].type === 'ObjectPattern'
+          ) {
+            checkSorted(node.declarations[0].init.params[0].properties);
+          }
+          break;
+        }
+        default:
+          break;
+      }
+    }
+
+    // --------------------------------------------------------------------------
+    // Public API
+    // --------------------------------------------------------------------------
+
+    return {
+      VariableDeclaration(node) {
+        checkNode(node);
+      },
+      FunctionDeclaration(node) {
+        checkNode(node);
+      }
+    };
+  }
+};

--- a/tests/lib/rules/jsx-sort-functional-props.js
+++ b/tests/lib/rules/jsx-sort-functional-props.js
@@ -1,0 +1,163 @@
+/**
+ * @fileoverview Tests for jsx-sort-functional-props
+ * @author IRoninCoder
+ */
+
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/jsx-sort-functional-props');
+
+const parsers = require('../../helpers/parsers');
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+const ERROR_MESSAGE = 'Functional component prop declarations should be sorted alphabetically';
+
+const ruleTester = new RuleTester({parserOptions});
+ruleTester.run('jsx-sort-functional-props', rule, {
+  valid: [
+    // short
+    {
+      code: [
+        'const First = ({ one, three, two }) => {',
+        '  return <div />;',
+        '};'
+      ].join('\n')
+    },
+    {
+      code: [
+        'const First = ({ One, Three, Two }) => {',
+        '  return <div />;',
+        '};'
+      ].join('\n')
+    },
+    {
+      code: [
+        'const First = ({ One, two, West }) => {',
+        '  return <div />;',
+        '};'
+      ].join('\n'),
+      options: [
+        {
+          ignoreCase: true
+        }
+      ]
+    },
+    // full
+    {
+      code: [
+        'function First ({ one, three, two }) {',
+        '  return <div />;',
+        '};'
+      ].join('\n')
+    },
+    {
+      code: [
+        'function First ({ One, Three, Two }) {',
+        '  return <div />;',
+        '};'
+      ].join('\n')
+    },
+    {
+      code: [
+        'function First ({ tWO, two, Two }) {',
+        '  return <div />;',
+        '};'
+      ].join('\n'),
+      options: [
+        {
+          ignoreCase: true
+        }
+      ]
+    }
+  ],
+
+  invalid: [
+    {
+      code: [
+        'const First = ({ one, two, three }) => {',
+        '  return <div />;',
+        '};'
+      ].join('\n'),
+      parser: parsers.BABEL_ESLINT,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          line: 1,
+          column: 28
+        }
+      ]
+    },
+    {
+      code: [
+        'const First = ({ One, two, Three }) => {',
+        '  return <div />;',
+        '};'
+      ].join('\n'),
+      parser: parsers.BABEL_ESLINT,
+      options: [
+        {
+          ignoreCase: true
+        }
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          line: 1,
+          column: 28
+        }
+      ]
+    },
+    // full
+    {
+      code: [
+        'function First ({ one, two, three }) {',
+        '  return <div />;',
+        '};'
+      ].join('\n'),
+      parser: parsers.BABEL_ESLINT,
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          line: 1,
+          column: 29
+        }
+      ]
+    },
+    {
+      code: [
+        'function First ({ One, Txo, two }) {',
+        '  return <div />;',
+        '};'
+      ].join('\n'),
+      parser: parsers.BABEL_ESLINT,
+      options: [
+        {
+          ignoreCase: true
+        }
+      ],
+      errors: [
+        {
+          message: ERROR_MESSAGE,
+          line: 1,
+          column: 29
+        }
+      ]
+    }
+  ]
+});


### PR DESCRIPTION
Based on the question at SO [react functional component props sort alphabetically at the definition side](https://stackoverflow.com/questions/64750228/react-functional-component-props-sort-alphabetically-at-the-definition-side) the idea is to have the ability to lint for spread property names in order to ensure they are sorted alphabetically.