### PR TITLE
[Fix] `no-unused-prop-types`: apply `skipShapeProps` to exact types

### DIFF
--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -70,6 +70,7 @@ module.exports = {
         const usedProp = usedPropTypes[i];
         if (
           prop.type === 'shape'
+          || prop.type === 'exact'
           || prop.name === '__ANY_KEY__'
           || usedProp.name === prop.name
         ) {
@@ -98,7 +99,7 @@ module.exports = {
           return;
         }
 
-        if (prop.type === 'shape' && configuration.skipShapeProps) {
+        if ((prop.type === 'shape' || prop.type === 'exact') && configuration.skipShapeProps) {
           return;
         }
 

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -3213,6 +3213,25 @@ ruleTester.run('no-unused-prop-types', rule, {
         Foo.defaultProps = Object.assign({});
       `
     },
+    {
+      code: `
+        const Hello = ({a}) => (
+          <div>
+            {a.map(({b}) => (
+              <div>{b}</div>
+            ))}
+          </div>
+        );
+        Hello.propTypes = {
+          a: PropTypes.arrayOf(
+            PropTypes.exact({
+              b: PropTypes.string,
+            })
+          ),
+        };
+      `,
+      parser: parsers.BABEL_ESLINT
+    },
     parsers.TS([
       {
         code: `


### PR DESCRIPTION
Fixes #2850.

The option `skipShapeProps` was only applied to `PropTypes.shape`, this pr make the option apply to `PropTypes.exact` as well.

Props usages like `props.a.map({b} => use(b))` are hard to handle. Currently `PropTypes.shape` has the same bug under the option `skipShapeProps: false`. People do not complain about it because most people use `skipShapeProps: true`.

The bug has two parts:
1. `skipShapeProps` should applies to `PropTypes.exact`.
2. Props usages like `props.a.map({b} => use(b))` should be handled.

This pr only fixes 1.