### PR TITLE
[New] : Enforce no unused React elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Enable the rules that you would like to use.
 * [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md): Detect unescaped HTML entities, which might represent malformed tags
 * [react/no-unknown-property](docs/rules/no-unknown-property.md): Prevent usage of unknown DOM property (fixable)
 * [react/no-unsafe](docs/rules/no-unsafe.md): Prevent usage of unsafe lifecycle methods
+* [react/no-unused-elements](docs/rules/no-unused-elements.md): Disallow unused React elements
 * [react/no-unused-prop-types](docs/rules/no-unused-prop-types.md): Prevent definitions of unused prop types
 * [react/no-unused-state](docs/rules/no-unused-state.md): Prevent definition of unused state fields
 * [react/no-will-update-set-state](docs/rules/no-will-update-set-state.md): Prevent usage of setState in componentWillUpdate

--- a/docs/rules/no-unused-elements.md
+++ b/docs/rules/no-unused-elements.md
@@ -1,0 +1,25 @@
+# Disallow unused React elements  (react/no-unused-elements)
+
+An unused React element indicates a logic error.
+
+## Rule Details
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+<div />;
+```
+
+```js
+React.createElement('div');
+```
+
+Examples of **correct** code for this rule:
+
+```js
+return <div />;
+```
+
+```js
+const partial = <div />;
+```

--- a/index.js
+++ b/index.js
@@ -76,6 +76,7 @@ const allRules = {
   'no-unescaped-entities': require('./lib/rules/no-unescaped-entities'),
   'no-unknown-property': require('./lib/rules/no-unknown-property'),
   'no-unsafe': require('./lib/rules/no-unsafe'),
+  'no-unused-elements': require('./lib/rules/no-unused-elements'),
   'no-unused-prop-types': require('./lib/rules/no-unused-prop-types'),
   'no-unused-state': require('./lib/rules/no-unused-state'),
   'no-will-update-set-state': require('./lib/rules/no-will-update-set-state'),

--- a/lib/rules/no-unused-elements.js
+++ b/lib/rules/no-unused-elements.js
@@ -1,0 +1,53 @@
+/**
+ * @fileoverview Disallow unused React elements
+ * @author Duncan Beevers
+ */
+
+'use strict';
+
+const Components = require('../util/Components');
+const docsUrl = require('../util/docsUrl');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+const NO_UNUSED_ELEMENTS_MESSAGE = 'noUnusedElements';
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Disallow unused React elements',
+      category: 'Best Practices',
+      recommended: false,
+      url: docsUrl('no-unused-elements')
+    },
+    messages: {
+      [NO_UNUSED_ELEMENTS_MESSAGE]: 'Unused React element'
+    },
+    schema: [{
+      type: 'object',
+      additionalProperties: false
+    }]
+  },
+
+  create: Components.detect((context, components, utils) => ({
+    JSXElement(node) {
+      if (node.parent.type === 'ExpressionStatement') {
+        context.report({
+          node,
+          messageId: NO_UNUSED_ELEMENTS_MESSAGE
+        });
+      }
+    },
+    CallExpression(node) {
+      if (utils.isCreateElement(node) && node.parent.type === 'ExpressionStatement') {
+        context.report({
+          node,
+          messageId: NO_UNUSED_ELEMENTS_MESSAGE
+        });
+      }
+    }
+  })
+  )
+};

--- a/lib/rules/no-unused-elements.js
+++ b/lib/rules/no-unused-elements.js
@@ -14,6 +14,28 @@ const docsUrl = require('../util/docsUrl');
 
 const NO_UNUSED_ELEMENTS_MESSAGE = 'noUnusedElements';
 
+function isUnusedElement(node) {
+  const isChildOfExpressionStatement = (
+    node.parent.type === 'ExpressionStatement'
+  );
+
+  if (isChildOfExpressionStatement) {
+    return true;
+  }
+
+  const isChildOfConditionalExpressionStatement = (
+    node.parent.type === 'ConditionalExpression'
+    && node.parent.parent
+    && node.parent.parent.type === 'ExpressionStatement'
+  );
+
+  if (isChildOfConditionalExpressionStatement) {
+    return true;
+  }
+
+  return false;
+}
+
 module.exports = {
   meta: {
     docs: {
@@ -33,7 +55,7 @@ module.exports = {
 
   create: Components.detect((context, components, utils) => ({
     JSXElement(node) {
-      if (node.parent.type === 'ExpressionStatement') {
+      if (isUnusedElement(node)) {
         context.report({
           node,
           messageId: NO_UNUSED_ELEMENTS_MESSAGE
@@ -41,7 +63,7 @@ module.exports = {
       }
     },
     CallExpression(node) {
-      if (utils.isCreateElement(node) && node.parent.type === 'ExpressionStatement') {
+      if (utils.isCreateElement(node) && isUnusedElement(node)) {
         context.report({
           node,
           messageId: NO_UNUSED_ELEMENTS_MESSAGE

--- a/tests/lib/rules/no-unused-elements.js
+++ b/tests/lib/rules/no-unused-elements.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Disallow unused React elements
+ * @author Duncan Beevers
+ */
+
+'use strict';
+
+// ------------------------------------------------------------------------------
+// Requirements
+// ------------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/no-unused-elements');
+
+// ------------------------------------------------------------------------------
+// Tests
+// ------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true
+    }
+  }
+});
+
+const tests = {
+  valid: [
+    {
+      code: 'const partial = <div />'
+    },
+    {
+      code: '() => <div />'
+    },
+    {
+      code: 'const partial = React.createElement(\'div\', {}, \'\')'
+    }
+  ],
+  invalid: [
+    {
+      code: '<div />',
+      errors: [{
+        message: 'Unused React element'
+      }]
+    },
+    {
+      code: 'React.createElement(\'div\', {}, \'\')',
+      errors: [{
+        message: 'Unused React element'
+      }]
+    },
+    {
+      code: 'if (condition) { <div /> }',
+      errors: [{
+        message: 'Unused React element'
+      }]
+    }
+  ]
+};
+
+ruleTester.run('no-unused-elements', rule, tests);

--- a/tests/lib/rules/no-unused-elements.js
+++ b/tests/lib/rules/no-unused-elements.js
@@ -32,10 +32,16 @@ const tests = {
       code: 'const partial = <div />'
     },
     {
+      code: 'const partial = React.createElement(\'div\', {}, \'\')'
+    },
+    {
       code: '() => <div />'
     },
     {
-      code: 'const partial = React.createElement(\'div\', {}, \'\')'
+      code: '() => condition ? <div /> : <span />'
+    },
+    {
+      code: 'function MyComponent() { return condition ? <div /> : <span /> }'
     }
   ],
   invalid: [
@@ -49,6 +55,32 @@ const tests = {
       code: 'React.createElement(\'div\', {}, \'\')',
       errors: [{
         message: 'Unused React element'
+      }]
+    },
+    {
+      code: 'condition ? <div /> : <span />',
+      errors: [{
+        message: 'Unused React element',
+        line: 1,
+        column: 13
+      },
+      {
+        message: 'Unused React element',
+        line: 1,
+        column: 23
+      }]
+    },
+    {
+      code: 'condition ? React.createElement(\'div\', {}, \'\') : React.createElement(\'span\', {}, \'\')',
+      errors: [{
+        message: 'Unused React element',
+        line: 1,
+        column: 13
+      },
+      {
+        message: 'Unused React element',
+        line: 1,
+        column: 50
       }]
     },
     {


### PR DESCRIPTION
### 
React elements declared and then not used indicate a logic error.

eslint's built-in rule [no-unused-expressions](https://eslint.org/docs/rules/no-unused-expressions) flags instances of side-effect-free, unused code.

The built-in rule **does not** flag unused `React.createElement` calls / JSX, recognizing them as possibly-side-effecting.

This PR adds a custom rule to flag unused `React.createElement` uses.

Even in a strongly-typed system, I managed to footgun myself with some early return clauses. This pseudo-code demonstrates the issue; The second guard clause does not return.

### Code that would be flagged

```tsx
function MyComponent(): ReactNode {
  const userStatus = useUserStatus();

  if (userStatus === UserStatus.Pending) {
    return <UserPending />;
  }

  if (userStatus === UserStatus.Error) {
    // Oops! I forgot to return
    <UserError />;
  }

  return <UserReady />;
}
```