### PR TITLE
[Docs] Improve legibility of lists of available rules in readme

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -50,5 +50,11 @@
           "no-template-curly-in-string": 1,
         },
       },
+      {
+        "files": "markdown.config.js",
+        "rules": {
+          "no-console": 0,
+        },
+      },
     ],
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Changed
 * [Docs] [`jsx-no-constructed-context-values`][]: fix invalid example syntax ([#2910][] @kud)
+* [readme] Replace lists of rules with tables in readme ([#2908][] @motato1)
 
 [#2910]: https://github.com/yannickcr/eslint-plugin-react/pull/2910
+[#2908]: https://github.com/yannickcr/eslint-plugin-react/pull/2908
 [#2906]: https://github.com/yannickcr/eslint-plugin-react/pull/2906
 [#2900]: https://github.com/yannickcr/eslint-plugin-react/pull/2900
 [#2899]: https://github.com/yannickcr/eslint-plugin-react/issues/2899

--- a/README.md
+++ b/README.md
@@ -98,101 +98,108 @@ Enable the rules that you would like to use.
 
 # List of supported rules
 
+✔: Enabled in the [`recommended`](#recommended) configuration.\
+🔧: Fixable with [`eslint --fix`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).
+
 <!-- AUTO-GENERATED-CONTENT:START (BASIC_RULES) -->
-* [react/boolean-prop-naming](docs/rules/boolean-prop-naming.md): Enforces consistent naming for boolean props
-* [react/button-has-type](docs/rules/button-has-type.md): Forbid "button" element without an explicit "type" attribute
-* [react/default-props-match-prop-types](docs/rules/default-props-match-prop-types.md): Enforce all defaultProps are defined and not "required" in propTypes.
-* [react/destructuring-assignment](docs/rules/destructuring-assignment.md): Enforce consistent usage of destructuring assignment of props, state, and context
-* [react/display-name](docs/rules/display-name.md): Prevent missing displayName in a React component definition
-* [react/forbid-component-props](docs/rules/forbid-component-props.md): Forbid certain props on components
-* [react/forbid-dom-props](docs/rules/forbid-dom-props.md): Forbid certain props on DOM Nodes
-* [react/forbid-elements](docs/rules/forbid-elements.md): Forbid certain elements
-* [react/forbid-foreign-prop-types](docs/rules/forbid-foreign-prop-types.md): Forbid using another component's propTypes
-* [react/forbid-prop-types](docs/rules/forbid-prop-types.md): Forbid certain propTypes
-* [react/function-component-definition](docs/rules/function-component-definition.md): Standardize the way function component get defined (fixable)
-* [react/no-access-state-in-setstate](docs/rules/no-access-state-in-setstate.md): Reports when this.state is accessed within setState
-* [react/no-adjacent-inline-elements](docs/rules/no-adjacent-inline-elements.md): Prevent adjacent inline elements not separated by whitespace.
-* [react/no-array-index-key](docs/rules/no-array-index-key.md): Prevent usage of Array index in keys
-* [react/no-children-prop](docs/rules/no-children-prop.md): Prevent passing of children as props.
-* [react/no-danger](docs/rules/no-danger.md): Prevent usage of dangerous JSX props
-* [react/no-danger-with-children](docs/rules/no-danger-with-children.md): Report when a DOM element is using both children and dangerouslySetInnerHTML
-* [react/no-deprecated](docs/rules/no-deprecated.md): Prevent usage of deprecated methods
-* [react/no-did-mount-set-state](docs/rules/no-did-mount-set-state.md): Prevent usage of setState in componentDidMount
-* [react/no-did-update-set-state](docs/rules/no-did-update-set-state.md): Prevent usage of setState in componentDidUpdate
-* [react/no-direct-mutation-state](docs/rules/no-direct-mutation-state.md): Prevent direct mutation of this.state
-* [react/no-find-dom-node](docs/rules/no-find-dom-node.md): Prevent usage of findDOMNode
-* [react/no-is-mounted](docs/rules/no-is-mounted.md): Prevent usage of isMounted
-* [react/no-multi-comp](docs/rules/no-multi-comp.md): Prevent multiple component definition per file
-* [react/no-redundant-should-component-update](docs/rules/no-redundant-should-component-update.md): Flag shouldComponentUpdate when extending PureComponent
-* [react/no-render-return-value](docs/rules/no-render-return-value.md): Prevent usage of the return value of React.render
-* [react/no-set-state](docs/rules/no-set-state.md): Prevent usage of setState
-* [react/no-string-refs](docs/rules/no-string-refs.md): Prevent string definitions for references and prevent referencing this.refs
-* [react/no-this-in-sfc](docs/rules/no-this-in-sfc.md): Report "this" being used in stateless components
-* [react/no-typos](docs/rules/no-typos.md): Prevent common typos
-* [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md): Detect unescaped HTML entities, which might represent malformed tags
-* [react/no-unknown-property](docs/rules/no-unknown-property.md): Prevent usage of unknown DOM property (fixable)
-* [react/no-unsafe](docs/rules/no-unsafe.md): Prevent usage of unsafe lifecycle methods
-* [react/no-unused-prop-types](docs/rules/no-unused-prop-types.md): Prevent definitions of unused prop types
-* [react/no-unused-state](docs/rules/no-unused-state.md): Prevent definition of unused state fields
-* [react/no-will-update-set-state](docs/rules/no-will-update-set-state.md): Prevent usage of setState in componentWillUpdate
-* [react/prefer-es6-class](docs/rules/prefer-es6-class.md): Enforce ES5 or ES6 class for React Components
-* [react/prefer-read-only-props](docs/rules/prefer-read-only-props.md): Require read-only props. (fixable)
-* [react/prefer-stateless-function](docs/rules/prefer-stateless-function.md): Enforce stateless components to be written as a pure function
-* [react/prop-types](docs/rules/prop-types.md): Prevent missing props validation in a React component definition
-* [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md): Prevent missing React when using JSX
-* [react/require-default-props](docs/rules/require-default-props.md): Enforce a defaultProps definition for every prop that is not a required prop.
-* [react/require-optimization](docs/rules/require-optimization.md): Enforce React components to have a shouldComponentUpdate method
-* [react/require-render-return](docs/rules/require-render-return.md): Enforce ES5 or ES6 class for returning value in render function
-* [react/self-closing-comp](docs/rules/self-closing-comp.md): Prevent extra closing tags for components without children (fixable)
-* [react/sort-comp](docs/rules/sort-comp.md): Enforce component methods order
-* [react/sort-prop-types](docs/rules/sort-prop-types.md): Enforce propTypes declarations alphabetical sorting
-* [react/state-in-constructor](docs/rules/state-in-constructor.md): State initialization in an ES6 class component should be in a constructor
-* [react/static-property-placement](docs/rules/static-property-placement.md): Defines where React component static properties should be positioned.
-* [react/style-prop-object](docs/rules/style-prop-object.md): Enforce style prop value is an object
-* [react/void-dom-elements-no-children](docs/rules/void-dom-elements-no-children.md): Prevent passing of children to void DOM elements (e.g. `<br />`).
+| ✔ | 🔧 | Rule | Description |
+| :---: | :---: | :--- | :--- |
+|  |  | [react/boolean-prop-naming](docs/rules/boolean-prop-naming.md) | Enforces consistent naming for boolean props |
+|  |  | [react/button-has-type](docs/rules/button-has-type.md) | Forbid "button" element without an explicit "type" attribute |
+|  |  | [react/default-props-match-prop-types](docs/rules/default-props-match-prop-types.md) | Enforce all defaultProps are defined and not "required" in propTypes. |
+|  |  | [react/destructuring-assignment](docs/rules/destructuring-assignment.md) | Enforce consistent usage of destructuring assignment of props, state, and context |
+| ✔ |  | [react/display-name](docs/rules/display-name.md) | Prevent missing displayName in a React component definition |
+|  |  | [react/forbid-component-props](docs/rules/forbid-component-props.md) | Forbid certain props on components |
+|  |  | [react/forbid-dom-props](docs/rules/forbid-dom-props.md) | Forbid certain props on DOM Nodes |
+|  |  | [react/forbid-elements](docs/rules/forbid-elements.md) | Forbid certain elements |
+|  |  | [react/forbid-foreign-prop-types](docs/rules/forbid-foreign-prop-types.md) | Forbid using another component's propTypes |
+|  |  | [react/forbid-prop-types](docs/rules/forbid-prop-types.md) | Forbid certain propTypes |
+|  | 🔧 | [react/function-component-definition](docs/rules/function-component-definition.md) | Standardize the way function component get defined |
+|  |  | [react/no-access-state-in-setstate](docs/rules/no-access-state-in-setstate.md) | Reports when this.state is accessed within setState |
+|  |  | [react/no-adjacent-inline-elements](docs/rules/no-adjacent-inline-elements.md) | Prevent adjacent inline elements not separated by whitespace. |
+|  |  | [react/no-array-index-key](docs/rules/no-array-index-key.md) | Prevent usage of Array index in keys |
+| ✔ |  | [react/no-children-prop](docs/rules/no-children-prop.md) | Prevent passing of children as props. |
+|  |  | [react/no-danger](docs/rules/no-danger.md) | Prevent usage of dangerous JSX props |
+| ✔ |  | [react/no-danger-with-children](docs/rules/no-danger-with-children.md) | Report when a DOM element is using both children and dangerouslySetInnerHTML |
+| ✔ |  | [react/no-deprecated](docs/rules/no-deprecated.md) | Prevent usage of deprecated methods |
+|  |  | [react/no-did-mount-set-state](docs/rules/no-did-mount-set-state.md) | Prevent usage of setState in componentDidMount |
+|  |  | [react/no-did-update-set-state](docs/rules/no-did-update-set-state.md) | Prevent usage of setState in componentDidUpdate |
+| ✔ |  | [react/no-direct-mutation-state](docs/rules/no-direct-mutation-state.md) | Prevent direct mutation of this.state |
+| ✔ |  | [react/no-find-dom-node](docs/rules/no-find-dom-node.md) | Prevent usage of findDOMNode |
+| ✔ |  | [react/no-is-mounted](docs/rules/no-is-mounted.md) | Prevent usage of isMounted |
+|  |  | [react/no-multi-comp](docs/rules/no-multi-comp.md) | Prevent multiple component definition per file |
+|  |  | [react/no-redundant-should-component-update](docs/rules/no-redundant-should-component-update.md) | Flag shouldComponentUpdate when extending PureComponent |
+| ✔ |  | [react/no-render-return-value](docs/rules/no-render-return-value.md) | Prevent usage of the return value of React.render |
+|  |  | [react/no-set-state](docs/rules/no-set-state.md) | Prevent usage of setState |
+| ✔ |  | [react/no-string-refs](docs/rules/no-string-refs.md) | Prevent string definitions for references and prevent referencing this.refs |
+|  |  | [react/no-this-in-sfc](docs/rules/no-this-in-sfc.md) | Report "this" being used in stateless components |
+|  |  | [react/no-typos](docs/rules/no-typos.md) | Prevent common typos |
+| ✔ |  | [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md) | Detect unescaped HTML entities, which might represent malformed tags |
+| ✔ | 🔧 | [react/no-unknown-property](docs/rules/no-unknown-property.md) | Prevent usage of unknown DOM property |
+|  |  | [react/no-unsafe](docs/rules/no-unsafe.md) | Prevent usage of unsafe lifecycle methods |
+|  |  | [react/no-unused-prop-types](docs/rules/no-unused-prop-types.md) | Prevent definitions of unused prop types |
+|  |  | [react/no-unused-state](docs/rules/no-unused-state.md) | Prevent definition of unused state fields |
+|  |  | [react/no-will-update-set-state](docs/rules/no-will-update-set-state.md) | Prevent usage of setState in componentWillUpdate |
+|  |  | [react/prefer-es6-class](docs/rules/prefer-es6-class.md) | Enforce ES5 or ES6 class for React Components |
+|  | 🔧 | [react/prefer-read-only-props](docs/rules/prefer-read-only-props.md) | Require read-only props. |
+|  |  | [react/prefer-stateless-function](docs/rules/prefer-stateless-function.md) | Enforce stateless components to be written as a pure function |
+| ✔ |  | [react/prop-types](docs/rules/prop-types.md) | Prevent missing props validation in a React component definition |
+| ✔ |  | [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md) | Prevent missing React when using JSX |
+|  |  | [react/require-default-props](docs/rules/require-default-props.md) | Enforce a defaultProps definition for every prop that is not a required prop. |
+|  |  | [react/require-optimization](docs/rules/require-optimization.md) | Enforce React components to have a shouldComponentUpdate method |
+| ✔ |  | [react/require-render-return](docs/rules/require-render-return.md) | Enforce ES5 or ES6 class for returning value in render function |
+|  | 🔧 | [react/self-closing-comp](docs/rules/self-closing-comp.md) | Prevent extra closing tags for components without children |
+|  |  | [react/sort-comp](docs/rules/sort-comp.md) | Enforce component methods order |
+|  |  | [react/sort-prop-types](docs/rules/sort-prop-types.md) | Enforce propTypes declarations alphabetical sorting |
+|  |  | [react/state-in-constructor](docs/rules/state-in-constructor.md) | State initialization in an ES6 class component should be in a constructor |
+|  |  | [react/static-property-placement](docs/rules/static-property-placement.md) | Defines where React component static properties should be positioned. |
+|  |  | [react/style-prop-object](docs/rules/style-prop-object.md) | Enforce style prop value is an object |
+|  |  | [react/void-dom-elements-no-children](docs/rules/void-dom-elements-no-children.md) | Prevent passing of children to void DOM elements (e.g. `<br />`). |
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## JSX-specific rules
 
 <!-- AUTO-GENERATED-CONTENT:START (JSX_RULES) -->
-* [react/jsx-boolean-value](docs/rules/jsx-boolean-value.md): Enforce boolean attributes notation in JSX (fixable)
-* [react/jsx-child-element-spacing](docs/rules/jsx-child-element-spacing.md): Ensures inline tags are not rendered without spaces between them
-* [react/jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md): Validate closing bracket location in JSX (fixable)
-* [react/jsx-closing-tag-location](docs/rules/jsx-closing-tag-location.md): Validate closing tag location for multiline JSX (fixable)
-* [react/jsx-curly-brace-presence](docs/rules/jsx-curly-brace-presence.md): Disallow unnecessary JSX expressions when literals alone are sufficient or enfore JSX expressions on literals in JSX children or attributes (fixable)
-* [react/jsx-curly-newline](docs/rules/jsx-curly-newline.md): Enforce consistent line breaks inside jsx curly (fixable)
-* [react/jsx-curly-spacing](docs/rules/jsx-curly-spacing.md): Enforce or disallow spaces inside of curly braces in JSX attributes (fixable)
-* [react/jsx-equals-spacing](docs/rules/jsx-equals-spacing.md): Disallow or enforce spaces around equal signs in JSX attributes (fixable)
-* [react/jsx-filename-extension](docs/rules/jsx-filename-extension.md): Restrict file extensions that may contain JSX
-* [react/jsx-first-prop-new-line](docs/rules/jsx-first-prop-new-line.md): Ensure proper position of the first property in JSX (fixable)
-* [react/jsx-fragments](docs/rules/jsx-fragments.md): Enforce shorthand or standard form for React fragments (fixable)
-* [react/jsx-handler-names](docs/rules/jsx-handler-names.md): Enforce event handler naming conventions in JSX
-* [react/jsx-indent](docs/rules/jsx-indent.md): Validate JSX indentation (fixable)
-* [react/jsx-indent-props](docs/rules/jsx-indent-props.md): Validate props indentation in JSX (fixable)
-* [react/jsx-key](docs/rules/jsx-key.md): Report missing `key` props in iterators/collection literals
-* [react/jsx-max-depth](docs/rules/jsx-max-depth.md): Validate JSX maximum depth
-* [react/jsx-max-props-per-line](docs/rules/jsx-max-props-per-line.md): Limit maximum of props on a single line in JSX (fixable)
-* [react/jsx-newline](docs/rules/jsx-newline.md): Enforce a new line after jsx elements and expressions (fixable)
-* [react/jsx-no-bind](docs/rules/jsx-no-bind.md): Prevents usage of Function.prototype.bind and arrow functions in React component props
-* [react/jsx-no-comment-textnodes](docs/rules/jsx-no-comment-textnodes.md): Comments inside children section of tag should be placed inside braces
-* [react/jsx-no-constructed-context-values](docs/rules/jsx-no-constructed-context-values.md): Prevents JSX context provider values from taking values that will cause needless rerenders.
-* [react/jsx-no-duplicate-props](docs/rules/jsx-no-duplicate-props.md): Enforce no duplicate props
-* [react/jsx-no-literals](docs/rules/jsx-no-literals.md): Prevent using string literals in React component definition
-* [react/jsx-no-script-url](docs/rules/jsx-no-script-url.md): Forbid `javascript:` URLs
-* [react/jsx-no-target-blank](docs/rules/jsx-no-target-blank.md): Forbid `target="_blank"` attribute without `rel="noreferrer"`
-* [react/jsx-no-undef](docs/rules/jsx-no-undef.md): Disallow undeclared variables in JSX
-* [react/jsx-no-useless-fragment](docs/rules/jsx-no-useless-fragment.md): Disallow unnecessary fragments (fixable)
-* [react/jsx-one-expression-per-line](docs/rules/jsx-one-expression-per-line.md): Limit to one expression per line in JSX (fixable)
-* [react/jsx-pascal-case](docs/rules/jsx-pascal-case.md): Enforce PascalCase for user-defined JSX components
-* [react/jsx-props-no-multi-spaces](docs/rules/jsx-props-no-multi-spaces.md): Disallow multiple spaces between inline JSX props (fixable)
-* [react/jsx-props-no-spreading](docs/rules/jsx-props-no-spreading.md): Prevent JSX prop spreading
-* [react/jsx-sort-default-props](docs/rules/jsx-sort-default-props.md): Enforce default props alphabetical sorting
-* [react/jsx-sort-props](docs/rules/jsx-sort-props.md): Enforce props alphabetical sorting (fixable)
-* [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md): Validate spacing before closing bracket in JSX (fixable)
-* [react/jsx-tag-spacing](docs/rules/jsx-tag-spacing.md): Validate whitespace in and around the JSX opening and closing brackets (fixable)
-* [react/jsx-uses-react](docs/rules/jsx-uses-react.md): Prevent React to be marked as unused
-* [react/jsx-uses-vars](docs/rules/jsx-uses-vars.md): Prevent variables used in JSX to be marked as unused
-* [react/jsx-wrap-multilines](docs/rules/jsx-wrap-multilines.md): Prevent missing parentheses around multilines JSX (fixable)
+| ✔ | 🔧 | Rule | Description |
+| :---: | :---: | :--- | :--- |
+|  | 🔧 | [react/jsx-boolean-value](docs/rules/jsx-boolean-value.md) | Enforce boolean attributes notation in JSX |
+|  |  | [react/jsx-child-element-spacing](docs/rules/jsx-child-element-spacing.md) | Ensures inline tags are not rendered without spaces between them |
+|  | 🔧 | [react/jsx-closing-bracket-location](docs/rules/jsx-closing-bracket-location.md) | Validate closing bracket location in JSX |
+|  | 🔧 | [react/jsx-closing-tag-location](docs/rules/jsx-closing-tag-location.md) | Validate closing tag location for multiline JSX |
+|  | 🔧 | [react/jsx-curly-brace-presence](docs/rules/jsx-curly-brace-presence.md) | Disallow unnecessary JSX expressions when literals alone are sufficient or enfore JSX expressions on literals in JSX children or attributes |
+|  | 🔧 | [react/jsx-curly-newline](docs/rules/jsx-curly-newline.md) | Enforce consistent line breaks inside jsx curly |
+|  | 🔧 | [react/jsx-curly-spacing](docs/rules/jsx-curly-spacing.md) | Enforce or disallow spaces inside of curly braces in JSX attributes |
+|  | 🔧 | [react/jsx-equals-spacing](docs/rules/jsx-equals-spacing.md) | Disallow or enforce spaces around equal signs in JSX attributes |
+|  |  | [react/jsx-filename-extension](docs/rules/jsx-filename-extension.md) | Restrict file extensions that may contain JSX |
+|  | 🔧 | [react/jsx-first-prop-new-line](docs/rules/jsx-first-prop-new-line.md) | Ensure proper position of the first property in JSX |
+|  | 🔧 | [react/jsx-fragments](docs/rules/jsx-fragments.md) | Enforce shorthand or standard form for React fragments |
+|  |  | [react/jsx-handler-names](docs/rules/jsx-handler-names.md) | Enforce event handler naming conventions in JSX |
+|  | 🔧 | [react/jsx-indent](docs/rules/jsx-indent.md) | Validate JSX indentation |
+|  | 🔧 | [react/jsx-indent-props](docs/rules/jsx-indent-props.md) | Validate props indentation in JSX |
+| ✔ |  | [react/jsx-key](docs/rules/jsx-key.md) | Report missing `key` props in iterators/collection literals |
+|  |  | [react/jsx-max-depth](docs/rules/jsx-max-depth.md) | Validate JSX maximum depth |
+|  | 🔧 | [react/jsx-max-props-per-line](docs/rules/jsx-max-props-per-line.md) | Limit maximum of props on a single line in JSX |
+|  | 🔧 | [react/jsx-newline](docs/rules/jsx-newline.md) | Enforce a new line after jsx elements and expressions |
+|  |  | [react/jsx-no-bind](docs/rules/jsx-no-bind.md) | Prevents usage of Function.prototype.bind and arrow functions in React component props |
+| ✔ |  | [react/jsx-no-comment-textnodes](docs/rules/jsx-no-comment-textnodes.md) | Comments inside children section of tag should be placed inside braces |
+|  |  | [react/jsx-no-constructed-context-values](docs/rules/jsx-no-constructed-context-values.md) | Prevents JSX context provider values from taking values that will cause needless rerenders. |
+| ✔ |  | [react/jsx-no-duplicate-props](docs/rules/jsx-no-duplicate-props.md) | Enforce no duplicate props |
+|  |  | [react/jsx-no-literals](docs/rules/jsx-no-literals.md) | Prevent using string literals in React component definition |
+|  |  | [react/jsx-no-script-url](docs/rules/jsx-no-script-url.md) | Forbid `javascript:` URLs |
+| ✔ | 🔧 | [react/jsx-no-target-blank](docs/rules/jsx-no-target-blank.md) | Forbid `target="_blank"` attribute without `rel="noreferrer"` |
+| ✔ |  | [react/jsx-no-undef](docs/rules/jsx-no-undef.md) | Disallow undeclared variables in JSX |
+|  | 🔧 | [react/jsx-no-useless-fragment](docs/rules/jsx-no-useless-fragment.md) | Disallow unnecessary fragments |
+|  | 🔧 | [react/jsx-one-expression-per-line](docs/rules/jsx-one-expression-per-line.md) | Limit to one expression per line in JSX |
+|  |  | [react/jsx-pascal-case](docs/rules/jsx-pascal-case.md) | Enforce PascalCase for user-defined JSX components |
+|  | 🔧 | [react/jsx-props-no-multi-spaces](docs/rules/jsx-props-no-multi-spaces.md) | Disallow multiple spaces between inline JSX props |
+|  |  | [react/jsx-props-no-spreading](docs/rules/jsx-props-no-spreading.md) | Prevent JSX prop spreading |
+|  |  | [react/jsx-sort-default-props](docs/rules/jsx-sort-default-props.md) | Enforce default props alphabetical sorting |
+|  | 🔧 | [react/jsx-sort-props](docs/rules/jsx-sort-props.md) | Enforce props alphabetical sorting |
+|  | 🔧 | [react/jsx-space-before-closing](docs/rules/jsx-space-before-closing.md) | Validate spacing before closing bracket in JSX |
+|  | 🔧 | [react/jsx-tag-spacing](docs/rules/jsx-tag-spacing.md) | Validate whitespace in and around the JSX opening and closing brackets |
+| ✔ |  | [react/jsx-uses-react](docs/rules/jsx-uses-react.md) | Prevent React to be marked as unused |
+| ✔ |  | [react/jsx-uses-vars](docs/rules/jsx-uses-vars.md) | Prevent variables used in JSX to be marked as unused |
+|  | 🔧 | [react/jsx-wrap-multilines](docs/rules/jsx-wrap-multilines.md) | Prevent missing parentheses around multilines JSX |
 <!-- AUTO-GENERATED-CONTENT:END -->
 
 ## Other useful plugins
@@ -216,30 +223,6 @@ To enable this configuration use the `extends` property in your `.eslintrc` conf
 ```
 
 See [ESLint documentation](http://eslint.org/docs/user-guide/configuring#extending-configuration-files) for more information about extending configuration files.
-
-The rules enabled in this configuration are:
-
-* [react/display-name](docs/rules/display-name.md)
-* [react/jsx-key](docs/rules/jsx-key.md)
-* [react/jsx-no-comment-textnodes](docs/rules/jsx-no-comment-textnodes.md)
-* [react/jsx-no-duplicate-props](docs/rules/jsx-no-duplicate-props.md)
-* [react/jsx-no-target-blank](docs/rules/jsx-no-target-blank.md)
-* [react/jsx-no-undef](docs/rules/jsx-no-undef.md)
-* [react/jsx-uses-react](docs/rules/jsx-uses-react.md)
-* [react/jsx-uses-vars](docs/rules/jsx-uses-vars.md)
-* [react/no-children-prop](docs/rules/no-children-prop.md)
-* [react/no-danger-with-children](docs/rules/no-danger-with-children.md)
-* [react/no-deprecated](docs/rules/no-deprecated.md)
-* [react/no-direct-mutation-state](docs/rules/no-direct-mutation-state.md)
-* [react/no-find-dom-node](docs/rules/no-find-dom-node.md)
-* [react/no-is-mounted](docs/rules/no-is-mounted.md)
-* [react/no-render-return-value](docs/rules/no-render-return-value.md)
-* [react/no-string-refs](docs/rules/no-string-refs.md)
-* [react/no-unescaped-entities](docs/rules/no-unescaped-entities.md)
-* [react/no-unknown-property](docs/rules/no-unknown-property.md)
-* [react/prop-types](docs/rules/prop-types.md)
-* [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md)
-* [react/require-render-return](docs/rules/require-render-return.md)
 
 ## All
 

--- a/markdown.config.js
+++ b/markdown.config.js
@@ -4,16 +4,30 @@
 
 const {rules} = require('./index');
 
-const ruleListItems = Object.keys(rules)
+const ruleTableRows = Object.keys(rules)
   .sort()
   .map((id) => {
     const {meta} = rules[id];
     const {fixable, docs} = meta;
-    return `* [react/${id}](docs/rules/${id}.md): ${docs.description}${fixable ? ' (fixable)' : ''}`;
+    return [
+      docs.recommended ? '✔' : '',
+      fixable ? '🔧' : '',
+      `[react/${id}](docs/rules/${id}.md)`,
+      docs.description
+    ].join(' | ');
   });
 
-const BASIC_RULES = () => ruleListItems.filter((rule) => !rule.includes('react/jsx-')).join('\n');
-const JSX_RULES = () => ruleListItems.filter((rule) => rule.includes('react/jsx-')).join('\n');
+const buildRulesTable = (rows) => {
+  const header = '✔ | 🔧 | Rule | Description';
+  const separator = ':---: | :---: | :--- | :---';
+
+  return [header, separator, ...rows]
+    .map((row) => `| ${row} |`)
+    .join('\n');
+};
+
+const BASIC_RULES = () => buildRulesTable(ruleTableRows.filter((rule) => !rule.includes('react/jsx-')));
+const JSX_RULES = () => buildRulesTable(ruleTableRows.filter((rule) => rule.includes('react/jsx-')));
 
 module.exports = {
   transforms: {
@@ -21,7 +35,6 @@ module.exports = {
     JSX_RULES
   },
   callback: () => {
-    // eslint-disable-next-line no-console
     console.log('The auto-generating of rules finished!');
   }
 };


### PR DESCRIPTION
The README contains three different lists of rules (basic rules, JSX-specific ones, recommended ones). I've found that looking through those lists to find out what rule is part of the recommended ruleset is not as simple as it could be.

This PR replaces the lists of available rules with tables containing indicators for whether a rule is enabled in the recommended ruleset and if it is fixable (just like the official [ESLint page](https://eslint.org/docs/rules/) does).

I have removed the list of the recommended rules entirely as the information can now be found in the tables mentioned above, but I can undo that change if you prefer to keep that list in (or transform it into a table as well).

The result looks like this:

✔: Enabled in the [`recommended`](#recommended) configuration.\
🔧: Fixable with [`eslint --fix`](https://eslint.org/docs/user-guide/command-line-interface#fixing-problems).

| ✔ | 🔧 | Rule | Description |
| :---: | :---: | :--- | :--- |
| ✔ |  | [react/display-name](docs/rules/display-name.md) | Prevent missing displayName in a React component definition |
|  | 🔧 | [react/function-component-definition](docs/rules/function-component-definition.md) | Standardize the way function component get defined |
|  |  | [react/forbid-component-props](docs/rules/forbid-component-props.md) | Forbid certain props on components |