### PR TITLE
[Fix] `jsx-pascal-case`: support regex ignore option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Added
 * [`jsx-no-target-blank`]: add fixer ([#2862][] @Nokel81)
+* [`jsx-pascal-case`]: support minimatch `ignore` option ([#2906][] @bcherny)
 
 ### Fixed
 * [`jsx-no-constructed-context-values`]: avoid a crash with `as X` TS code ([#2894][] @ljharb)
@@ -16,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`no-typos`]: avoid a crash on bindingless `prop-types` import; add warning ([#2899][] @ljharb)
 * [`jsx-curly-brace-presence`]: ignore containers with comments ([#2900][] @golopot)
 
+[#2906]: https://github.com/yannickcr/eslint-plugin-react/pull/2906
 [#2900]: https://github.com/yannickcr/eslint-plugin-react/pull/2900
 [#2899]: https://github.com/yannickcr/eslint-plugin-react/issues/2899
 [#2897]: https://github.com/yannickcr/eslint-plugin-react/pull/2897

--- a/docs/rules/jsx-pascal-case.md
+++ b/docs/rules/jsx-pascal-case.md
@@ -46,7 +46,7 @@ Examples of **correct** code for this rule:
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
 * `allowAllCaps`: optional boolean set to `true` to allow components name in all caps (default to `false`).
-* `ignore`: optional string-array of component names to ignore during validation.
+* `ignore`: optional string-array of component names to ignore during validation (supports [minimatch](https://github.com/isaacs/minimatch)-style globs).
 
 ### `allowAllCaps`
 

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const elementType = require('jsx-ast-utils/elementType');
+const minimatch = require('minimatch');
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
 
@@ -79,7 +80,14 @@ module.exports = {
           type: 'boolean'
         },
         ignore: {
-          type: 'array'
+          items: [
+            {
+              type: 'string'
+            }
+          ],
+          minItems: 0,
+          type: 'array',
+          uniqueItems: true
         }
       },
       additionalProperties: false
@@ -109,7 +117,9 @@ module.exports = {
 
         const isPascalCase = testPascalCase(name);
         const isAllowedAllCaps = allowAllCaps && testAllCaps(name);
-        const isIgnored = ignore.indexOf(name) !== -1;
+        const isIgnored = ignore.some(
+          (entry) => name === entry || minimatch(name, entry, {noglobstar: true})
+        );
 
         if (!isPascalCase && !isAllowedAllCaps && !isIgnored) {
           let message = `Imported JSX component ${name} must be in PascalCase`;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "doctrine": "^2.1.0",
     "has": "^1.0.3",
     "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+    "minimatch": "^3.0.4",
     "object.entries": "^1.1.2",
     "object.fromentries": "^2.0.2",
     "object.values": "^1.1.1",

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -77,6 +77,12 @@ ruleTester.run('jsx-pascal-case', rule, {
     code: '<IGNORED />',
     options: [{ignore: ['IGNORED']}]
   }, {
+    code: '<Foo_DEPRECATED />',
+    options: [{ignore: ['*_D*D']}]
+  }, {
+    code: '<Foo_DEPRECATED />',
+    options: [{ignore: ['*_+(DEPRECATED|IGNORED)']}]
+  }, {
     code: '<$ />'
   }, {
     code: '<_ />'
@@ -110,5 +116,9 @@ ruleTester.run('jsx-pascal-case', rule, {
   }, {
     code: '<$a />',
     errors: [{message: 'Imported JSX component $a must be in PascalCase'}]
+  }, {
+    code: '<Foo_DEPRECATED />',
+    options: [{ignore: ['*_FOO']}],
+    errors: [{message: 'Imported JSX component Foo_DEPRECATED must be in PascalCase'}]
   }]
 });


### PR DESCRIPTION
Fixes #2905.

Note: This will potentially relax existing `ignore`s:

- **Before**, `ignore`only checked exact matches
- **After**, `ignore` checks partial matches as well

I think this is fine, since it mirrors ESLint's behavior for the `camelcase` rule. If we prefer to be extra careful, I can make this a new option (eg. `ignoreRegex`).