### PR TITLE
[Fix] `no-danger-with-children`: add category

### DIFF
--- a/lib/rules/no-adjacent-inline-elements.js
+++ b/lib/rules/no-adjacent-inline-elements.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const docsUrl = require('../util/docsUrl');
+
 // ------------------------------------------------------------------------------
 // Helpers
 // ------------------------------------------------------------------------------
@@ -76,7 +78,8 @@ module.exports = {
     docs: {
       description: 'Prevent adjacent inline elements not separated by whitespace.',
       category: 'Best Practices',
-      recommended: false
+      recommended: false,
+      url: docsUrl('no-adjacent-inline-elements')
     },
     schema: []
   },

--- a/lib/rules/no-danger-with-children.js
+++ b/lib/rules/no-danger-with-children.js
@@ -16,7 +16,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'Report when a DOM element is using both children and dangerouslySetInnerHTML',
-      category: '',
+      category: 'Possible Errors',
       recommended: true,
       url: docsUrl('no-danger-with-children')
     },

--- a/lib/rules/style-prop-object.js
+++ b/lib/rules/style-prop-object.js
@@ -16,7 +16,7 @@ module.exports = {
   meta: {
     docs: {
       description: 'Enforce style prop value is an object',
-      category: '',
+      category: 'Possible Errors',
       recommended: false,
       url: docsUrl('style-prop-object')
     },


### PR DESCRIPTION
The category for the `react/no-danger-with-children` rule is missing a category. This adds the category as `'Possible Errors'`.