### PR TITLE
[New] : Enforce useState hook destructuring and variable naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Enable the rules that you would like to use.
 * [react/forbid-foreign-prop-types](docs/rules/forbid-foreign-prop-types.md): Forbid using another component's propTypes
 * [react/forbid-prop-types](docs/rules/forbid-prop-types.md): Forbid certain propTypes
 * [react/function-component-definition](docs/rules/function-component-definition.md): Standardize the way function component get defined (fixable)
+* [react/hook-use-state](docs/rules/hook-use-state.md): Ensure symmetric naming of useState hook value and setter variables (fixable)
 * [react/no-access-state-in-setstate](docs/rules/no-access-state-in-setstate.md): Reports when this.state is accessed within setState
 * [react/no-adjacent-inline-elements](docs/rules/no-adjacent-inline-elements.md): Prevent adjacent inline elements not separated by whitespace.
 * [react/no-array-index-key](docs/rules/no-array-index-key.md): Prevent usage of Array index in keys

--- a/docs/rules/hook-use-state.md
+++ b/docs/rules/hook-use-state.md
@@ -1,0 +1,23 @@
+# Ensure destructuring and symmetric naming of useState hook value and setter variables (react/hook-use-state)
+
+**Fixable:** In some cases, this rule is automatically fixable using the `--fix` flag on the command line.
+
+## Rule Details
+
+This rule checks whether the value and setter variables destructured from a `React.useState()` call are named symmetrically.
+
+Examples of **incorrect** code for this rule:
+
+```js
+const useStateResult = React.useState();
+```
+
+```js
+const [color, updateColor] = React.useState();
+```
+
+Examples of **correct** code for this rule:
+
+```js
+const [color, setColor] = React.useState();
+```

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ const allRules = {
   'forbid-foreign-prop-types': require('./lib/rules/forbid-foreign-prop-types'),
   'forbid-prop-types': require('./lib/rules/forbid-prop-types'),
   'function-component-definition': require('./lib/rules/function-component-definition'),
+  'hook-use-state': require('./lib/rules/hook-use-state'),
   'jsx-boolean-value': require('./lib/rules/jsx-boolean-value'),
   'jsx-child-element-spacing': require('./lib/rules/jsx-child-element-spacing'),
   'jsx-closing-bracket-location': require('./lib/rules/jsx-closing-bracket-location'),

--- a/lib/rules/hook-use-state.js
+++ b/lib/rules/hook-use-state.js
@@ -68,7 +68,7 @@ module.exports = {
 
         const valueVariableName = valueVariable
           ? valueVariable.name
-          : 'state';
+          : undefined;
 
         const setterVariableName = setterVariable
           ? setterVariable.name
@@ -89,12 +89,10 @@ module.exports = {
           context.report({
             node: node.parent.id,
             messageId: USE_STATE_ERROR_MESSAGE,
-            fix(fixer) {
-              return fixer.replaceTextRange(
-                [node.parent.id.range[0] + 1, node.parent.id.range[1] - 1],
-                `${valueVariableName}, ${expectedSetterVariableName}`
-              );
-            }
+            fix: valueVariableName ? (fixer) => fixer.replaceTextRange(
+              [node.parent.id.range[0], node.parent.id.range[1]],
+              `[${valueVariableName}, ${expectedSetterVariableName}]`
+            ) : undefined
           });
         }
       }

--- a/lib/rules/hook-use-state.js
+++ b/lib/rules/hook-use-state.js
@@ -11,6 +11,8 @@ const docsUrl = require('../util/docsUrl');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+const USE_STATE_ERROR_MESSAGE = 'useStateErrorMessage';
+
 module.exports = {
   meta: {
     docs: {
@@ -21,9 +23,7 @@ module.exports = {
     },
     fixable: 'code',
     messages: {
-      useStateAsymmetric: 'setState variable names are not symmetric, setter should be {{expectedSetterVariableName}}',
-      useStateBadPrefix: 'setState setter variable name should begin with set',
-      useStateNotDestructured: 'setState call is not destructured into value + setter pair'
+      [USE_STATE_ERROR_MESSAGE]: 'setState call is not destructured into value + setter pair'
     },
     schema: [{
       type: 'object',
@@ -58,7 +58,7 @@ module.exports = {
         );
 
         if (!isDestructuringDeclarator) {
-          context.report({node, messageId: 'useStateNotDestructured'});
+          context.report({node, messageId: USE_STATE_ERROR_MESSAGE});
           return;
         }
 
@@ -66,54 +66,35 @@ module.exports = {
         const valueVariable = variableNodes[0];
         const setterVariable = variableNodes[1];
 
-        // Make sure the list destructured off of useState is sized just right.
-        if (variableNodes.length > 2) {
-          context.report({
-            node: node.parent,
-            messageId: 'useStateNotDestructured',
-            // Set the trim locations, starting from the end of the setter
-            // variable, and spanning to the end of final extraneous variable.
-            fix: setterVariable ? (fixer) => fixer.removeRange([
-              setterVariable.range[1],
-              (variableNodes[variableNodes.length - 1]).range[1]
-            ])
-              : undefined
-          });
-
-          return;
-        }
-
         const valueVariableName = valueVariable
           ? valueVariable.name
-          : undefined;
+          : 'state';
 
         const setterVariableName = setterVariable
           ? setterVariable.name
           : undefined;
 
-        if (valueVariableName) {
-          const expectedSetterVariableName = (
-            `set${
-              valueVariableName.charAt(0).toUpperCase()
-            }${valueVariableName.slice(1)}`
-          );
-          if (setterVariableName !== expectedSetterVariableName) {
-            context.report({
-              node: node.parent.id,
-              messageId: 'useStateAsymmetric',
-              data: {expectedSetterVariableName},
-              fix(fixer) {
-                return fixer.replaceText(
-                  setterVariable,
-                  expectedSetterVariableName
-                );
-              }
-            });
-          }
-        } else if (!setterVariableName.match(/^set[A-Z]\w+/)) {
+        const expectedSetterVariableName = valueVariableName ? (
+          `set${
+            valueVariableName.charAt(0).toUpperCase()
+          }${valueVariableName.slice(1)}`
+        ) : undefined;
+
+        if (
+          !valueVariable
+          || !setterVariable
+          || setterVariableName !== expectedSetterVariableName
+          || variableNodes.length !== 2
+        ) {
           context.report({
-            node: node.parent,
-            messageId: 'useStateBadPrefix'
+            node: node.parent.id,
+            messageId: USE_STATE_ERROR_MESSAGE,
+            fix(fixer) {
+              return fixer.replaceTextRange(
+                [node.parent.id.range[0] + 1, node.parent.id.range[1] - 1],
+                `${valueVariableName}, ${expectedSetterVariableName}`
+              );
+            }
           });
         }
       }

--- a/lib/rules/hook-use-state.js
+++ b/lib/rules/hook-use-state.js
@@ -71,17 +71,15 @@ module.exports = {
           context.report({
             node: node.parent,
             messageId: 'useStateNotDestructured',
-            fix(fixer) {
-              // Set the trim locations, starting from the end of the setter
-              // variable, and spanning to the end of final extraneous variable.
-              return fixer.removeRange([
-                setterVariable.range[1],
-                (variableNodes[variableNodes.length - 1]).range[1]
-              ]);
-            }
+            // Set the trim locations, starting from the end of the setter
+            // variable, and spanning to the end of final extraneous variable.
+            fix: setterVariable ? (fixer) => fixer.removeRange([
+              setterVariable.range[1],
+              (variableNodes[variableNodes.length - 1]).range[1]
+            ])
+              : undefined
           });
 
-          // console.log(node.parent.id.elements);
           return;
         }
 

--- a/lib/rules/hook-use-state.js
+++ b/lib/rules/hook-use-state.js
@@ -1,0 +1,124 @@
+/**
+ * @fileoverview Ensure symmetric naming of useState hook value and setter variables
+ * @author Duncan Beevers
+ */
+
+'use strict';
+
+const docsUrl = require('../util/docsUrl');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Ensure symmetric naming of useState hook value and setter variables',
+      category: 'Best Practices',
+      recommended: false,
+      url: docsUrl('hook-use-state')
+    },
+    fixable: 'code',
+    messages: {
+      useStateAsymmetric: 'setState variable names are not symmetric, setter should be {{expectedSetterVariableName}}',
+      useStateBadPrefix: 'setState setter variable name should begin with set',
+      useStateNotDestructured: 'setState call is not destructured into value + setter pair'
+    },
+    schema: [{
+      type: 'object',
+      additionalProperties: false
+    }]
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const isReactUseStateCall = (
+          node.callee.type === 'MemberExpression'
+          && node.callee.object.type === 'Identifier'
+          && node.callee.object.name === 'React'
+          && node.callee.property.type === 'Identifier'
+          && node.callee.property.name === 'useState'
+        );
+
+        const isUseStateCall = (
+          node.callee.type === 'Identifier'
+          && node.callee.name === 'useState'
+        );
+
+        // Ignore unless this is a useState() or React.useState() call.
+        if (!isReactUseStateCall && !isUseStateCall) {
+          return;
+        }
+
+        const isDestructuringDeclarator = (
+          node.parent.type === 'VariableDeclarator'
+          && node.parent.id.type === 'ArrayPattern'
+        );
+
+        if (!isDestructuringDeclarator) {
+          context.report({node, messageId: 'useStateNotDestructured'});
+          return;
+        }
+
+        const variableNodes = node.parent.id.elements;
+        const valueVariable = variableNodes[0];
+        const setterVariable = variableNodes[1];
+
+        // Make sure the list destructured off of useState is sized just right.
+        if (variableNodes.length > 2) {
+          context.report({
+            node: node.parent,
+            messageId: 'useStateNotDestructured',
+            fix(fixer) {
+              // Set the trim locations, starting from the end of the setter
+              // variable, and spanning to the end of final extraneous variable.
+              return fixer.removeRange([
+                setterVariable.range[1],
+                (variableNodes[variableNodes.length - 1]).range[1]
+              ]);
+            }
+          });
+
+          // console.log(node.parent.id.elements);
+          return;
+        }
+
+        const valueVariableName = valueVariable
+          ? valueVariable.name
+          : undefined;
+
+        const setterVariableName = setterVariable
+          ? setterVariable.name
+          : undefined;
+
+        if (valueVariableName) {
+          const expectedSetterVariableName = (
+            `set${
+              valueVariableName.charAt(0).toUpperCase()
+            }${valueVariableName.slice(1)}`
+          );
+          if (setterVariableName !== expectedSetterVariableName) {
+            context.report({
+              node: node.parent.id,
+              messageId: 'useStateAsymmetric',
+              data: {expectedSetterVariableName},
+              fix(fixer) {
+                return fixer.replaceText(
+                  setterVariable,
+                  expectedSetterVariableName
+                );
+              }
+            });
+          }
+        } else if (!setterVariableName.match(/^set[A-Z]\w+/)) {
+          context.report({
+            node: node.parent,
+            messageId: 'useStateBadPrefix'
+          });
+        }
+      }
+    };
+  }
+};

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -1,0 +1,124 @@
+/**
+ * @fileoverview Ensure symmetric naming of setState hook value and setter variables
+ * @author Duncan Beevers
+ */
+
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/hook-use-state');
+const parsers = require('../../helpers/parsers');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module'
+  }
+});
+
+const tests = {
+  valid: [
+    {
+      code: 'const [color, setColor] = useState()'
+    },
+    {
+      code: 'const [color, setColor] = useState(\'#ffffff\')'
+    },
+    {
+      code: 'const [color, setColor] = React.useState()'
+    },
+    {
+      code: 'const [color1, setColor1] = useState()'
+    },
+    {
+      code: 'const [, setColor] = useState()'
+    },
+    {
+      code: 'const [color, setColor] = useState<string>()',
+      parser: parsers.TYPESCRIPT_ESLINT
+    },
+    {
+      code: 'const [color, setColor] = useState<string>(\'#ffffff\')',
+      parser: parsers.TYPESCRIPT_ESLINT
+    }
+  ].concat(parsers.TS([
+    {
+      code: 'const [color, setColor] = useState<string>()',
+      parser: parsers['@TYPESCRIPT_ESLINT']
+    },
+    {
+      code: 'const [color, setColor] = useState<string>(\'#ffffff\')',
+      parser: parsers['@TYPESCRIPT_ESLINT']
+    }
+  ])
+  ),
+  invalid: [
+    {
+      code: 'useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }]
+    },
+    {
+      code: 'const result = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }]
+    },
+    {
+      code: 'const result = React.useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }]
+    },
+    {
+      code: 'const [color, setColor, extra1, extra2, extra3] = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }],
+      output: 'const [color, setColor] = useState()'
+    },
+    {
+      code: 'const [, makeColor] = useState()',
+      errors: [{
+        message: 'setState setter variable name should begin with set'
+      }]
+    },
+    {
+      code: 'const [color, setFlavor] = useState()',
+      errors: [{
+        message: 'setState variable names are not symmetric, setter should be setColor'
+      }],
+      output: 'const [color, setColor] = useState()'
+    },
+    {
+      code: 'const [color, setFlavor] = useState<string>()',
+      errors: [{
+        message: 'setState variable names are not symmetric, setter should be setColor'
+      }],
+      output: 'const [color, setColor] = useState<string>()',
+      parser: parsers.TYPESCRIPT_ESLINT
+    }
+  ].concat(
+    parsers.TS([
+      {
+        code: 'const [color, setFlavor] = useState<string>()',
+        errors: [{
+          message: 'setState variable names are not symmetric, setter should be setColor'
+        }],
+        output: 'const [color, setColor] = useState<string>()',
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      }
+    ])
+  )
+};
+
+ruleTester.run('hook-set-state-names', rule, tests);

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -39,9 +39,6 @@ const tests = {
       code: 'const [color1, setColor1] = useState()'
     },
     {
-      code: 'const [, setColor] = useState()'
-    },
-    {
       code: 'const [color, setColor] = useState<string>()',
       parser: parsers.TYPESCRIPT_ESLINT
     },
