### PR TITLE
[Docs] `prop-types`: fix example

### DIFF
--- a/docs/rules/prop-types.md
+++ b/docs/rules/prop-types.md
@@ -42,7 +42,7 @@ Hello.propTypes = {
 In TypeScript:
 
 ```tsx
-interface Props = {
+interface Props {
   age: number
 }
 function Hello({ name }: Props) {


### PR DESCRIPTION
Fixed typo to make the interface usage correct.
