### PR TITLE
[react/jsx-uses-vars]: False negative on HTML elements used in JSX

### DIFF
--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -215,6 +215,19 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
         React.render(<lowercase />);
       `,
       errors: [{message: '\'lowercase\' is defined but never used.'}]
+    }, {
+      code: `
+        /* eslint jsx-uses-vars: 1 */
+        function Greetings(div) {
+          return <div />;
+        }
+        Greetings();
+      `,
+      errors: [{
+        message: '\'div\' is defined but never used.',
+        line: 3
+      }],
+      parser: parsers.BABEL_ESLINT
     }
   ]
 });


### PR DESCRIPTION
This PR is to add a failing test for the following situation:

```js
// False Negative:
// The `div` parameter below is not recognized as an unused variable
function App(div) {
  return <div />
}
```

This also happens with other variables (eg. variables declared separately):

```js
const div = 123;

export function App() {
  return <div />;
}
```

Incorrectly reported here: https://github.com/typescript-eslint/typescript-eslint/issues/2985