@@ -83,7 +80,43 @@ const tests = {
       code: 'const [, , extra1] = useState()',
       errors: [{
         message: 'setState call is not destructured into value + setter pair'
-      }]
+      }],
+      output: 'const [state, setState] = useState()'
+    },
+    {
+      code: 'const [, setColor] = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }],
+      output: 'const [state, setState] = useState()'
+    },
+    {
+      code: 'const [] = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }],
+      output: 'const [state, setState] = useState()'
+    },
+    {
+      code: 'const [, , , ,] = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }],
+      output: 'const [state, setState] = useState()'
+    },
+    {
+      code: 'const [color] = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }],
+      output: 'const [color, setColor] = useState()'
+    },
+    {
+      code: 'const [color, , extra1] = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }],
+      output: 'const [color, setColor] = useState()'
     },
     {
       code: 'const [color, setColor, extra1, extra2, extra3] = useState()',
@@ -95,20 +128,28 @@ const tests = {
     {
       code: 'const [, makeColor] = useState()',
       errors: [{
-        message: 'setState setter variable name should begin with set'
-      }]
+        message: 'setState call is not destructured into value + setter pair'
+      }],
+      output: 'const [state, setState] = useState()'
+    },
+    {
+      code: 'const [color, setFlavor, extraneous] = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }],
+      output: 'const [color, setColor] = useState()'
     },
     {
       code: 'const [color, setFlavor] = useState()',
       errors: [{
-        message: 'setState variable names are not symmetric, setter should be setColor'
+        message: 'setState call is not destructured into value + setter pair'
       }],
       output: 'const [color, setColor] = useState()'
     },
     {
       code: 'const [color, setFlavor] = useState<string>()',
       errors: [{
-        message: 'setState variable names are not symmetric, setter should be setColor'
+        message: 'setState call is not destructured into value + setter pair'
       }],
       output: 'const [color, setColor] = useState<string>()',
       parser: parsers.TYPESCRIPT_ESLINT
@@ -118,7 +159,7 @@ const tests = {
       {
         code: 'const [color, setFlavor] = useState<string>()',
         errors: [{
-          message: 'setState variable names are not symmetric, setter should be setColor'
+          message: 'setState call is not destructured into value + setter pair'
         }],
         output: 'const [color, setColor] = useState<string>()',
         parser: parsers['@TYPESCRIPT_ESLINT']

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -80,6 +80,12 @@ const tests = {
       }]
     },
     {
+      code: 'const [, , extra1] = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }]
+    },
+    {
       code: 'const [color, setColor, extra1, extra2, extra3] = useState()',
       errors: [{
         message: 'setState call is not destructured into value + setter pair'

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -80,29 +80,25 @@ const tests = {
       code: 'const [, , extra1] = useState()',
       errors: [{
         message: 'setState call is not destructured into value + setter pair'
-      }],
-      output: 'const [state, setState] = useState()'
+      }]
     },
     {
       code: 'const [, setColor] = useState()',
       errors: [{
         message: 'setState call is not destructured into value + setter pair'
-      }],
-      output: 'const [state, setState] = useState()'
+      }]
     },
     {
       code: 'const [] = useState()',
       errors: [{
         message: 'setState call is not destructured into value + setter pair'
-      }],
-      output: 'const [state, setState] = useState()'
+      }]
     },
     {
       code: 'const [, , , ,] = useState()',
       errors: [{
         message: 'setState call is not destructured into value + setter pair'
-      }],
-      output: 'const [state, setState] = useState()'
+      }]
     },
     {
       code: 'const [color] = useState()',
@@ -129,8 +125,7 @@ const tests = {
       code: 'const [, makeColor] = useState()',
       errors: [{
         message: 'setState call is not destructured into value + setter pair'
-      }],
-      output: 'const [state, setState] = useState()'
+      }]
     },
     {
       code: 'const [color, setFlavor, extraneous] = useState()',

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -89,6 +89,12 @@ const tests = {
       }]
     },
     {
+      code: 'const { color } = useState()',
+      errors: [{
+        message: 'setState call is not destructured into value + setter pair'
+      }]
+    },
+    {
       code: 'const [] = useState()',
       errors: [{
         message: 'setState call is not destructured into value + setter pair'


### PR DESCRIPTION
Ensure symmetric value and setter variable names are destructured from React.setState hook calls

Towards #2417

@karlhorky feel free to riff on this, or let me know how this compares to your own proof-of-concept.

* Supports both `useState` and `React.useState`
* Tested with TypeScript parser and `useState<>` type annotation
* Robust against weird `useState` uses like destructuring too many items, or not destructuring at all
* Fixable when 2nd destructured arg does not matching `set<X>` naming convention

@ljharb I included this in the `Best Practices` category, though perhaps a different categorization would be more appropriate.

Let me know if the documentation needs anything else, like more examples, or whether the laissez-faire approach to weird assignment is too forgiving.