### PR TITLE
[Fix] move error messages to meta property

### DIFF
--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -14,6 +14,10 @@ const propWrapperUtil = require('../util/propWrapper');
 // Rule Definition
 // ------------------------------------------------------------------------------
 
+// Predefine message for use in context.report conditional.
+// messageId will still be usable in tests.
+const PATTERN_MISMATCH_MSG = 'Prop name ({{propName}}) doesn\'t match rule ({{pattern}})';
+
 module.exports = {
   meta: {
     docs: {
@@ -21,6 +25,10 @@ module.exports = {
       description: 'Enforces consistent naming for boolean props',
       recommended: false,
       url: docsUrl('boolean-prop-naming')
+    },
+
+    messages: {
+      patternMismatch: PATTERN_MISMATCH_MSG
     },
 
     schema: [{
@@ -193,15 +201,14 @@ module.exports = {
     function reportInvalidNaming(component) {
       component.invalidProps.forEach((propNode) => {
         const propName = getPropName(propNode);
-        context.report({
+        context.report(Object.assign({
           node: propNode,
-          message: config.message || 'Prop name ({{ propName }}) doesn\'t match rule ({{ pattern }})',
           data: {
             component: propName,
             propName,
             pattern: config.rule
           }
-        });
+        }, config.message ? {message: config.message} : {messageId: 'patternMismatch'}));
       });
     }
 

--- a/lib/rules/button-has-type.js
+++ b/lib/rules/button-has-type.js
@@ -42,6 +42,14 @@ module.exports = {
       recommended: false,
       url: docsUrl('button-has-type')
     },
+
+    messages: {
+      missingType: 'Missing an explicit type attribute for button',
+      complexType: 'The button type attribute must be specified by a static string or a trivial ternary expression',
+      invalidValue: '"{{value}}" is an invalid value for button type attribute',
+      forbiddenValue: '"{{value}}" is an invalid value for button type attribute'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -68,28 +76,33 @@ module.exports = {
     function reportMissing(node) {
       context.report({
         node,
-        message: 'Missing an explicit type attribute for button'
+        messageId: 'missingType'
       });
     }
 
     function reportComplex(node) {
       context.report({
         node,
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       });
     }
 
     function checkValue(node, value) {
-      const q = (x) => `"${x}"`;
       if (!(value in configuration)) {
         context.report({
           node,
-          message: `${q(value)} is an invalid value for button type attribute`
+          messageId: 'invalidValue',
+          data: {
+            value
+          }
         });
       } else if (!configuration[value]) {
         context.report({
           node,
-          message: `${q(value)} is a forbidden value for button type attribute`
+          messageId: 'forbiddenValue',
+          data: {
+            value
+          }
         });
       }
     }

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -21,6 +21,11 @@ module.exports = {
       url: docsUrl('default-props-match-prop-types')
     },
 
+    messages: {
+      requiredHasDefault: 'defaultProp "{{name}}" defined for isRequired propType.',
+      defaultHasNoType: 'defaultProp "{{name}}" has no corresponding propTypes declaration.'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -62,14 +67,18 @@ module.exports = {
         if (prop) {
           context.report({
             node: defaultProp.node,
-            message: 'defaultProp "{{name}}" defined for isRequired propType.',
-            data: {name: defaultPropName}
+            messageId: 'requiredHasDefault',
+            data: {
+              name: defaultPropName
+            }
           });
         } else {
           context.report({
             node: defaultProp.node,
-            message: 'defaultProp "{{name}}" has no corresponding propTypes declaration.',
-            data: {name: defaultPropName}
+            messageId: 'defaultHasNoType',
+            data: {
+              name: defaultPropName
+            }
           });
         }
       });

--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -18,6 +18,14 @@ module.exports = {
       recommended: false,
       url: docsUrl('destructuring-assignment')
     },
+
+    messages: {
+      noDestructPropsInSFCArg: 'Must never use destructuring props assignment in SFC argument',
+      noDestructContextInSFCArg: 'Must never use destructuring context assignment in SFC argument',
+      noDestructAssignment: 'Must never use destructuring {{type}} assignment',
+      useDestructAssignment: 'Must use destructuring {{type}} assignment'
+    },
+
     schema: [{
       type: 'string',
       enum: [
@@ -50,12 +58,12 @@ module.exports = {
       if (destructuringProps && components.get(node) && configuration === 'never') {
         context.report({
           node,
-          message: 'Must never use destructuring props assignment in SFC argument'
+          messageId: 'noDestructPropsInSFCArg'
         });
       } else if (destructuringContext && components.get(node) && configuration === 'never') {
         context.report({
           node,
-          message: 'Must never use destructuring context assignment in SFC argument'
+          messageId: 'noDestructContextInSFCArg'
         });
       }
     }
@@ -66,7 +74,10 @@ module.exports = {
       if (isPropUsed && configuration === 'always') {
         context.report({
           node,
-          message: `Must use destructuring ${node.object.name} assignment`
+          messageId: 'useDestructAssignment',
+          data: {
+            type: node.object.name
+          }
         });
       }
     }
@@ -96,7 +107,10 @@ module.exports = {
       ) {
         context.report({
           node,
-          message: `Must use destructuring ${node.object.property.name} assignment`
+          messageId: 'useDestructAssignment',
+          data: {
+            type: node.object.property.name
+          }
         });
       }
     }
@@ -135,7 +149,10 @@ module.exports = {
         if (SFCComponent && destructuringSFC && configuration === 'never') {
           context.report({
             node,
-            message: `Must never use destructuring ${node.init.name} assignment`
+            messageId: 'noDestructAssignment',
+            data: {
+              type: node.init.name
+            }
           });
         }
 
@@ -145,7 +162,10 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: `Must never use destructuring ${node.init.property.name} assignment`
+            messageId: 'noDestructAssignment',
+            data: {
+              type: node.init.property.name
+            }
           });
         }
       }

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -23,6 +23,10 @@ module.exports = {
       url: docsUrl('display-name')
     },
 
+    messages: {
+      noDisplayName: 'Component definition is missing display name'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -37,8 +41,6 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     const config = context.options[0] || {};
     const ignoreTranspilerName = config.ignoreTranspilerName || false;
-
-    const MISSING_MESSAGE = 'Component definition is missing display name';
 
     /**
      * Mark a prop type as declared
@@ -57,10 +59,7 @@ module.exports = {
     function reportMissingDisplayName(component) {
       context.report({
         node: component.node,
-        message: MISSING_MESSAGE,
-        data: {
-          component: component.name
-        }
+        messageId: 'noDisplayName'
       });
     }
 

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -26,6 +26,10 @@ module.exports = {
       url: docsUrl('forbid-component-props')
     },
 
+    messages: {
+      propIsForbidden: 'Prop "{{prop}}" is forbidden on Components'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -94,12 +98,13 @@ module.exports = {
         }
 
         const customMessage = forbid.get(prop).message;
-        const errorMessage = customMessage || `Prop \`${prop}\` is forbidden on Components`;
 
-        context.report({
+        context.report(Object.assign({
           node,
-          message: errorMessage
-        });
+          data: {
+            prop
+          }
+        }, customMessage ? {message: customMessage} : {messageId: 'propIsForbidden'}));
       }
     };
   }

--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -26,6 +26,10 @@ module.exports = {
       url: docsUrl('forbid-dom-props')
     },
 
+    messages: {
+      propIsForbidden: 'Prop "{{prop}}" is forbidden on DOM Nodes'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -83,12 +87,13 @@ module.exports = {
         }
 
         const customMessage = forbid.get(prop).message;
-        const errorMessage = customMessage || `Prop \`${prop}\` is forbidden on DOM Nodes`;
 
-        context.report({
+        context.report(Object.assign({
           node,
-          message: errorMessage
-        });
+          data: {
+            prop
+          }
+        }, customMessage ? {message: customMessage} : {messageId: 'propIsForbidden'}));
       }
     };
   }

--- a/lib/rules/forbid-elements.js
+++ b/lib/rules/forbid-elements.js
@@ -21,6 +21,11 @@ module.exports = {
       url: docsUrl('forbid-elements')
     },
 
+    messages: {
+      forbiddenElement: '<{{element}}> is forbidden',
+      forbiddenElement_message: '<{{element}}> is forbidden, {{message}}'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -60,17 +65,6 @@ module.exports = {
       }
     });
 
-    function errorMessageForElement(name) {
-      const message = `<${name}> is forbidden`;
-      const additionalMessage = indexedForbidConfigs[name].message;
-
-      if (additionalMessage) {
-        return `${message}, ${additionalMessage}`;
-      }
-
-      return message;
-    }
-
     function isValidCreateElement(node) {
       return node.callee
         && node.callee.type === 'MemberExpression'
@@ -81,9 +75,15 @@ module.exports = {
 
     function reportIfForbidden(element, node) {
       if (has(indexedForbidConfigs, element)) {
+        const message = indexedForbidConfigs[element].message;
+
         context.report({
           node,
-          message: errorMessageForElement(element)
+          messageId: message ? 'forbiddenElement_message' : 'forbiddenElement',
+          data: {
+            element,
+            message
+          }
         });
       }
     }

--- a/lib/rules/forbid-foreign-prop-types.js
+++ b/lib/rules/forbid-foreign-prop-types.js
@@ -17,6 +17,10 @@ module.exports = {
       url: docsUrl('forbid-foreign-prop-types')
     },
 
+    messages: {
+      forbiddenPropType: 'Using propTypes from another component is not safe because they may be removed in production builds'
+    },
+
     schema: [
       {
         type: 'object',
@@ -109,7 +113,7 @@ module.exports = {
         ) {
           context.report({
             node: node.property,
-            message: 'Using propTypes from another component is not safe because they may be removed in production builds'
+            messageId: 'forbiddenPropType'
           });
         }
       },
@@ -120,7 +124,7 @@ module.exports = {
         if (propTypesNode) {
           context.report({
             node: propTypesNode,
-            message: 'Using propTypes from another component is not safe because they may be removed in production builds'
+            messageId: 'forbiddenPropType'
           });
         }
       }

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -29,6 +29,10 @@ module.exports = {
       url: docsUrl('forbid-prop-types')
     },
 
+    messages: {
+      forbiddenPropType: 'Prop type "{{target}}" is forbidden'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -63,7 +67,10 @@ module.exports = {
       if (isForbidden(type)) {
         context.report({
           node: declaration,
-          message: `Prop type \`${target}\` is forbidden`
+          messageId: 'forbiddenPropType',
+          data: {
+            target
+          }
         });
       }
     }

--- a/lib/rules/function-component-definition.js
+++ b/lib/rules/function-component-definition.js
@@ -28,12 +28,6 @@ const UNNAMED_FUNCTION_TEMPLATES = {
   'arrow-function': '{typeParams}({params}){returnType} => {body}'
 };
 
-const ERROR_MESSAGES = {
-  'function-declaration': 'Function component is not a function declaration',
-  'function-expression': 'Function component is not a function expression',
-  'arrow-function': 'Function component is not an arrow function'
-};
-
 function hasOneUnconstrainedTypeParam(node) {
   if (node.typeParameters) {
     return node.typeParameters.params.length === 1 && !node.typeParameters.params[0].constraint;
@@ -106,6 +100,12 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      'function-declaration': 'Function component is not a function declaration',
+      'function-expression': 'Function component is not a function expression',
+      'arrow-function': 'Function component is not an arrow function'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -149,7 +149,7 @@ module.exports = {
     function report(node, options) {
       context.report({
         node,
-        message: options.message,
+        messageId: options.messageId,
         fix: getFixer(node, options.fixerOptions)
       });
     }
@@ -161,7 +161,7 @@ module.exports = {
 
       if (hasName(node) && namedConfig !== functionType) {
         report(node, {
-          message: ERROR_MESSAGES[namedConfig],
+          messageId: namedConfig,
           fixerOptions: {
             type: namedConfig,
             template: NAMED_FUNCTION_TEMPLATES[namedConfig],
@@ -173,7 +173,7 @@ module.exports = {
       }
       if (!hasName(node) && unnamedConfig !== functionType) {
         report(node, {
-          message: ERROR_MESSAGES[unnamedConfig],
+          messageId: unnamedConfig,
           fixerOptions: {
             type: unnamedConfig,
             template: UNNAMED_FUNCTION_TEMPLATES[unnamedConfig],

--- a/lib/rules/jsx-boolean-value.js
+++ b/lib/rules/jsx-boolean-value.js
@@ -56,6 +56,13 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      omitBoolean: 'Value must be omitted for boolean attributes{{exceptionsMessage}}',
+      omitBoolean_noMessage: 'Value must be omitted for boolean attributes',
+      setBoolean: 'Value must be set for boolean attributes{{exceptionsMessage}}',
+      setBoolean_noMessage: 'Value must be set for boolean attributes'
+    },
+
     schema: {
       anyOf: [{
         type: 'array',
@@ -94,9 +101,6 @@ module.exports = {
     const configObject = context.options[1] || {};
     const exceptions = new Set((configuration === ALWAYS ? configObject[NEVER] : configObject[ALWAYS]) || []);
 
-    const NEVER_MESSAGE = 'Value must be omitted for boolean attributes{{exceptionsMessage}}';
-    const ALWAYS_MESSAGE = 'Value must be set for boolean attributes{{exceptionsMessage}}';
-
     return {
       JSXAttribute(node) {
         const propName = node.name && node.name.name;
@@ -106,7 +110,7 @@ module.exports = {
           const data = getErrorData(exceptions);
           context.report({
             node,
-            message: ALWAYS_MESSAGE,
+            messageId: data.exceptionsMessage ? 'setBoolean' : 'setBoolean_noMessage',
             data,
             fix(fixer) {
               return fixer.insertTextAfter(node, '={true}');
@@ -117,7 +121,7 @@ module.exports = {
           const data = getErrorData(exceptions);
           context.report({
             node,
-            message: NEVER_MESSAGE,
+            messageId: data.exceptionsMessage ? 'omitBoolean' : 'omitBoolean_noMessage',
             data,
             fix(fixer) {
               return fixer.removeRange([node.name.range[1], value.range[1]]);

--- a/lib/rules/jsx-child-element-spacing.js
+++ b/lib/rules/jsx-child-element-spacing.js
@@ -46,6 +46,12 @@ module.exports = {
       url: docsUrl('jsx-child-element-spacing')
     },
     fixable: null,
+
+    messages: {
+      spacingAfterPrev: 'Ambiguous spacing after previous element {{element}}',
+      spacingBeforeNext: 'Ambiguous spacing before next element {{element}}'
+    },
+
     schema: [
       {
         type: 'object',
@@ -86,13 +92,19 @@ module.exports = {
             context.report({
               node: lastChild,
               loc: lastChild.loc.end,
-              message: `Ambiguous spacing after previous element ${elementName(lastChild)}`
+              messageId: 'spacingAfterPrev',
+              data: {
+                element: elementName(lastChild)
+              }
             });
           } else if (nextChild && child.value.match(TEXT_PRECEDING_ELEMENT_PATTERN)) {
             context.report({
               node: nextChild,
               loc: nextChild.loc.start,
-              message: `Ambiguous spacing before next element ${elementName(nextChild)}`
+              messageId: 'spacingBeforeNext',
+              data: {
+                element: elementName(nextChild)
+              }
             });
           }
         }

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -21,6 +21,10 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      bracketLocation: 'The closing bracket must be {{location}}{{details}}'
+    },
+
     schema: [{
       oneOf: [
         {
@@ -51,7 +55,6 @@ module.exports = {
   },
 
   create(context) {
-    const MESSAGE = 'The closing bracket must be {{location}}{{details}}';
     const MESSAGE_LOCATION = {
       'after-props': 'placed after the last prop',
       'after-tag': 'placed after the opening tag',
@@ -259,7 +262,7 @@ module.exports = {
           return;
         }
 
-        const data = {location: MESSAGE_LOCATION[expectedLocation], details: ''};
+        const data = {location: MESSAGE_LOCATION[expectedLocation]};
         const correctColumn = getCorrectColumn(tokens, expectedLocation);
 
         if (correctColumn !== null) {
@@ -271,7 +274,7 @@ module.exports = {
         context.report({
           node,
           loc: tokens.closing,
-          message: MESSAGE,
+          messageId: 'bracketLocation',
           data,
           fix(fixer) {
             const closingTag = tokens.selfClosing ? '/>' : '>';

--- a/lib/rules/jsx-closing-tag-location.js
+++ b/lib/rules/jsx-closing-tag-location.js
@@ -11,6 +11,7 @@ const docsUrl = require('../util/docsUrl');
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
+
 module.exports = {
   meta: {
     docs: {
@@ -19,7 +20,12 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-closing-tag-location')
     },
-    fixable: 'whitespace'
+    fixable: 'whitespace',
+
+    messages: {
+      onOwnLine: 'Closing tag of a multiline JSX expression must be on its own line.',
+      matchIndent: 'Expected closing tag to match indentation of opening.'
+    }
   },
 
   create(context) {
@@ -37,17 +43,12 @@ module.exports = {
         return;
       }
 
-      let message;
-      if (!astUtil.isNodeFirstInLine(context, node)) {
-        message = 'Closing tag of a multiline JSX expression must be on its own line.';
-      } else {
-        message = 'Expected closing tag to match indentation of opening.';
-      }
-
       context.report({
         node,
         loc: node.loc,
-        message,
+        messageId: astUtil.isNodeFirstInLine(context, node)
+          ? 'matchIndent'
+          : 'onOwnLine',
         fix(fixer) {
           const indent = Array(opening.loc.start.column + 1).join(' ');
           if (astUtil.isNodeFirstInLine(context, node)) {

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -42,6 +42,11 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      unnecessaryCurly: 'Curly braces are unnecessary here.',
+      missingCurly: 'Need to wrap this literal in a JSX expression.'
+    },
+
     schema: [
       {
         oneOf: [
@@ -163,7 +168,7 @@ module.exports = {
     function reportUnnecessaryCurly(JSXExpressionNode) {
       context.report({
         node: JSXExpressionNode,
-        message: 'Curly braces are unnecessary here.',
+        messageId: 'unnecessaryCurly',
         fix(fixer) {
           const expression = JSXExpressionNode.expression;
           const expressionType = expression.type;
@@ -192,7 +197,7 @@ module.exports = {
     function reportMissingCurly(literalNode) {
       context.report({
         node: literalNode,
-        message: 'Need to wrap this literal in a JSX expression.',
+        messageId: 'missingCurly',
         fix(fixer) {
           // If a HTML entity name is found, bail out because it can be fixed
           // by either using the real character or the unicode equivalent.

--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -34,6 +34,15 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      noNewlineAfter: 'There should be no newline after \'{{token}}\'',
+      noNewlineBefore: 'There should be no newline before \'{{token}}\'',
+      noSpaceAfter: 'There should be no space after \'{{token}}\'',
+      noSpaceBefore: 'There should be no space before \'{{token}}\'',
+      spaceNeededAfter: 'A space is required after \'{{token}}\'',
+      spaceNeededBefore: 'A space is required before \'{{token}}\''
+    },
+
     schema: {
       definitions: {
         basicConfig: {
@@ -190,7 +199,10 @@ module.exports = {
       context.report({
         node,
         loc: token.loc.start,
-        message: `There should be no newline after '${token.value}'`,
+        messageId: 'noNewlineAfter',
+        data: {
+          token: token.value
+        },
         fix(fixer) {
           const nextToken = context.getSourceCode().getTokenAfter(token);
           return fixByTrimmingWhitespace(fixer, token.range[1], nextToken.range[0], 'start', spacing);
@@ -209,7 +221,10 @@ module.exports = {
       context.report({
         node,
         loc: token.loc.start,
-        message: `There should be no newline before '${token.value}'`,
+        messageId: 'noNewlineBefore',
+        data: {
+          token: token.value
+        },
         fix(fixer) {
           const previousToken = context.getSourceCode().getTokenBefore(token);
           return fixByTrimmingWhitespace(fixer, previousToken.range[1], token.range[0], 'end', spacing);
@@ -227,7 +242,10 @@ module.exports = {
       context.report({
         node,
         loc: token.loc.start,
-        message: `There should be no space after '${token.value}'`,
+        messageId: 'noSpaceAfter',
+        data: {
+          token: token.value
+        },
         fix(fixer) {
           const sourceCode = context.getSourceCode();
           const nextToken = sourceCode.getTokenAfter(token);
@@ -262,7 +280,10 @@ module.exports = {
       context.report({
         node,
         loc: token.loc.start,
-        message: `There should be no space before '${token.value}'`,
+        messageId: 'noSpaceBefore',
+        data: {
+          token: token.value
+        },
         fix(fixer) {
           const sourceCode = context.getSourceCode();
           const previousToken = sourceCode.getTokenBefore(token);
@@ -297,7 +318,10 @@ module.exports = {
       context.report({
         node,
         loc: token.loc.start,
-        message: `A space is required after '${token.value}'`,
+        messageId: 'spaceNeededAfter',
+        data: {
+          token: token.value
+        },
         fix(fixer) {
           return fixer.insertTextAfter(token, ' ');
         }
@@ -314,7 +338,10 @@ module.exports = {
       context.report({
         node,
         loc: token.loc.start,
-        message: `A space is required before '${token.value}'`,
+        messageId: 'spaceNeededBefore',
+        data: {
+          token: token.value
+        },
         fix(fixer) {
           return fixer.insertTextBefore(token, ' ');
         }

--- a/lib/rules/jsx-equals-spacing.js
+++ b/lib/rules/jsx-equals-spacing.js
@@ -21,6 +21,13 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      noSpaceBefore: 'There should be no space before \'=\'',
+      noSpaceAfter: 'There should be no space after \'=\'',
+      needSpaceBefore: 'A space is required before \'=\'',
+      needSpaceAfter: 'A space is required after \'=\''
+    },
+
     schema: [{
       enum: ['always', 'never']
     }]
@@ -61,7 +68,7 @@ module.exports = {
                 context.report({
                   node: attrNode,
                   loc: equalToken.loc.start,
-                  message: 'There should be no space before \'=\'',
+                  messageId: 'noSpaceBefore',
                   fix(fixer) {
                     return fixer.removeRange([attrNode.name.range[1], equalToken.range[0]]);
                   }
@@ -71,7 +78,7 @@ module.exports = {
                 context.report({
                   node: attrNode,
                   loc: equalToken.loc.start,
-                  message: 'There should be no space after \'=\'',
+                  messageId: 'noSpaceAfter',
                   fix(fixer) {
                     return fixer.removeRange([equalToken.range[1], attrNode.value.range[0]]);
                   }
@@ -83,7 +90,7 @@ module.exports = {
                 context.report({
                   node: attrNode,
                   loc: equalToken.loc.start,
-                  message: 'A space is required before \'=\'',
+                  messageId: 'needSpaceBefore',
                   fix(fixer) {
                     return fixer.insertTextBefore(equalToken, ' ');
                   }
@@ -93,7 +100,7 @@ module.exports = {
                 context.report({
                   node: attrNode,
                   loc: equalToken.loc.start,
-                  message: 'A space is required after \'=\'',
+                  messageId: 'needSpaceAfter',
                   fix(fixer) {
                     return fixer.insertTextAfter(equalToken, ' ');
                   }

--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -30,6 +30,11 @@ module.exports = {
       url: docsUrl('jsx-filename-extension')
     },
 
+    messages: {
+      noJSXWithExtension: 'JSX not allowed in files with extension \'{{ext}}\'',
+      extensionOnlyForJSX: 'Only files containing JSX may use the extension \'{{ext}}\''
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -80,7 +85,10 @@ module.exports = {
           if (!isAllowedExtension) {
             context.report({
               node: jsxNode,
-              message: `JSX not allowed in files with extension '${path.extname(filename)}'`
+              messageId: 'noJSXWithExtension',
+              data: {
+                ext: path.extname(filename)
+              }
             });
           }
           return;
@@ -89,7 +97,10 @@ module.exports = {
         if (isAllowedExtension && allow === 'as-needed') {
           context.report({
             node,
-            message: `Only files containing JSX may use the extension '${path.extname(filename)}'`
+            messageId: 'extensionOnlyForJSX',
+            data: {
+              ext: path.extname(filename)
+            }
           });
         }
       }

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -21,6 +21,11 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      propOnNewLine: 'Property should be placed on a new line',
+      propOnSameLine: 'Property should be placed on the same line as the component declaration'
+    },
+
     schema: [{
       enum: ['always', 'never', 'multiline', 'multiline-multiprop']
     }]
@@ -44,7 +49,7 @@ module.exports = {
             if (decl.loc.start.line === node.loc.start.line) {
               context.report({
                 node: decl,
-                message: 'Property should be placed on a new line',
+                messageId: 'propOnNewLine',
                 fix(fixer) {
                   return fixer.replaceTextRange([node.name.range[1], decl.range[0]], '\n');
                 }
@@ -57,7 +62,7 @@ module.exports = {
           if (node.loc.start.line < firstNode.loc.start.line) {
             context.report({
               node: firstNode,
-              message: 'Property should be placed on the same line as the component declaration',
+              messageId: 'propOnSameLine',
               fix(fixer) {
                 return fixer.replaceTextRange([node.name.range[1], firstNode.range[0]], ' ');
               }

--- a/lib/rules/jsx-fragments.js
+++ b/lib/rules/jsx-fragments.js
@@ -29,6 +29,13 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      fragmentsNotSupported: 'Fragments are only supported starting from React v16.2. '
+        + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.',
+      preferPragma: 'Prefer {{react}}.{{fragment}} over fragment shorthand',
+      preferFragment: 'Prefer fragment shorthand over {{react}}.{{fragment}}'
+    },
+
     schema: [{
       enum: ['syntax', 'element']
     }]
@@ -47,8 +54,7 @@ module.exports = {
       if (!versionUtil.testReactVersion(context, '16.2.0')) {
         context.report({
           node,
-          message: 'Fragments are only supported starting from React v16.2. '
-            + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
+          messageId: 'fragmentsNotSupported'
         });
         return true;
       }
@@ -146,7 +152,11 @@ module.exports = {
         if (configuration === 'element') {
           context.report({
             node,
-            message: `Prefer ${reactPragma}.${fragmentPragma} over fragment shorthand`,
+            messageId: 'preferPragma',
+            data: {
+              react: reactPragma,
+              fragment: fragmentPragma
+            },
             fix: getFixerToLong(node)
           });
         }
@@ -178,7 +188,11 @@ module.exports = {
             if (configuration === 'syntax' && !(attrs && attrs.length > 0)) {
               context.report({
                 node,
-                message: `Prefer fragment shorthand over ${reactPragma}.${fragmentPragma}`,
+                messageId: 'preferFragment',
+                data: {
+                  react: reactPragma,
+                  fragment: fragmentPragma
+                },
                 fix: getFixerToShort(node)
               });
             }

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -20,6 +20,11 @@ module.exports = {
       url: docsUrl('jsx-handler-names')
     },
 
+    messages: {
+      badHandlerName: 'Handler function for {{propKey}} prop key must be a camelCase name beginning with \'{{handlerPrefix}}\' only',
+      badPropKey: 'Prop key for {{propValue}} must begin with \'{{handlerPropPrefix}\''
+    },
+
     schema: [{
       anyOf: [
         {
@@ -139,7 +144,11 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: `Handler function for ${propKey} prop key must be a camelCase name beginning with '${eventHandlerPrefix}' only`
+            messageId: 'badHandlerName',
+            data: {
+              propKey,
+              handlerPrefix: eventHandlerPrefix
+            }
           });
         } else if (
           propFnIsNamedCorrectly
@@ -148,7 +157,11 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: `Prop key for ${propValue} must begin with '${eventHandlerPropPrefix}'`
+            messageId: 'badPropKey',
+            data: {
+              propValue,
+              handlerPropPrefix: eventHandlerPropPrefix
+            }
           });
         }
       }

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -46,6 +46,10 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      wrongIndent: 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.'
+    },
+
     schema: [{
       oneOf: [{
         enum: ['tab', 'first']
@@ -70,8 +74,6 @@ module.exports = {
   },
 
   create(context) {
-    const MESSAGE = 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.';
-
     const extraColumnStart = 0;
     let indentType = 'space';
     /** @type {number|'first'} */
@@ -120,7 +122,7 @@ module.exports = {
 
       context.report({
         node,
-        message: MESSAGE,
+        messageId: 'wrongIndent',
         data: msgContext,
         fix(fixer) {
           return fixer.replaceTextRange([node.range[0] - node.loc.start.column, node.range[0]],

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -47,6 +47,11 @@ module.exports = {
       url: docsUrl('jsx-indent')
     },
     fixable: 'whitespace',
+
+    messages: {
+      wrongIndent: 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.'
+    },
+
     schema: [{
       oneOf: [{
         enum: ['tab']
@@ -68,8 +73,6 @@ module.exports = {
   },
 
   create(context) {
-    const MESSAGE = 'Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.';
-
     const extraColumnStart = 0;
     let indentType = 'space';
     let indentSize = 4;
@@ -126,22 +129,12 @@ module.exports = {
         gotten
       };
 
-      if (loc) {
-        context.report({
-          node,
-          loc,
-          message: MESSAGE,
-          data: msgContext,
-          fix: getFixerFunction(node, needed)
-        });
-      } else {
-        context.report({
-          node,
-          message: MESSAGE,
-          data: msgContext,
-          fix: getFixerFunction(node, needed)
-        });
-      }
+      context.report(Object.assign({
+        node,
+        messageId: 'wrongIndent',
+        data: msgContext,
+        fix: getFixerFunction(node, needed)
+      }, loc && {loc}));
     }
 
     /**

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -27,6 +27,15 @@ module.exports = {
       recommended: true,
       url: docsUrl('jsx-key')
     },
+
+    messages: {
+      missingIterKey: 'Missing "key" prop for element in iterator',
+      missingIterKeyUsePrag: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use {{reactPrag}}.{{fragPrag}} instead',
+      missingArrayKey: 'Missing "key" prop for element in array',
+      missingArrayKeyUsePrag: 'Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use {{reactPrag}}.{{fragPrag}} instead',
+      keyBeforeSpread: '`key` prop must be placed before any `{...spread}, to avoid conflicting with React’s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -54,12 +63,16 @@ module.exports = {
       if (node.type === 'JSXElement' && !hasProp(node.openingElement.attributes, 'key')) {
         context.report({
           node,
-          message: 'Missing "key" prop for element in iterator'
+          messageId: 'missingIterKey'
         });
       } else if (checkFragmentShorthand && node.type === 'JSXFragment') {
         context.report({
           node,
-          message: `Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use ${reactPragma}.${fragmentPragma} instead`
+          messageId: 'missingIterKeyUsePrag',
+          data: {
+            reactPrag: reactPragma,
+            fragPrag: fragmentPragma
+          }
         });
       }
     }
@@ -88,7 +101,7 @@ module.exports = {
           if (checkKeyMustBeforeSpread && isKeyAfterSpread(node.openingElement.attributes)) {
             context.report({
               node,
-              message: '`key` prop must before any `{...spread}, to avoid conflicting with React’s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`'
+              messageId: 'keyBeforeSpread'
             });
           }
           return;
@@ -97,7 +110,7 @@ module.exports = {
         if (node.parent.type === 'ArrayExpression') {
           context.report({
             node,
-            message: 'Missing "key" prop for element in array'
+            messageId: 'missingArrayKey'
           });
         }
       },
@@ -110,7 +123,11 @@ module.exports = {
         if (node.parent.type === 'ArrayExpression') {
           context.report({
             node,
-            message: `Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use ${reactPragma}.${fragmentPragma} instead`
+            messageId: 'missingArrayKeyUsePrag',
+            data: {
+              reactPrag: reactPragma,
+              fragPrag: fragmentPragma
+            }
           });
         }
       },

--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -21,6 +21,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-max-depth')
     },
+
+    messages: {
+      wrongDepth: 'Expected the depth of nested jsx elements to be <= {{needed}}, but found {{found}}.'
+    },
+
     schema: [
       {
         type: 'object',
@@ -35,7 +40,6 @@ module.exports = {
     ]
   },
   create(context) {
-    const MESSAGE = 'Expected the depth of nested jsx elements to be <= {{needed}}, but found {{found}}.';
     const DEFAULT_DEPTH = 2;
 
     const option = context.options[0] || {};
@@ -71,7 +75,7 @@ module.exports = {
     function report(node, depth) {
       context.report({
         node,
-        message: MESSAGE,
+        messageId: 'wrongDepth',
         data: {
           found: depth,
           needed: maxDepth

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -20,6 +20,11 @@ module.exports = {
       url: docsUrl('jsx-max-props-per-line')
     },
     fixable: 'code',
+
+    messages: {
+      newLine: 'Prop `{{prop}}` must be placed on a new line'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -94,7 +99,10 @@ module.exports = {
             const name = getPropName(propsInLine[maximum]);
             context.report({
               node: propsInLine[maximum],
-              message: `Prop \`${name}\` must be placed on a new line`,
+              messageId: 'newLine',
+              data: {
+                prop: name
+              },
               fix: generateFixFunction(propsInLine, maximum)
             });
           }

--- a/lib/rules/jsx-newline.js
+++ b/lib/rules/jsx-newline.js
@@ -19,7 +19,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-newline')
     },
-    fixable: 'code'
+    fixable: 'code',
+
+    messages: {
+      newLine: 'JSX element should start in a new line'
+    }
   },
   create(context) {
     const jsxElementParents = new Set();
@@ -40,7 +44,7 @@ module.exports = {
               ) {
                 context.report({
                   node: secondAdjacentSibling,
-                  message: 'JSX element should start in a new line',
+                  messageId: 'newLine',
                   fix(fixer) {
                     return fixer.replaceText(
                       firstAdjacentSibling,

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -16,13 +16,6 @@ const jsxUtil = require('../util/jsx');
 // Rule Definition
 // -----------------------------------------------------------------------------
 
-const violationMessageStore = {
-  bindCall: 'JSX props should not use .bind()',
-  arrowFunc: 'JSX props should not use arrow functions',
-  bindExpression: 'JSX props should not use ::',
-  func: 'JSX props should not use functions'
-};
-
 module.exports = {
   meta: {
     docs: {
@@ -30,6 +23,13 @@ module.exports = {
       category: 'Best Practices',
       recommended: false,
       url: docsUrl('jsx-no-bind')
+    },
+
+    messages: {
+      bindCall: 'JSX props should not use .bind()',
+      arrowFunc: 'JSX props should not use arrow functions',
+      bindExpression: 'JSX props should not use ::',
+      func: 'JSX props should not use functions'
     },
 
     schema: [{
@@ -122,7 +122,10 @@ module.exports = {
 
       return violationTypes.find((type) => {
         if (blockSets[type].has(name)) {
-          context.report({node, message: violationMessageStore[type]});
+          context.report({
+            node,
+            messageId: type
+          });
           return true;
         }
 
@@ -176,7 +179,8 @@ module.exports = {
           findVariableViolation(node, valueNode.name);
         } else if (nodeViolationType) {
           context.report({
-            node, message: violationMessageStore[nodeViolationType]
+            node,
+            messageId: nodeViolationType
           });
         }
       }

--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -23,7 +23,7 @@ function checkText(node, context) {
     ) {
       context.report({
         node,
-        message: 'Comments inside children section of tag should be placed inside braces'
+        messageId: 'putCommentInBraces'
       });
     }
   }
@@ -36,6 +36,10 @@ module.exports = {
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('jsx-no-comment-textnodes')
+    },
+
+    messages: {
+      putCommentInBraces: 'Comments inside children section of tag should be placed inside braces'
     },
 
     schema: [{

--- a/lib/rules/jsx-no-duplicate-props.js
+++ b/lib/rules/jsx-no-duplicate-props.js
@@ -21,6 +21,10 @@ module.exports = {
       url: docsUrl('jsx-no-duplicate-props')
     },
 
+    messages: {
+      noDuplicateProps: 'No duplicate props allowed'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -58,7 +62,7 @@ module.exports = {
           if (has(props, name)) {
             context.report({
               node: decl,
-              message: 'No duplicate props allowed'
+              messageId: 'noDuplicateProps'
             });
           } else {
             props[name] = 1;

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -25,6 +25,13 @@ module.exports = {
       url: docsUrl('jsx-no-literals')
     },
 
+    messages: {
+      invalidPropValue: 'Invalid prop value: "{{text}}"',
+      noStringsInAttributes: 'Strings not allowed in attributes: "{{text}}"',
+      noStringsInJSX: 'Strings not allowed in JSX files: "{{text}}"',
+      literalNotInJSXExpression: 'Missing JSX expression container around literal string: "{{text}}"'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -59,22 +66,25 @@ module.exports = {
     const config = Object.assign({}, defaults, context.options[0] || {});
     config.allowedStrings = new Set(config.allowedStrings.map(trimIfString));
 
-    function defaultMessage() {
+    function defaultMessageId() {
       if (config.noAttributeStrings) {
-        return 'Strings not allowed in attributes';
+        return 'noStringsInAttributes';
       }
       if (config.noStrings) {
-        return 'Strings not allowed in JSX files';
+        return 'noStringsInJSX';
       }
-      return 'Missing JSX expression container around literal string';
+      return 'literalNotInJSXExpression';
     }
 
-    function reportLiteralNode(node, customMessage) {
-      const errorMessage = customMessage || defaultMessage();
+    function reportLiteralNode(node, messageId) {
+      messageId = messageId || defaultMessageId();
 
       context.report({
         node,
-        message: `${errorMessage}: “${context.getSourceCode().getText(node).trim()}”`
+        messageId,
+        data: {
+          text: context.getSourceCode().getText(node).trim()
+        }
       });
     }
 
@@ -149,8 +159,8 @@ module.exports = {
         const isNodeValueString = node && node.value && node.value.type === 'Literal' && typeof node.value.value === 'string' && !config.allowedStrings.has(node.value.value);
 
         if (config.noStrings && !config.ignoreProps && isNodeValueString) {
-          const customMessage = 'Invalid prop value';
-          reportLiteralNode(node, customMessage);
+          const messageId = 'invalidPropValue';
+          reportLiteralNode(node, messageId);
         }
       },
 

--- a/lib/rules/jsx-no-script-url.js
+++ b/lib/rules/jsx-no-script-url.js
@@ -50,6 +50,12 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-no-script-url')
     },
+
+    messages: {
+      noScriptURL: 'A future version of React will block javascript: URLs as a security precaution. '
+        + 'Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.'
+    },
+
     schema: [{
       type: 'array',
       uniqueItems: true,
@@ -81,8 +87,7 @@ module.exports = {
         if (shouldVerifyElement(parent, config) && shouldVerifyProp(node, config) && hasJavaScriptProtocol(node)) {
           context.report({
             node,
-            message: 'A future version of React will block javascript: URLs as a security precaution. '
-              + 'Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.'
+            messageId: 'noScriptURL'
           });
         }
       }

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -100,6 +100,12 @@ module.exports = {
       recommended: true,
       url: docsUrl('jsx-no-target-blank')
     },
+
+    messages: {
+      noTargetBlank: 'Using target="_blank" without rel="noreferrer" '
+        + 'is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -149,8 +155,7 @@ module.exports = {
         if (hasDangerousLink && !hasSecureRel(node, allowReferrer, warnOnSpreadAttributes, spreadAttributeIndex)) {
           context.report({
             node,
-            message: 'Using target="_blank" without rel="noreferrer" '
-              + 'is a security risk: see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener',
+            messageId: 'noTargetBlank',
             fix(fixer) {
               // eslint 5 uses `node.attributes`; eslint 6+ uses `node.parent.attributes`
               const nodeWithAttrs = node.parent.attributes ? node.parent : node;

--- a/lib/rules/jsx-no-undef.js
+++ b/lib/rules/jsx-no-undef.js
@@ -20,6 +20,11 @@ module.exports = {
       recommended: true,
       url: docsUrl('jsx-no-undef')
     },
+
+    messages: {
+      undefined: '\'{{identifier}}\' is not defined.'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -74,7 +79,10 @@ module.exports = {
 
       context.report({
         node,
-        message: `'${node.name}' is not defined.`
+        messageId: 'undefined',
+        data: {
+          identifier: node.name
+        }
       });
     }
 

--- a/lib/rules/jsx-one-expression-per-line.js
+++ b/lib/rules/jsx-one-expression-per-line.js
@@ -25,6 +25,11 @@ module.exports = {
       url: docsUrl('jsx-one-expression-per-line')
     },
     fixable: 'whitespace',
+
+    messages: {
+      moveToNewLine: '`{{descriptor}}` must be placed on a new line'
+    },
+
     schema: [
       {
         type: 'object',
@@ -207,7 +212,10 @@ module.exports = {
 
         context.report({
           node: nodeToReport,
-          message: `\`${descriptor}\` must be placed on a new line`,
+          messageId: 'moveToNewLine',
+          data: {
+            descriptor
+          },
           fix(fixer) {
             return fixer.replaceText(nodeToReport, replaceText);
           }

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -73,6 +73,11 @@ module.exports = {
       url: docsUrl('jsx-pascal-case')
     },
 
+    messages: {
+      usePascalCase: 'Imported JSX component {{name}} must be in PascalCase',
+      usePascalOrSnakeCase: 'Imported JSX component {{name}} must be in PascalCase or SCREAMING_SNAKE_CASE'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -122,13 +127,13 @@ module.exports = {
         );
 
         if (!isPascalCase && !isAllowedAllCaps && !isIgnored) {
-          let message = `Imported JSX component ${name} must be in PascalCase`;
-
-          if (allowAllCaps) {
-            message += ' or SCREAMING_SNAKE_CASE';
-          }
-
-          context.report({node, message});
+          context.report({
+            node,
+            messageId: allowAllCaps ? 'usePascalOrSnakeCase' : 'usePascalCase',
+            data: {
+              name
+            }
+          });
         }
       }
     };

--- a/lib/rules/jsx-props-no-multi-spaces.js
+++ b/lib/rules/jsx-props-no-multi-spaces.js
@@ -20,6 +20,12 @@ module.exports = {
       url: docsUrl('jsx-props-no-multi-spaces')
     },
     fixable: 'code',
+
+    messages: {
+      noLineGap: 'Expected no line gap between “{{prop1}}” and “{{prop2}}”',
+      onlyOneSpace: 'Expected only one space between “{{prop1}}” and “{{prop2}}”'
+    },
+
     schema: []
   },
 
@@ -59,7 +65,11 @@ module.exports = {
       if (hasEmptyLines(prev, node)) {
         context.report({
           node,
-          message: `Expected no line gap between “${getPropName(prev)}” and “${getPropName(node)}”`
+          messageId: 'noLineGap',
+          data: {
+            prop1: getPropName(prev),
+            prop2: getPropName(node)
+          }
         });
       }
 
@@ -72,7 +82,11 @@ module.exports = {
       if (between !== ' ') {
         context.report({
           node,
-          message: `Expected only one space between "${getPropName(prev)}" and "${getPropName(node)}"`,
+          messageId: 'onlyOneSpace',
+          data: {
+            prop1: getPropName(prev),
+            prop2: getPropName(node)
+          },
           fix(fixer) {
             return fixer.replaceTextRange([prev.range[1], node.range[0]], ' ');
           }

--- a/lib/rules/jsx-props-no-spreading.js
+++ b/lib/rules/jsx-props-no-spreading.js
@@ -31,6 +31,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-props-no-spreading')
     },
+
+    messages: {
+      noSpreading: 'Prop spreading is forbidden'
+    },
+
     schema: [{
       allOf: [{
         type: 'object',
@@ -119,7 +124,7 @@ module.exports = {
         }
         context.report({
           node,
-          message: 'Prop spreading is forbidden'
+          messageId: 'noSpreading'
         });
       }
     };

--- a/lib/rules/jsx-sort-default-props.js
+++ b/lib/rules/jsx-sort-default-props.js
@@ -22,8 +22,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-sort-default-props')
     },
-
     // fixable: 'code',
+
+    messages: {
+      propsNotSorted: 'Default prop types declarations should be sorted alphabetically'
+    },
 
     schema: [{
       type: 'object',
@@ -120,7 +123,7 @@ module.exports = {
         if (currentPropName < prevPropName) {
           context.report({
             node: curr,
-            message: 'Default prop types declarations should be sorted alphabetically'
+            messageId: 'propsNotSorted'
             // fix
           });
 

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -185,7 +185,7 @@ function validateReservedFirstConfig(context, reservedFirst) {
         return function report(decl) {
           context.report({
             node: decl,
-            message: 'A customized reserved first list must not be empty'
+            messageId: 'listIsEmpty'
           });
         };
       }
@@ -193,10 +193,9 @@ function validateReservedFirstConfig(context, reservedFirst) {
         return function report(decl) {
           context.report({
             node: decl,
-            message: 'A customized reserved first list must only contain a subset of React reserved props.'
-              + ' Remove: {{ nonReservedWords }}',
+            messageId: 'noUnreservedProps',
             data: {
-              nonReservedWords: nonReservedWords.toString()
+              unreservedWords: nonReservedWords.toString()
             }
           });
         };
@@ -214,6 +213,17 @@ module.exports = {
       url: docsUrl('jsx-sort-props')
     },
     fixable: 'code',
+
+    messages: {
+      noUnreservedProps: 'A customized reserved first list must only contain a subset of React reserved props. Remove: {{unreservedWords}}',
+      listIsEmpty: 'A customized reserved first list must not be empty',
+      listReservedPropsFirst: 'Reserved props must be listed before all other props',
+      listCallbacksLast: 'Callbacks must be listed after all other props',
+      listShorthandFirst: 'Shorthand props must be listed before all other props',
+      listShorthandLast: 'Shorthand props must be listed after all other props',
+      sortPropsByAlpha: 'Props should be sorted alphabetically'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -295,7 +305,7 @@ module.exports = {
             if (!previousIsReserved && currentIsReserved) {
               context.report({
                 node: decl.name,
-                message: 'Reserved props must be listed before all other props',
+                messageId: 'listReservedPropsFirst',
                 fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
@@ -311,7 +321,7 @@ module.exports = {
               // Encountered a non-callback prop after a callback prop
               context.report({
                 node: memo.name,
-                message: 'Callbacks must be listed after all other props',
+                messageId: 'listCallbacksLast',
                 fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
@@ -325,7 +335,7 @@ module.exports = {
             if (!currentValue && previousValue) {
               context.report({
                 node: memo.name,
-                message: 'Shorthand props must be listed before all other props',
+                messageId: 'listShorthandFirst',
                 fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
@@ -339,7 +349,7 @@ module.exports = {
             if (currentValue && !previousValue) {
               context.report({
                 node: memo.name,
-                message: 'Shorthand props must be listed after all other props',
+                messageId: 'listShorthandLast',
                 fix: generateFixerFunction(node, context, reservedList)
               });
               return memo;
@@ -356,7 +366,7 @@ module.exports = {
           ) {
             context.report({
               node: decl.name,
-              message: 'Props should be sorted alphabetically',
+              messageId: 'sortPropsByAlpha',
               fix: generateFixerFunction(node, context, reservedList)
             });
             return memo;

--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -27,6 +27,11 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      noSpaceBeforeClose: 'A space is forbidden before closing bracket',
+      needSpaceBeforeClose: 'A space is required before closing bracket'
+    },
+
     schema: [{
       enum: ['always', 'never']
     }]
@@ -34,9 +39,6 @@ module.exports = {
 
   create(context) {
     const configuration = context.options[0] || 'always';
-
-    const NEVER_MESSAGE = 'A space is forbidden before closing bracket';
-    const ALWAYS_MESSAGE = 'A space is required before closing bracket';
 
     // --------------------------------------------------------------------------
     // Public
@@ -60,7 +62,7 @@ module.exports = {
         if (configuration === 'always' && !sourceCode.isSpaceBetweenTokens(leftToken, closingSlash)) {
           context.report({
             loc: closingSlash.loc.start,
-            message: ALWAYS_MESSAGE,
+            messageId: 'needSpaceBeforeClose',
             fix(fixer) {
               return fixer.insertTextBefore(closingSlash, ' ');
             }
@@ -68,7 +70,7 @@ module.exports = {
         } else if (configuration === 'never' && sourceCode.isSpaceBetweenTokens(leftToken, closingSlash)) {
           context.report({
             loc: closingSlash.loc.start,
-            message: NEVER_MESSAGE,
+            messageId: 'noSpaceBeforeClose',
             fix(fixer) {
               const previousToken = sourceCode.getTokenBefore(closingSlash);
               return fixer.removeRange([previousToken.range[1], closingSlash.range[0]]);

--- a/lib/rules/jsx-tag-spacing.js
+++ b/lib/rules/jsx-tag-spacing.js
@@ -15,11 +15,6 @@ const docsUrl = require('../util/docsUrl');
 function validateClosingSlash(context, node, option) {
   const sourceCode = context.getSourceCode();
 
-  const SELF_CLOSING_NEVER_MESSAGE = 'Whitespace is forbidden between `/` and `>`; write `/>`';
-  const SELF_CLOSING_ALWAYS_MESSAGE = 'Whitespace is required between `/` and `>`; write `/ >`';
-  const NEVER_MESSAGE = 'Whitespace is forbidden between `<` and `/`; write `</`';
-  const ALWAYS_MESSAGE = 'Whitespace is required between `<` and `/`; write `< /`';
-
   let adjacent;
 
   if (node.selfClosing) {
@@ -35,7 +30,7 @@ function validateClosingSlash(context, node, option) {
             start: lastTokens[0].loc.start,
             end: lastTokens[1].loc.end
           },
-          message: SELF_CLOSING_NEVER_MESSAGE,
+          messageId: 'selfCloseSlashNoSpace',
           fix(fixer) {
             return fixer.removeRange([lastTokens[0].range[1], lastTokens[1].range[0]]);
           }
@@ -48,7 +43,7 @@ function validateClosingSlash(context, node, option) {
           start: lastTokens[0].loc.start,
           end: lastTokens[1].loc.end
         },
-        message: SELF_CLOSING_ALWAYS_MESSAGE,
+        messageId: 'selfCloseSlashNeedSpace',
         fix(fixer) {
           return fixer.insertTextBefore(lastTokens[1], ' ');
         }
@@ -67,7 +62,7 @@ function validateClosingSlash(context, node, option) {
             start: firstTokens[0].loc.start,
             end: firstTokens[1].loc.end
           },
-          message: NEVER_MESSAGE,
+          messageId: 'closeSlashNoSpace',
           fix(fixer) {
             return fixer.removeRange([firstTokens[0].range[1], firstTokens[1].range[0]]);
           }
@@ -80,7 +75,7 @@ function validateClosingSlash(context, node, option) {
           start: firstTokens[0].loc.start,
           end: firstTokens[1].loc.end
         },
-        message: ALWAYS_MESSAGE,
+        messageId: 'closeSlashNeedSpace',
         fix(fixer) {
           return fixer.insertTextBefore(firstTokens[1], ' ');
         }
@@ -91,10 +86,6 @@ function validateClosingSlash(context, node, option) {
 
 function validateBeforeSelfClosing(context, node, option) {
   const sourceCode = context.getSourceCode();
-
-  const NEVER_MESSAGE = 'A space is forbidden before closing bracket';
-  const ALWAYS_MESSAGE = 'A space is required before closing bracket';
-
   const leftToken = getTokenBeforeClosingBracket(node);
   const closingSlash = sourceCode.getTokenAfter(leftToken);
 
@@ -106,7 +97,7 @@ function validateBeforeSelfClosing(context, node, option) {
     context.report({
       node,
       loc: closingSlash.loc.start,
-      message: ALWAYS_MESSAGE,
+      messageId: 'beforeSelfCloseNeedSpace',
       fix(fixer) {
         return fixer.insertTextBefore(closingSlash, ' ');
       }
@@ -115,7 +106,7 @@ function validateBeforeSelfClosing(context, node, option) {
     context.report({
       node,
       loc: closingSlash.loc.start,
-      message: NEVER_MESSAGE,
+      messageId: 'beforeSelfCloseNoSpace',
       fix(fixer) {
         const previousToken = sourceCode.getTokenBefore(closingSlash);
         return fixer.removeRange([previousToken.range[1], closingSlash.range[0]]);
@@ -126,10 +117,6 @@ function validateBeforeSelfClosing(context, node, option) {
 
 function validateAfterOpening(context, node, option) {
   const sourceCode = context.getSourceCode();
-
-  const NEVER_MESSAGE = 'A space is forbidden after opening bracket';
-  const ALWAYS_MESSAGE = 'A space is required after opening bracket';
-
   const openingToken = sourceCode.getTokenBefore(node.name);
 
   if (option === 'allow-multiline') {
@@ -148,7 +135,7 @@ function validateAfterOpening(context, node, option) {
           start: openingToken.loc.start,
           end: node.name.loc.start
         },
-        message: NEVER_MESSAGE,
+        messageId: 'afterOpenNoSpace',
         fix(fixer) {
           return fixer.removeRange([openingToken.range[1], node.name.range[0]]);
         }
@@ -161,7 +148,7 @@ function validateAfterOpening(context, node, option) {
         start: openingToken.loc.start,
         end: node.name.loc.start
       },
-      message: ALWAYS_MESSAGE,
+      messageId: 'afterOpenNeedSpace',
       fix(fixer) {
         return fixer.insertTextBefore(node.name, ' ');
       }
@@ -173,10 +160,6 @@ function validateBeforeClosing(context, node, option) {
   // Don't enforce this rule for self closing tags
   if (!node.selfClosing) {
     const sourceCode = context.getSourceCode();
-
-    const NEVER_MESSAGE = 'A space is forbidden before closing bracket';
-    const ALWAYS_MESSAGE = 'Whitespace is required before closing bracket';
-
     const lastTokens = sourceCode.getLastTokens(node, 2);
     const closingToken = lastTokens[1];
     const leftToken = lastTokens[0];
@@ -194,7 +177,7 @@ function validateBeforeClosing(context, node, option) {
           start: leftToken.loc.end,
           end: closingToken.loc.start
         },
-        message: NEVER_MESSAGE,
+        messageId: 'beforeCloseNoSpace',
         fix(fixer) {
           return fixer.removeRange([leftToken.range[1], closingToken.range[0]]);
         }
@@ -206,7 +189,7 @@ function validateBeforeClosing(context, node, option) {
           start: leftToken.loc.end,
           end: closingToken.loc.start
         },
-        message: ALWAYS_MESSAGE,
+        messageId: 'beforeCloseNeedSpace',
         fix(fixer) {
           return fixer.insertTextBefore(closingToken, ' ');
         }
@@ -235,6 +218,20 @@ module.exports = {
       url: docsUrl('jsx-tag-spacing')
     },
     fixable: 'whitespace',
+
+    messages: {
+      selfCloseSlashNoSpace: 'Whitespace is forbidden between `/` and `>`; write `/>`',
+      selfCloseSlashNeedSpace: 'Whitespace is required between `/` and `>`; write `/ >`',
+      closeSlashNoSpace: 'Whitespace is forbidden between `<` and `/`; write `</`',
+      closeSlashNeedSpace: 'Whitespace is required between `<` and `/`; write `< /`',
+      beforeSelfCloseNoSpace: 'A space is forbidden before closing bracket',
+      beforeSelfCloseNeedSpace: 'A space is required before closing bracket',
+      afterOpenNoSpace: 'A space is forbidden after opening bracket',
+      afterOpenNeedSpace: 'A space is required after opening bracket',
+      beforeCloseNoSpace: 'A space is forbidden before closing bracket',
+      beforeCloseNeedSpace: 'Whitespace is required before closing bracket'
+    },
+
     schema: [
       {
         type: 'object',

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -23,9 +23,6 @@ const DEFAULTS = {
   prop: 'ignore'
 };
 
-const MISSING_PARENS = 'Missing parentheses around multilines JSX';
-const PARENS_NEW_LINES = 'Parentheses around JSX should be on separate lines';
-
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -39,6 +36,11 @@ module.exports = {
       url: docsUrl('jsx-wrap-multilines')
     },
     fixable: 'code',
+
+    messages: {
+      missingParens: 'Missing parentheses around multilines JSX',
+      parensOnNewLines: 'Parentheses around JSX should be on separate lines'
+    },
 
     schema: [{
       type: 'object',
@@ -126,10 +128,10 @@ module.exports = {
       return node.loc.start.line !== node.loc.end.line;
     }
 
-    function report(node, message, fix) {
+    function report(node, messageId, fix) {
       context.report({
         node,
-        message,
+        messageId,
         fix
       });
     }
@@ -150,7 +152,7 @@ module.exports = {
       const option = getOption(type);
 
       if ((option === true || option === 'parens') && !isParenthesised(node) && isMultilines(node)) {
-        report(node, MISSING_PARENS, (fixer) => fixer.replaceText(node, `(${sourceCode.getText(node)})`));
+        report(node, 'missingParens', (fixer) => fixer.replaceText(node, `(${sourceCode.getText(node)})`));
       }
 
       if (option === 'parens-new-line' && isMultilines(node)) {
@@ -162,20 +164,20 @@ module.exports = {
             // Strip newline after operator if parens newline is specified
             report(
               node,
-              MISSING_PARENS,
+              'missingParens',
               (fixer) => fixer.replaceTextRange(
                 [tokenBefore.range[0], tokenAfter && (tokenAfter.value === ';' || tokenAfter.value === '}') ? tokenAfter.range[0] : node.range[1]],
                 `${trimTokenBeforeNewline(node, tokenBefore)}(\n${start.column > 0 ? ' '.repeat(start.column) : ''}${sourceCode.getText(node)}\n${start.column > 0 ? ' '.repeat(start.column - 2) : ''})`
               )
             );
           } else {
-            report(node, MISSING_PARENS, (fixer) => fixer.replaceText(node, `(\n${sourceCode.getText(node)}\n)`));
+            report(node, 'missingParens', (fixer) => fixer.replaceText(node, `(\n${sourceCode.getText(node)}\n)`));
           }
         } else {
           const needsOpening = needsOpeningNewLine(node);
           const needsClosing = needsClosingNewLine(node);
           if (needsOpening || needsClosing) {
-            report(node, PARENS_NEW_LINES, (fixer) => {
+            report(node, 'parensOnNewLines', (fixer) => {
               const text = sourceCode.getText(node);
               let fixed = text;
               if (needsOpening) {

--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -19,6 +19,10 @@ module.exports = {
       category: 'Possible Errors',
       recommended: false,
       url: docsUrl('no-access-state-in-setstate')
+    },
+
+    messages: {
+      useCallback: 'Use callback in setState when referencing the previous state.'
     }
   },
 
@@ -82,7 +86,7 @@ module.exports = {
               if (method.methodName === methodName) {
                 context.report({
                   node: method.node,
-                  message: 'Use callback in setState when referencing the previous state.'
+                  messageId: 'useCallback'
                 });
               }
             });
@@ -105,7 +109,7 @@ module.exports = {
             if (isFirstArgumentInSetStateCall(current, node)) {
               context.report({
                 node,
-                message: 'Use callback in setState when referencing the previous state.'
+                messageId: 'useCallback'
               });
               break;
             }
@@ -157,7 +161,7 @@ module.exports = {
                 .forEach((v) => {
                   context.report({
                     node: v.node,
-                    message: 'Use callback in setState when referencing the previous state.'
+                    messageId: 'useCallback'
                   });
                 });
             }

--- a/lib/rules/no-adjacent-inline-elements.js
+++ b/lib/rules/no-adjacent-inline-elements.js
@@ -66,14 +66,11 @@ function isInline(node) {
   return false;
 }
 
-const ERROR = 'Child elements which render as inline HTML elements should be separated by a space or wrapped in block level elements.';
-
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
 module.exports = {
-  ERROR,
   meta: {
     docs: {
       description: 'Prevent adjacent inline elements not separated by whitespace.',
@@ -81,7 +78,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-adjacent-inline-elements')
     },
-    schema: []
+    schema: [],
+
+    messages: {
+      inlineElement: 'Child elements which render as inline HTML elements should be separated by a space or wrapped in block level elements.'
+    }
   },
   create(context) {
     function validate(node, children) {
@@ -95,7 +96,7 @@ module.exports = {
         if (previousIsInline && currentIsInline) {
           context.report({
             node,
-            message: ERROR
+            messageId: 'inlineElement'
           });
           return;
         }

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -23,6 +23,10 @@ module.exports = {
       url: docsUrl('no-array-index-key')
     },
 
+    messages: {
+      noArrayIndex: 'Do not use Array index in keys'
+    },
+
     schema: []
   },
 
@@ -42,7 +46,6 @@ module.exports = {
       reduceRight: 2,
       some: 1
     };
-    const ERROR_MESSAGE = 'Do not use Array index in keys';
 
     function isArrayIndex(node) {
       return node.type === 'Identifier'
@@ -129,7 +132,7 @@ module.exports = {
         // key={bar}
         context.report({
           node,
-          message: ERROR_MESSAGE
+          messageId: 'noArrayIndex'
         });
         return;
       }
@@ -137,7 +140,7 @@ module.exports = {
       if (node.type === 'TemplateLiteral') {
         // key={`foo-${bar}`}
         node.expressions.filter(isArrayIndex).forEach(() => {
-          context.report({node, message: ERROR_MESSAGE});
+          context.report({node, messageId: 'noArrayIndex'});
         });
 
         return;
@@ -148,7 +151,7 @@ module.exports = {
         const identifiers = getIdentifiersFromBinaryExpression(node);
 
         identifiers.filter(isArrayIndex).forEach(() => {
-          context.report({node, message: ERROR_MESSAGE});
+          context.report({node, messageId: 'noArrayIndex'});
         });
       }
     }

--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -37,6 +37,12 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-children-prop')
     },
+
+    messages: {
+      nestChildren: 'Do not pass children as props. Instead, nest children between the opening and closing tags.',
+      passChildrenAsArgs: 'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.'
+    },
+
     schema: []
   },
   create(context) {
@@ -48,7 +54,7 @@ module.exports = {
 
         context.report({
           node,
-          message: 'Do not pass children as props. Instead, nest children between the opening and closing tags.'
+          messageId: 'nestChildren'
         });
       },
       CallExpression(node) {
@@ -62,7 +68,7 @@ module.exports = {
         if (childrenProp) {
           context.report({
             node,
-            message: 'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.'
+            messageId: 'passChildrenAsArgs'
           });
         }
       }

--- a/lib/rules/no-danger-with-children.js
+++ b/lib/rules/no-danger-with-children.js
@@ -20,6 +20,11 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-danger-with-children')
     },
+
+    messages: {
+      dangerWithChildren: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'
+    },
+
     schema: [] // no options
   },
   create(context) {
@@ -104,7 +109,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'
+            messageId: 'dangerWithChildren'
           });
         }
       },
@@ -139,7 +144,7 @@ module.exports = {
           if (dangerously && hasChildren) {
             context.report({
               node,
-              message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'
+              messageId: 'dangerWithChildren'
             });
           }
         }

--- a/lib/rules/no-danger.js
+++ b/lib/rules/no-danger.js
@@ -12,8 +12,6 @@ const jsxUtil = require('../util/jsx');
 // Constants
 // ------------------------------------------------------------------------------
 
-const DANGEROUS_MESSAGE = 'Dangerous property \'{{name}}\' found';
-
 const DANGEROUS_PROPERTY_NAMES = [
   'dangerouslySetInnerHTML'
 ];
@@ -48,6 +46,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-danger')
     },
+
+    messages: {
+      dangerousProp: 'Dangerous property \'{{name}}\' found'
+    },
+
     schema: []
   },
 
@@ -58,7 +61,7 @@ module.exports = {
         if (jsxUtil.isDOMComponent(node.parent) && isDangerous(node.name.name)) {
           context.report({
             node,
-            message: DANGEROUS_MESSAGE,
+            messageId: 'dangerousProp',
             data: {
               name: node.name.name
             }

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -24,8 +24,6 @@ const MODULES = {
   'react-addons-perf': ['ReactPerf', 'Perf']
 };
 
-const DEPRECATED_MESSAGE = '{{oldMethod}} is deprecated since React {{version}}{{newMethod}}{{refs}}';
-
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -38,6 +36,11 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-deprecated')
     },
+
+    messages: {
+      deprecated: '{{oldMethod}} is deprecated since React {{version}}{{newMethod}}{{refs}}'
+    },
+
     schema: []
   },
 
@@ -122,7 +125,7 @@ module.exports = {
       const refs = deprecated[methodName][2];
       context.report({
         node: methodNode || node,
-        message: DEPRECATED_MESSAGE,
+        messageId: 'deprecated',
         data: {
           oldMethod: methodName,
           version,

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -20,6 +20,10 @@ module.exports = {
       category: 'Possible Errors',
       recommended: true,
       url: docsUrl('no-direct-mutation-state')
+    },
+
+    messages: {
+      noDirectMutation: 'Do not mutate state directly. Use setState().'
     }
   },
 
@@ -43,7 +47,7 @@ module.exports = {
         mutation = component.mutations[i];
         context.report({
           node: mutation,
-          message: 'Do not mutate state directly. Use setState().'
+          messageId: 'noDirectMutation'
         });
       }
     }

--- a/lib/rules/no-find-dom-node.js
+++ b/lib/rules/no-find-dom-node.js
@@ -19,6 +19,11 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-find-dom-node')
     },
+
+    messages: {
+      noFindDOMNode: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
+    },
+
     schema: []
   },
 
@@ -40,7 +45,7 @@ module.exports = {
 
         context.report({
           node: callee,
-          message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
+          messageId: 'noFindDOMNode'
         });
       }
     };

--- a/lib/rules/no-is-mounted.js
+++ b/lib/rules/no-is-mounted.js
@@ -19,6 +19,11 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-is-mounted')
     },
+
+    messages: {
+      noIsMounted: 'Do not use isMounted'
+    },
+
     schema: []
   },
 
@@ -42,7 +47,7 @@ module.exports = {
           if (ancestors[i].type === 'Property' || ancestors[i].type === 'MethodDefinition') {
             context.report({
               node: callee,
-              message: 'Do not use isMounted'
+              messageId: 'noIsMounted'
             });
             break;
           }

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -21,6 +21,10 @@ module.exports = {
       url: docsUrl('no-multi-comp')
     },
 
+    messages: {
+      onlyOneComponent: 'Declare only one React component per file'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -36,8 +40,6 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     const configuration = context.options[0] || {};
     const ignoreStateless = configuration.ignoreStateless || false;
-
-    const MULTI_COMP_MESSAGE = 'Declare only one React component per file';
 
     /**
      * Checks if the component is ignored
@@ -69,7 +71,7 @@ module.exports = {
           if (i >= 1) {
             context.report({
               node: list[component].node,
-              message: MULTI_COMP_MESSAGE
+              messageId: 'onlyOneComponent'
             });
           }
         });

--- a/lib/rules/no-redundant-should-component-update.js
+++ b/lib/rules/no-redundant-should-component-update.js
@@ -8,10 +8,6 @@ const Components = require('../util/Components');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
 
-function errorMessage(node) {
-  return `${node} does not need shouldComponentUpdate when extending React.PureComponent.`;
-}
-
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -24,6 +20,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-redundant-should-component-update')
     },
+
+    messages: {
+      noShouldCompUpdate: '{{component}} does not need shouldComponentUpdate when extending React.PureComponent.'
+    },
+
     schema: []
   },
 
@@ -67,7 +68,10 @@ module.exports = {
           const className = getNodeName(node);
           context.report({
             node,
-            message: errorMessage(className)
+            messageId: 'noShouldCompUpdate',
+            data: {
+              component: className
+            }
           });
         }
       }

--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -20,6 +20,11 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-render-return-value')
     },
+
+    messages: {
+      noReturnValue: 'Do not depend on the return value from {{node}}.render'
+    },
+
     schema: []
   },
 
@@ -63,7 +68,10 @@ module.exports = {
         ) {
           context.report({
             node: callee,
-            message: `Do not depend on the return value from ${callee.object.name}.render`
+            messageId: 'noReturnValue',
+            data: {
+              node: callee.object.name
+            }
           });
         }
       }

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -20,6 +20,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-set-state')
     },
+
+    messages: {
+      noSetState: 'Do not use setState'
+    },
+
     schema: []
   },
 
@@ -43,7 +48,7 @@ module.exports = {
         setStateUsage = component.setStateUsages[i];
         context.report({
           node: setStateUsage,
-          message: 'Do not use setState'
+          messageId: 'noSetState'
         });
       }
     }

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -20,6 +20,12 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-string-refs')
     },
+
+    messages: {
+      thisRefsDeprecated: 'Using this.refs is deprecated.',
+      stringInRefDeprecated: 'Using string literals in ref attributes is deprecated.'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -95,7 +101,7 @@ module.exports = {
         if (isRefsUsage(node)) {
           context.report({
             node,
-            message: 'Using this.refs is deprecated.'
+            messageId: 'thisRefsDeprecated'
           });
         }
       },
@@ -106,7 +112,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: 'Using string literals in ref attributes is deprecated.'
+            messageId: 'stringInRefDeprecated'
           });
         }
       }

--- a/lib/rules/no-this-in-sfc.js
+++ b/lib/rules/no-this-in-sfc.js
@@ -8,12 +8,6 @@ const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
 // ------------------------------------------------------------------------------
-// Constants
-// ------------------------------------------------------------------------------
-
-const ERROR_MESSAGE = 'Stateless functional components should not use `this`';
-
-// ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
 
@@ -25,6 +19,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-this-in-sfc')
     },
+
+    messages: {
+      noThisInSFC: 'Stateless functional components should not use `this`'
+    },
+
     schema: []
   },
 
@@ -37,7 +36,7 @@ module.exports = {
         }
         context.report({
           node,
-          message: ERROR_MESSAGE
+          messageId: 'noThisInSFC'
         });
       }
     }

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -39,6 +39,18 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-typos')
     },
+
+    messages: {
+      typoPropTypeChain: 'Typo in prop type chain qualifier: {{name}}',
+      typoPropType: 'Typo in declared prop type: {{name}}',
+      typoStaticClassProp: 'Typo in static class property declaration',
+      typoPropDeclaration: 'Typo in property declaration',
+      typoLifecycleMethod: 'Typo in component lifecycle method declaration: {{actual}} should be {{expected}}',
+      staticLifecycleMethod: 'Lifecycle method should be static: {{method}}',
+      noPropTypesBinding: '`\'prop-types\'` imported without a local `PropTypes` binding.',
+      noReactBinding: '`\'react\'` imported without a local `React` binding.'
+    },
+
     schema: []
   },
 
@@ -50,7 +62,7 @@ module.exports = {
       if (node.name !== 'isRequired') {
         context.report({
           node,
-          message: 'Typo in prop type chain qualifier: {{name}}',
+          messageId: 'typoPropTypeChain',
           data: {name: node.name}
         });
       }
@@ -60,7 +72,7 @@ module.exports = {
       if (node.name && !PROP_TYPES.some((propTypeName) => propTypeName === node.name)) {
         context.report({
           node,
-          message: 'Typo in declared prop type: {{name}}',
+          messageId: 'typoPropType',
           data: {name: node.name}
         });
       }
@@ -134,12 +146,11 @@ module.exports = {
       }
       STATIC_CLASS_PROPERTIES.forEach((CLASS_PROP) => {
         if (propertyName && CLASS_PROP.toLowerCase() === propertyName.toLowerCase() && CLASS_PROP !== propertyName) {
-          const message = isClassProperty
-            ? 'Typo in static class property declaration'
-            : 'Typo in property declaration';
           context.report({
             node: propertyKey,
-            message
+            messageId: isClassProperty
+              ? 'typoStaticClassProp'
+              : 'typoPropDeclaration'
           });
         }
       });
@@ -158,7 +169,10 @@ module.exports = {
         if (!node.static && nodeKeyName.toLowerCase() === method.toLowerCase()) {
           context.report({
             node,
-            message: `Lifecycle method should be static: ${nodeKeyName}`
+            messageId: 'staticLifecycleMethod',
+            data: {
+              method: nodeKeyName
+            }
           });
         }
       });
@@ -167,7 +181,7 @@ module.exports = {
         if (method.toLowerCase() === nodeKeyName.toLowerCase() && method !== nodeKeyName) {
           context.report({
             node,
-            message: 'Typo in component lifecycle method declaration: {{actual}} should be {{expected}}',
+            messageId: 'typoLifecycleMethod',
             data: {actual: nodeKeyName, expected: method}
           });
         }
@@ -182,7 +196,7 @@ module.exports = {
           } else {
             context.report({
               node,
-              message: '`\'prop-types\'` imported without a local `PropTypes` binding.'
+              messageId: 'noPropTypesBinding'
             });
           }
         } else if (node.source && node.source.value === 'react') { // import { PropTypes } from "react"
@@ -191,7 +205,7 @@ module.exports = {
           } else {
             context.report({
               node,
-              message: '`\'react\'` imported without a local `React` binding.'
+              messageId: 'noReactBinding'
             });
           }
           if (node.specifiers.length >= 1) {

--- a/lib/rules/no-unescaped-entities.js
+++ b/lib/rules/no-unescaped-entities.js
@@ -37,6 +37,12 @@ module.exports = {
       recommended: true,
       url: docsUrl('no-unescaped-entities')
     },
+
+    messages: {
+      unescapedEntity: 'HTML entity, `{{entity}}` , must be escaped.',
+      unescapedEntityAlts: '`{{entity}}` can be escaped with {{alts}}.'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -91,16 +97,23 @@ module.exports = {
             if (typeof entities[j] === 'string') {
               if (c === entities[j]) {
                 context.report({
+                  node,
                   loc: {line: i, column: start + index},
-                  message: `HTML entity, \`${entities[j]}\` , must be escaped.`,
-                  node
+                  messageId: 'unescapedEntity',
+                  data: {
+                    entity: entities[j]
+                  }
                 });
               }
             } else if (c === entities[j].char) {
               context.report({
+                node,
                 loc: {line: i, column: start + index},
-                message: `\`${entities[j].char}\` can be escaped with ${entities[j].alternatives.map((alt) => `\`${alt}\``).join(', ')}.`,
-                node
+                messageId: 'unescapedEntityAlts',
+                data: {
+                  entity: entities[j].char,
+                  alts: entities[j].alternatives.map((alt) => `\`${alt}\``).join(', ')
+                }
               });
             }
           }

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -17,9 +17,6 @@ const DEFAULTS = {
   ignore: []
 };
 
-const UNKNOWN_MESSAGE = 'Unknown property \'{{name}}\' found, use \'{{standardName}}\' instead';
-const WRONG_TAG_MESSAGE = 'Invalid property \'{{name}}\' found on tag \'{{tagName}}\', but it is only allowed on: {{allowedTags}}';
-
 const DOM_ATTRIBUTE_NAMES = {
   'accept-charset': 'acceptCharset',
   class: 'className',
@@ -224,6 +221,11 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      invalidPropOnTag: 'Invalid property \'{{name}}\' found on tag \'{{tagName}}\', but it is only allowed on: {{allowedTags}}',
+      unknownProp: 'Unknown property \'{{name}}\' found, use \'{{standardName}}\' instead'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -263,7 +265,7 @@ module.exports = {
         if (tagName && allowedTags && /[^A-Z]/.test(tagName.charAt(0)) && allowedTags.indexOf(tagName) === -1) {
           context.report({
             node,
-            message: WRONG_TAG_MESSAGE,
+            messageId: 'invalidPropOnTag',
             data: {
               name,
               tagName,
@@ -282,7 +284,7 @@ module.exports = {
         }
         context.report({
           node,
-          message: UNKNOWN_MESSAGE,
+          messageId: 'unknownProp',
           data: {
             name,
             standardName

--- a/lib/rules/no-unsafe.js
+++ b/lib/rules/no-unsafe.js
@@ -22,6 +22,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-unsafe')
     },
+
+    messages: {
+      unsafeMethod: '{{method}} is unsafe for use in async rendering. Update the component to use {{newMethod}} instead. {{details}}'
+    },
+
     schema: [
       {
         type: 'object',
@@ -102,7 +107,12 @@ module.exports = {
 
       context.report({
         node,
-        message: `${method} is unsafe for use in async rendering. Update the component to use ${newMethod} instead. ${details}`
+        messageId: 'unsafeMethod',
+        data: {
+          method,
+          newMethod,
+          details
+        }
       });
     }
 

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -24,6 +24,10 @@ module.exports = {
       url: docsUrl('no-unused-prop-types')
     },
 
+    messages: {
+      unusedPropType: '\'{{name}}\' PropType is defined but prop is never used'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -44,7 +48,6 @@ module.exports = {
   create: Components.detect((context, components) => {
     const defaults = {skipShapeProps: true, customValidators: []};
     const configuration = Object.assign({}, defaults, context.options[0] || {});
-    const UNUSED_MESSAGE = '\'{{name}}\' PropType is defined but prop is never used';
 
     /**
      * Checks if the component must be validated
@@ -111,7 +114,7 @@ module.exports = {
         if (prop.node && !isPropUsed(component, prop)) {
           context.report({
             node: prop.node.key || prop.node,
-            message: UNUSED_MESSAGE,
+            messageId: 'unusedPropType',
             data: {
               name: prop.fullName
             }

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -80,6 +80,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('no-unused-state')
     },
+
+    messages: {
+      unusedStateField: 'Unused state field: \'{{name}}\''
+    },
+
     schema: []
   },
 
@@ -213,7 +218,10 @@ module.exports = {
         if (!classInfo.usedStateFields.has(name)) {
           context.report({
             node,
-            message: `Unused state field: '${name}'`
+            messageId: 'unusedStateField',
+            data: {
+              name
+            }
           });
         }
       }

--- a/lib/rules/prefer-es6-class.js
+++ b/lib/rules/prefer-es6-class.js
@@ -21,6 +21,11 @@ module.exports = {
       url: docsUrl('prefer-es6-class')
     },
 
+    messages: {
+      shouldUseES6Class: 'Component should use es6 class instead of createClass',
+      shouldUseCreateClass: 'Component should use createClass instead of es6 class'
+    },
+
     schema: [{
       enum: ['always', 'never']
     }]
@@ -34,7 +39,7 @@ module.exports = {
         if (utils.isES5Component(node) && configuration === 'always') {
           context.report({
             node,
-            message: 'Component should use es6 class instead of createClass'
+            messageId: 'shouldUseES6Class'
           });
         }
       },
@@ -42,7 +47,7 @@ module.exports = {
         if (utils.isES6Component(node) && configuration === 'never') {
           context.report({
             node,
-            message: 'Component should use createClass instead of es6 class'
+            messageId: 'shouldUseCreateClass'
           });
         }
       }

--- a/lib/rules/prefer-read-only-props.js
+++ b/lib/rules/prefer-read-only-props.js
@@ -29,6 +29,11 @@ module.exports = {
       url: docsUrl('prefer-read-only-props')
     },
     fixable: 'code',
+
+    messages: {
+      readOnlyProp: 'Prop \'{{name}}\' should be read-only.'
+    },
+
     schema: []
   },
 
@@ -53,9 +58,9 @@ module.exports = {
           if (!isCovariant(prop.node)) {
             context.report({
               node: prop.node,
-              message: 'Prop \'{{propName}}\' should be read-only.',
+              messageId: 'readOnlyProp',
               data: {
-                propName
+                name: propName
               },
               fix: (fixer) => {
                 if (!prop.node.variance) {

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -24,6 +24,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('prefer-stateless-function')
     },
+
+    messages: {
+      componentShouldBePure: 'Component should be written as a pure function'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -372,7 +377,7 @@ module.exports = {
           }
           context.report({
             node: list[component].node,
-            message: 'Component should be written as a pure function'
+            messageId: 'componentShouldBePure'
           });
         });
       }

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -24,6 +24,10 @@ module.exports = {
       url: docsUrl('prop-types')
     },
 
+    messages: {
+      missingPropType: '\'{{name}}\' is missing in props validation'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -51,8 +55,6 @@ module.exports = {
     const configuration = context.options[0] || {};
     const ignored = configuration.ignore || [];
     const skipUndeclared = configuration.skipUndeclared || false;
-
-    const MISSING_MESSAGE = '\'{{name}}\' is missing in props validation';
 
     /**
      * Checks if the prop is ignored
@@ -172,7 +174,7 @@ module.exports = {
       undeclareds.forEach((propType) => {
         context.report({
           node: propType.node,
-          message: MISSING_MESSAGE,
+          messageId: 'missingPropType',
           data: {
             name: propType.allNames.join('.').replace(/\.__COMPUTED_PROP__/g, '[]')
           }

--- a/lib/rules/react-in-jsx-scope.js
+++ b/lib/rules/react-in-jsx-scope.js
@@ -21,12 +21,16 @@ module.exports = {
       recommended: true,
       url: docsUrl('react-in-jsx-scope')
     },
+
+    messages: {
+      notInScope: '\'{{name}}\' must be in scope when using JSX'
+    },
+
     schema: []
   },
 
   create(context) {
     const pragma = pragmaUtil.getFromContext(context);
-    const NOT_DEFINED_MESSAGE = '\'{{name}}\' must be in scope when using JSX';
 
     function checkIfReactIsInScope(node) {
       const variables = variableUtil.variablesInScope(context);
@@ -35,7 +39,7 @@ module.exports = {
       }
       context.report({
         node,
-        message: NOT_DEFINED_MESSAGE,
+        messageId: 'notInScope',
         data: {
           name: pragma
         }

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -21,6 +21,11 @@ module.exports = {
       url: docsUrl('require-default-props')
     },
 
+    messages: {
+      noDefaultWithRequired: 'propType "{{name}}" is required and should not have a defaultProps declaration.',
+      shouldHaveDefault: 'propType "{{name}}" is not required, but has no corresponding defaultProps declaration.'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -59,7 +64,7 @@ module.exports = {
           if (forbidDefaultForRequired && defaultProps[propName]) {
             context.report({
               node: prop.node,
-              message: 'propType "{{name}}" is required and should not have a defaultProps declaration.',
+              messageId: 'noDefaultWithRequired',
               data: {name: propName}
             });
           }
@@ -72,7 +77,7 @@ module.exports = {
 
         context.report({
           node: prop.node,
-          message: 'propType "{{name}}" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
           data: {name: propName}
         });
       });

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -17,6 +17,10 @@ module.exports = {
       url: docsUrl('require-optimization')
     },
 
+    messages: {
+      noShouldComponentUpdate: 'Component is not optimized. Please add a shouldComponentUpdate method.'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -32,7 +36,6 @@ module.exports = {
   },
 
   create: Components.detect((context, components, utils) => {
-    const MISSING_MESSAGE = 'Component is not optimized. Please add a shouldComponentUpdate method.';
     const configuration = context.options[0] || {};
     const allowDecorators = configuration.allowDecorators || [];
 
@@ -139,10 +142,7 @@ module.exports = {
     function reportMissingOptimization(component) {
       context.report({
         node: component.node,
-        message: MISSING_MESSAGE,
-        data: {
-          component: component.name
-        }
+        messageId: 'noShouldComponentUpdate'
       });
     }
 

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -21,7 +21,12 @@ module.exports = {
       recommended: true,
       url: docsUrl('require-render-return')
     },
-    schema: [{}]
+
+    messages: {
+      noRenderReturn: 'Your render method should have a return statement'
+    },
+
+    schema: []
   },
 
   create: Components.detect((context, components, utils) => {
@@ -84,7 +89,7 @@ module.exports = {
           }
           context.report({
             node: findRenderMethod(list[component].node),
-            message: 'Your render method should have a return statement'
+            messageId: 'noRenderReturn'
           });
         });
       }

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -24,6 +24,10 @@ module.exports = {
     },
     fixable: 'code',
 
+    messages: {
+      notSelfClosing: 'Empty components are self-closing'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -84,7 +88,7 @@ module.exports = {
         }
         context.report({
           node,
-          message: 'Empty components are self-closing',
+          messageId: 'notSelfClosing',
           fix(fixer) {
             // Represents the last character of the JSXOpeningElement, the '>' character
             const openingElementEnding = node.range[1] - 1;

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -89,6 +89,10 @@ module.exports = {
       url: docsUrl('sort-comp')
     },
 
+    messages: {
+      unsortedProps: '{{propA}} should be placed {{position}} {{propB}}'
+    },
+
     schema: [{
       type: 'object',
       properties: {
@@ -116,9 +120,6 @@ module.exports = {
 
   create: Components.detect((context, components) => {
     const errors = {};
-
-    const MISPOSITION_MESSAGE = '{{propA}} should be placed {{position}} {{propB}}';
-
     const methodsOrder = getMethodsOrder(context.options[0]);
 
     // --------------------------------------------------------------------------
@@ -309,7 +310,7 @@ module.exports = {
 
         context.report({
           node: nodeA,
-          message: MISPOSITION_MESSAGE,
+          messageId: 'unsortedProps',
           data: {
             propA: getPropertyName(nodeA),
             propB: getPropertyName(nodeB),

--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -22,8 +22,13 @@ module.exports = {
       recommended: false,
       url: docsUrl('sort-prop-types')
     },
-
     // fixable: 'code',
+
+    messages: {
+      requiredPropsFirst: 'Required prop types must be listed before all other prop types',
+      callbackPropsLast: 'Callback prop types must be listed after all other prop types',
+      propsNotSorted: 'Prop types declarations should be sorted alphabetically'
+    },
 
     schema: [{
       type: 'object',
@@ -136,7 +141,7 @@ module.exports = {
             // Encountered a non-required prop after a required prop
             context.report({
               node: curr,
-              message: 'Required prop types must be listed before all other prop types'
+              messageId: 'requiredPropsFirst'
             //  fix
             });
             return curr;
@@ -152,7 +157,7 @@ module.exports = {
             // Encountered a non-callback prop after a callback prop
             context.report({
               node: prev,
-              message: 'Callback prop types must be listed after all other prop types'
+              messageId: 'callbackPropsLast'
               // fix
             });
             return prev;
@@ -162,7 +167,7 @@ module.exports = {
         if (!noSortAlphabetically && currentPropName < prevPropName) {
           context.report({
             node: curr,
-            message: 'Prop types declarations should be sorted alphabetically'
+            messageId: 'propsNotSorted'
             // fix
           });
           return prev;

--- a/lib/rules/state-in-constructor.js
+++ b/lib/rules/state-in-constructor.js
@@ -20,6 +20,12 @@ module.exports = {
       recommended: false,
       url: docsUrl('state-in-constructor')
     },
+
+    messages: {
+      stateInitConstructor: 'State initialization should be in a constructor',
+      stateInitClassProp: 'State initialization should be in a class property'
+    },
+
     schema: [{
       enum: ['always', 'never']
     }]
@@ -37,7 +43,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: 'State initialization should be in a constructor'
+            messageId: 'stateInitConstructor'
           });
         }
       },
@@ -50,7 +56,7 @@ module.exports = {
         ) {
           context.report({
             node,
-            message: 'State initialization should be in a class property'
+            messageId: 'stateInitClassProp'
           });
         }
       }

--- a/lib/rules/static-property-placement.js
+++ b/lib/rules/static-property-placement.js
@@ -23,9 +23,9 @@ const POSITION_SETTINGS = [STATIC_PUBLIC_FIELD, STATIC_GETTER, PROPERTY_ASSIGNME
 // Rule messages
 // ------------------------------------------------------------------------------
 const ERROR_MESSAGES = {
-  [STATIC_PUBLIC_FIELD]: '\'{{name}}\' should be declared as a static class property.',
-  [STATIC_GETTER]: '\'{{name}}\' should be declared as a static getter class function.',
-  [PROPERTY_ASSIGNMENT]: '\'{{name}}\' should be declared outside the class body.'
+  [STATIC_PUBLIC_FIELD]: 'notStaticClassProp',
+  [STATIC_GETTER]: 'notGetterClassFunc',
+  [PROPERTY_ASSIGNMENT]: 'declareOutsideClass'
 };
 
 // ------------------------------------------------------------------------------
@@ -56,6 +56,13 @@ module.exports = {
       url: docsUrl('static-property-placement')
     },
     fixable: null, // or 'code' or 'whitespace'
+
+    messages: {
+      notStaticClassProp: '\'{{name}}\' should be declared as a static class property.',
+      notGetterClassFunc: '\'{{name}}\' should be declared as a static getter class function.',
+      declareOutsideClass: '\'{{name}}\' should be declared outside the class body.'
+    },
+
     schema: [
       {enum: POSITION_SETTINGS},
       {
@@ -121,7 +128,7 @@ module.exports = {
         // Report the error
         context.report({
           node,
-          message: ERROR_MESSAGES[config[name]],
+          messageId: ERROR_MESSAGES[config[name]],
           data: {name}
         });
       }

--- a/lib/rules/style-prop-object.js
+++ b/lib/rules/style-prop-object.js
@@ -20,6 +20,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('style-prop-object')
     },
+
+    messages: {
+      stylePropNotObject: 'Style prop value must be an object'
+    },
+
     schema: [
       {
         type: 'object',
@@ -61,7 +66,7 @@ module.exports = {
       if (isNonNullaryLiteral(variable.defs[0].node.init)) {
         context.report({
           node,
-          message: 'Style prop value must be an object'
+          messageId: 'stylePropNotObject'
         });
       }
     }
@@ -92,7 +97,7 @@ module.exports = {
               } else if (isNonNullaryLiteral(style.value)) {
                 context.report({
                   node: style.value,
-                  message: 'Style prop value must be an object'
+                  messageId: 'stylePropNotObject'
                 });
               }
             }
@@ -122,7 +127,7 @@ module.exports = {
         if (node.value.type !== 'JSXExpressionContainer' || isNonNullaryLiteral(node.value.expression)) {
           context.report({
             node,
-            message: 'Style prop value must be an object'
+            messageId: 'stylePropNotObject'
           });
         } else if (node.value.expression.type === 'Identifier') {
           checkIdentifiers(node.value.expression);

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -40,10 +40,6 @@ function isVoidDOMElement(elementName) {
   return has(VOID_DOM_ELEMENTS, elementName);
 }
 
-function errorMessage(elementName) {
-  return `Void DOM element <${elementName} /> cannot receive children.`;
-}
-
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -56,6 +52,11 @@ module.exports = {
       recommended: false,
       url: docsUrl('void-dom-elements-no-children')
     },
+
+    messages: {
+      noChildrenInVoidEl: 'Void DOM element <{{element}} /> cannot receive children.'
+    },
+
     schema: []
   },
 
@@ -72,7 +73,10 @@ module.exports = {
         // e.g. <br>Foo</br>
         context.report({
           node,
-          message: errorMessage(elementName)
+          messageId: 'noChildrenInVoidEl',
+          data: {
+            element: elementName
+          }
         });
       }
 
@@ -90,7 +94,10 @@ module.exports = {
         // e.g. <br children="Foo" />
         context.report({
           node,
-          message: errorMessage(elementName)
+          messageId: 'noChildrenInVoidEl',
+          data: {
+            element: elementName
+          }
         });
       }
     },
@@ -127,7 +134,10 @@ module.exports = {
         // e.g. React.createElement('br', undefined, 'Foo')
         context.report({
           node,
-          message: errorMessage(elementName)
+          messageId: 'noChildrenInVoidEl',
+          data: {
+            element: elementName
+          }
         });
       }
 
@@ -145,7 +155,10 @@ module.exports = {
         // e.g. React.createElement('br', { children: 'Foo' })
         context.report({
           node,
-          message: errorMessage(elementName)
+          messageId: 'noChildrenInVoidEl',
+          data: {
+            element: elementName
+          }
         });
       }
     }

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -34,6 +34,10 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
         url: docsUrl(mapTitle(methodName))
       },
 
+      messages: {
+        noSetState: 'Do not use setState in {{name}}'
+      },
+
       schema: [{
         enum: ['disallow-in-func']
       }]
@@ -84,7 +88,10 @@ function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
             }
             context.report({
               node: callee,
-              message: `Do not use setState in ${ancestor.key.name}`
+              messageId: 'noSetState',
+              data: {
+                name: ancestor.key.name
+              }
             });
             return true;
           });

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -430,7 +430,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // createReactClass components with React.PropTypes
@@ -444,7 +445,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // React.createClass components with PropTypes
@@ -463,7 +465,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       }
     },
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // ES6 components as React.Component with boolean PropTypes
@@ -477,7 +480,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // ES6 components as Component with non-boolean PropTypes
@@ -491,7 +495,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // ES6 components as React.Component with non-boolean PropTypes
@@ -506,7 +511,8 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // ES6 components as React.Component with non-boolean PropTypes and Object.spread syntax
@@ -521,7 +527,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // ES6 components as React.Component with static class property, non-boolean PropTypes, and Object.spread syntax
@@ -537,7 +544,8 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // ES6 components as React.Component with non-boolean PropTypes
@@ -552,7 +560,8 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -564,7 +573,8 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -578,7 +588,8 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // ES6 components and Flowtype non-booleans
@@ -594,7 +605,8 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -612,9 +624,11 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }, {
-      message: 'Prop name (somethingElse) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'somethingElse', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -632,9 +646,11 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }, {
-      message: 'Prop name (somethingElse) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'somethingElse', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -651,7 +667,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'showScore', pattern: '^(is|has)[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -668,7 +685,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'showScore', pattern: '^(is|has)[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -685,7 +703,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'showScore', pattern: '^(is|has)[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -702,7 +721,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'showScore', pattern: '^(is|has)[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -721,7 +741,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'showScore', pattern: '^(is|has)[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -741,7 +762,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (showScore) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'showScore', pattern: '^(is|has)[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // If a custom message is provided, use it.
@@ -785,7 +807,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // Works when a prop isRequired in ES6 with static properties.
@@ -807,7 +830,8 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // Works when a prop isRequired in ES6 without static properties.
@@ -828,7 +852,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       rule: '^is[A-Z]([A-Za-z0-9]?)+'
     }],
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     // inline Flow type
@@ -848,7 +873,8 @@ ruleTester.run('boolean-prop-naming', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -872,7 +898,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       validateNested: true
     }],
     errors: [{
-      message: 'Prop name (failingItIs) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'failingItIs', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -898,7 +925,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       validateNested: true
     }],
     errors: [{
-      message: 'Prop name (failingItIs) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'failingItIs', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }, {
     code: `
@@ -913,7 +941,8 @@ ruleTester.run('boolean-prop-naming', rule, {
       validateNested: true
     }],
     errors: [{
-      message: 'Prop name (something) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)'
+      messageId: 'patternMismatch',
+      data: {propName: 'something', pattern: '^is[A-Z]([A-Za-z0-9]?)+'}
     }]
   }]
 });

--- a/tests/lib/rules/button-has-type.js
+++ b/tests/lib/rules/button-has-type.js
@@ -76,157 +76,172 @@ ruleTester.run('button-has-type', rule, {
     {
       code: '<button/>',
       errors: [{
-        message: 'Missing an explicit type attribute for button'
+        messageId: 'missingType'
       }]
     },
     {
       code: '<button type="foo"/>',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: '<button type={foo}/>',
       errors: [{
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       }]
     },
     {
       code: '<button type={"foo"}/>',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: '<button type={\'foo\'}/>',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: '<button type={`foo`}/>',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: '<button type={`button${foo}`}/>',
       errors: [{
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       }]
     },
     {
       code: '<button type="reset"/>',
       options: [{reset: false}],
       errors: [{
-        message: '"reset" is a forbidden value for button type attribute'
+        messageId: 'forbiddenValue',
+        data: {value: 'reset'}
       }]
     },
     {
       code: '<button type={condition ? "button" : foo}/>',
       errors: [{
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       }]
     },
     {
       code: '<button type={condition ? "button" : "foo"}/>',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: '<button type={condition ? "button" : "reset"}/>',
       options: [{reset: false}],
       errors: [{
-        message: '"reset" is a forbidden value for button type attribute'
+        messageId: 'forbiddenValue',
+        data: {value: 'reset'}
       }]
     },
     {
       code: '<button type={condition ? foo : "button"}/>',
       errors: [{
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       }]
     },
     {
       code: '<button type={condition ? "foo" : "button"}/>',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: '<button type={condition ? "reset" : "button"}/>',
       options: [{reset: false}],
       errors: [{
-        message: '"reset" is a forbidden value for button type attribute'
+        messageId: 'forbiddenValue',
+        data: {value: 'reset'}
       }]
     },
     {
       code: 'React.createElement("button")',
       errors: [{
-        message: 'Missing an explicit type attribute for button'
+        messageId: 'missingType'
       }]
     },
     {
       code: 'React.createElement("button", {type: foo})',
       errors: [{
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       }]
     },
     {
       code: 'React.createElement("button", {type: "foo"})',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: 'React.createElement("button", {type: "reset"})',
       options: [{reset: false}],
       errors: [{
-        message: '"reset" is a forbidden value for button type attribute'
+        messageId: 'forbiddenValue',
+        data: {value: 'reset'}
       }]
     },
     {
       code: 'React.createElement("button", {type: condition ? "button" : foo})',
       errors: [{
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       }]
     },
     {
       code: 'React.createElement("button", {type: condition ? "button" : "foo"})',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: 'React.createElement("button", {type: condition ? "button" : "reset"})',
       options: [{reset: false}],
       errors: [{
-        message: '"reset" is a forbidden value for button type attribute'
+        messageId: 'forbiddenValue',
+        data: {value: 'reset'}
       }]
     },
     {
       code: 'React.createElement("button", {type: condition ? foo : "button"})',
       errors: [{
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       }]
     },
     {
       code: 'React.createElement("button", {type: condition ? "foo" : "button"})',
       errors: [{
-        message: '"foo" is an invalid value for button type attribute'
+        messageId: 'invalidValue',
+        data: {value: 'foo'}
       }]
     },
     {
       code: 'React.createElement("button", {type: condition ? "reset" : "button"})',
       options: [{reset: false}],
       errors: [{
-        message: '"reset" is a forbidden value for button type attribute'
+        messageId: 'forbiddenValue',
+        data: {value: 'reset'}
       }]
     },
     {
       code: 'Foo.createElement("button")',
       errors: [{
-        message: 'Missing an explicit type attribute for button'
+        messageId: 'missingType'
       }],
       settings: {
         react: {
@@ -237,7 +252,7 @@ ruleTester.run('button-has-type', rule, {
     {
       code: 'function Button({ type, ...extraProps }) { const button = type; return <button type={button} {...extraProps} />; }',
       errors: [{
-        message: 'The button type attribute must be specified by a static string or a trivial ternary expression'
+        messageId: 'complexType'
       }]
     }
   ]

--- a/tests/lib/rules/default-props-match-prop-types.js
+++ b/tests/lib/rules/default-props-match-prop-types.js
@@ -842,7 +842,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 9,
         column: 3
       }]
@@ -861,7 +862,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 9,
         column: 3
       }],
@@ -884,7 +886,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         propWrapperFunctions: ['forbidExtraProps']
       },
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 9,
         column: 3
       }]
@@ -907,7 +910,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         propWrapperFunctions: ['forbidExtraProps']
       },
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 10,
         column: 3
       }]
@@ -926,7 +930,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 9,
         column: 3
       }],
@@ -950,12 +955,14 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'defaultProp "bar" defined for isRequired propType.',
+          messageId: 'requiredHasDefault',
+          data: {name: 'bar'},
           line: 9,
           column: 3
         },
         {
-          message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+          messageId: 'defaultHasNoType',
+          data: {name: 'baz'},
           line: 11,
           column: 1
         }
@@ -977,7 +984,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "bar" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'bar'},
         line: 10,
         column: 3
       }]
@@ -998,7 +1006,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         'MyStatelessComponent.defaultProps = defaults;'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 2,
         column: 3
       }]
@@ -1020,7 +1029,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         'MyStatelessComponent.defaultProps = defaults;'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 2,
         column: 3
       }]
@@ -1046,7 +1056,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 11,
         column: 7
       }]
@@ -1069,7 +1080,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 11,
         column: 7
       }]
@@ -1095,7 +1107,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 13,
         column: 3
       }]
@@ -1118,7 +1131,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 13,
         column: 3
       }]
@@ -1140,7 +1154,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         'Greeting.defaultProps.foo = "foo";'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 13,
         column: 1
       }]
@@ -1162,7 +1177,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         'Greeting.defaultProps.baz = "baz";'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 13,
         column: 1
       }]
@@ -1182,7 +1198,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         'Greeting.defaultProps.foo = "foo";'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 11,
         column: 1
       }]
@@ -1207,7 +1224,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         'Greeting.defaultProps = defaults;'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "bar" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'bar'},
         line: 14,
         column: 3
       }]
@@ -1232,7 +1250,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         'Greeting.defaultProps = defaults;'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 13,
         column: 3
       }]
@@ -1259,7 +1278,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "name" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'name'},
         line: 9,
         column: 7
       }]
@@ -1284,7 +1304,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 10,
         column: 7
       }]
@@ -1311,7 +1332,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 5,
         column: 3
       }]
@@ -1338,7 +1360,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "bar" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'bar'},
         line: 2,
         column: 3
       }]
@@ -1365,7 +1388,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'defaultProp "bar" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'bar'},
         line: 12,
         column: 5
       }]
@@ -1389,7 +1413,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 12,
         column: 5
       }]
@@ -1415,7 +1440,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'defaultProp "bar" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'bar'},
         line: 6,
         column: 3
       }]
@@ -1441,7 +1467,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'defaultProp "baz" has no corresponding propTypes declaration.',
+        messageId: 'defaultHasNoType',
+        data: {name: 'baz'},
         line: 6,
         column: 3
       }]
@@ -1465,7 +1492,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 11,
         column: 3
       }]
@@ -1483,7 +1511,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 8,
         column: 3
       }]
@@ -1510,7 +1539,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 11,
         column: 3
       }]
@@ -1526,7 +1556,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 5,
         column: 3
       }]
@@ -1546,7 +1577,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 8,
         column: 3
       }]
@@ -1560,7 +1592,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'defaultProp "foo" defined for isRequired propType.',
+        messageId: 'requiredHasDefault',
+        data: {name: 'foo'},
         line: 4,
         column: 24
       }]
@@ -1585,12 +1618,14 @@ ruleTester.run('default-props-match-prop-types', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'defaultProp "foo" defined for isRequired propType.',
+          messageId: 'requiredHasDefault',
+          data: {name: 'foo'},
           line: 12,
           column: 24
         },
         {
-          message: 'defaultProp "frob" has no corresponding propTypes declaration.',
+          messageId: 'defaultHasNoType',
+          data: {name: 'frob'},
           line: 12,
           column: 36
         }
@@ -1617,10 +1652,12 @@ ruleTester.run('default-props-match-prop-types', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'defaultProp "fooBar" has no corresponding propTypes declaration.'
+          messageId: 'defaultHasNoType',
+          data: {name: 'fooBar'}
         },
         {
-          message: 'defaultProp "foo" defined for isRequired propType.'
+          messageId: 'requiredHasDefault',
+          data: {name: 'foo'}
         }
       ]
     },
@@ -1641,7 +1678,8 @@ ruleTester.run('default-props-match-prop-types', rule, {
       `,
       errors: [
         {
-          message: 'defaultProp "firstProperty" defined for isRequired propType.'
+          messageId: 'requiredHasDefault',
+          data: {name: 'firstProperty'}
         }
       ]
     },
@@ -1665,12 +1703,14 @@ ruleTester.run('default-props-match-prop-types', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'defaultProp "foo" defined for isRequired propType.',
+          messageId: 'requiredHasDefault',
+          data: {name: 'foo'},
           line: 12,
           column: 24
         },
         {
-          message: 'defaultProp "frob" has no corresponding propTypes declaration.',
+          messageId: 'defaultHasNoType',
+          data: {name: 'frob'},
           line: 12,
           column: 36
         }
@@ -1698,12 +1738,14 @@ ruleTester.run('default-props-match-prop-types', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'defaultProp "foo" defined for isRequired propType.',
+          messageId: 'requiredHasDefault',
+          data: {name: 'foo'},
           line: 14,
           column: 24
         },
         {
-          message: 'defaultProp "frob" has no corresponding propTypes declaration.',
+          messageId: 'defaultHasNoType',
+          data: {name: 'frob'},
           line: 14,
           column: 36
         }

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -182,52 +182,56 @@ ruleTester.run('destructuring-assignment', rule, {
     code: `const MyComponent = (props) => {
       return (<div id={props.id} />)
     };`,
-    errors: [
-      {message: 'Must use destructuring props assignment'}
-    ]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `const MyComponent = ({ id, className }) => (
       <div id={id} className={className} />
     );`,
     options: ['never'],
-    errors: [
-      {message: 'Must never use destructuring props assignment in SFC argument'}
-    ]
+    errors: [{
+      messageId: 'noDestructPropsInSFCArg'
+    }]
   }, {
     code: `const MyComponent = (props, { color }) => (
       <div id={props.id} className={props.className} />
     );`,
     options: ['never'],
-    errors: [
-      {message: 'Must never use destructuring context assignment in SFC argument'}
-    ]
+    errors: [{
+      messageId: 'noDestructContextInSFCArg'
+    }]
   }, {
     code: `const Foo = class extends React.PureComponent {
       render() {
         return <div>{this.props.foo}</div>;
       }
     };`,
-    errors: [
-      {message: 'Must use destructuring props assignment'}
-    ]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `const Foo = class extends React.PureComponent {
       render() {
         return <div>{this.state.foo}</div>;
       }
     };`,
-    errors: [
-      {message: 'Must use destructuring state assignment'}
-    ]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'state'}
+    }]
   }, {
     code: `const Foo = class extends React.PureComponent {
       render() {
         return <div>{this.context.foo}</div>;
       }
     };`,
-    errors: [
-      {message: 'Must use destructuring context assignment'}
-    ]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'context'}
+    }]
   }, {
     code: `class Foo extends React.Component {
       render() { return this.foo(); }
@@ -235,18 +239,20 @@ ruleTester.run('destructuring-assignment', rule, {
         return this.props.children;
       }
     }`,
-    errors: [
-      {message: 'Must use destructuring props assignment'}
-    ]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `var Hello = React.createClass({
       render: function() {
         return <Text>{this.props.foo}</Text>;
       }
     });`,
-    errors: [
-      {message: 'Must use destructuring props assignment'}
-    ]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `
       module.exports = {
@@ -255,21 +261,30 @@ ruleTester.run('destructuring-assignment', rule, {
         }
       }
     `,
-    errors: [{message: 'Must use destructuring props assignment'}]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `
       export default function Foo(props) {
         return <p>{props.a}</p>;
       }
     `,
-    errors: [{message: 'Must use destructuring props assignment'}]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `
       function hof() {
         return (props) => <p>{props.a}</p>;
       }
     `,
-    errors: [{message: 'Must use destructuring props assignment'}]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `const Foo = class extends React.PureComponent {
       render() {
@@ -277,9 +292,10 @@ ruleTester.run('destructuring-assignment', rule, {
         return <div>{foo}</div>;
       }
     };`,
-    errors: [
-      {message: 'Must use destructuring props assignment'}
-    ]
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `const Foo = class extends React.PureComponent {
       render() {
@@ -289,9 +305,10 @@ ruleTester.run('destructuring-assignment', rule, {
     };`,
     options: ['never'],
     parser: parsers.BABEL_ESLINT,
-    errors: [
-      {message: 'Must never use destructuring props assignment'}
-    ]
+    errors: [{
+      messageId: 'noDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `const MyComponent = (props) => {
       const { id, className } = props;
@@ -299,9 +316,10 @@ ruleTester.run('destructuring-assignment', rule, {
     };`,
     options: ['never'],
     parser: parsers.BABEL_ESLINT,
-    errors: [
-      {message: 'Must never use destructuring props assignment'}
-    ]
+    errors: [{
+      messageId: 'noDestructAssignment',
+      data: {type: 'props'}
+    }]
   }, {
     code: `const Foo = class extends React.PureComponent {
       render() {
@@ -311,8 +329,9 @@ ruleTester.run('destructuring-assignment', rule, {
     };`,
     options: ['never'],
     parser: parsers.BABEL_ESLINT,
-    errors: [
-      {message: 'Must never use destructuring state assignment'}
-    ]
+    errors: [{
+      messageId: 'noDestructAssignment',
+      data: {type: 'state'}
+    }]
   }]
 });

--- a/tests/lib/rules/display-name.js
+++ b/tests/lib/rules/display-name.js
@@ -518,7 +518,7 @@ ruleTester.run('display-name', rule, {
       ignoreTranspilerName: true
     }],
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -537,7 +537,7 @@ ruleTester.run('display-name', rule, {
       }
     },
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -551,7 +551,7 @@ ruleTester.run('display-name', rule, {
       ignoreTranspilerName: true
     }],
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -565,7 +565,7 @@ ruleTester.run('display-name', rule, {
       ignoreTranspilerName: true
     }],
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -582,7 +582,7 @@ ruleTester.run('display-name', rule, {
       ignoreTranspilerName: true
     }],
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -592,7 +592,7 @@ ruleTester.run('display-name', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -602,7 +602,7 @@ ruleTester.run('display-name', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -614,7 +614,7 @@ ruleTester.run('display-name', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -632,7 +632,7 @@ ruleTester.run('display-name', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -656,7 +656,7 @@ ruleTester.run('display-name', rule, {
       }
     },
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -680,7 +680,7 @@ ruleTester.run('display-name', rule, {
     },
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -697,7 +697,7 @@ ruleTester.run('display-name', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -709,7 +709,7 @@ ruleTester.run('display-name', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -720,7 +720,7 @@ ruleTester.run('display-name', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -731,7 +731,7 @@ ruleTester.run('display-name', rule, {
       })
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -742,7 +742,7 @@ ruleTester.run('display-name', rule, {
       })
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -753,7 +753,7 @@ ruleTester.run('display-name', rule, {
       })
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -764,7 +764,7 @@ ruleTester.run('display-name', rule, {
       })
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     // Only trigger an error for the outer React.memo
@@ -778,7 +778,7 @@ ruleTester.run('display-name', rule, {
       )
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     // Only trigger an error for the outer React.memo
@@ -792,7 +792,7 @@ ruleTester.run('display-name', rule, {
       )
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     // React does not handle the result of forwardRef being passed into memo
@@ -808,7 +808,7 @@ ruleTester.run('display-name', rule, {
       )
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -820,7 +820,7 @@ ruleTester.run('display-name', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -832,7 +832,7 @@ ruleTester.run('display-name', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -851,7 +851,7 @@ ruleTester.run('display-name', rule, {
       }
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -871,7 +871,7 @@ ruleTester.run('display-name', rule, {
       }
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -892,7 +892,7 @@ ruleTester.run('display-name', rule, {
       }
     `,
     errors: [{
-      message: 'Component definition is missing display name'
+      messageId: 'noDisplayName'
     }]
   }, {
     code: `
@@ -909,13 +909,13 @@ ruleTester.run('display-name', rule, {
       })();
     `,
     errors: [{
-      message: 'Component definition is missing display name',
+      messageId: 'noDisplayName',
       line: 2,
       column: 22,
       endLine: 6,
       endColumn: 8
     }, {
-      message: 'Component definition is missing display name',
+      messageId: 'noDisplayName',
       line: 9,
       column: 16,
       endLine: 11,

--- a/tests/lib/rules/forbid-component-props.js
+++ b/tests/lib/rules/forbid-component-props.js
@@ -23,9 +23,6 @@ const parserOptions = {
 // Tests
 // -----------------------------------------------------------------------------
 
-const CLASSNAME_ERROR_MESSAGE = 'Prop `className` is forbidden on Components';
-const STYLE_ERROR_MESSAGE = 'Prop `style` is forbidden on Components';
-
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('forbid-component-props', rule, {
 
@@ -126,7 +123,8 @@ ruleTester.run('forbid-component-props', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: CLASSNAME_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'className'},
       line: 4,
       column: 17,
       type: 'JSXAttribute'
@@ -141,7 +139,8 @@ ruleTester.run('forbid-component-props', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: STYLE_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'style'},
       line: 4,
       column: 17,
       type: 'JSXAttribute'
@@ -157,7 +156,8 @@ ruleTester.run('forbid-component-props', rule, {
     ].join('\n'),
     options: [{forbid: ['className', 'style']}],
     errors: [{
-      message: CLASSNAME_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'className'},
       line: 4,
       column: 17,
       type: 'JSXAttribute'
@@ -173,7 +173,8 @@ ruleTester.run('forbid-component-props', rule, {
     ].join('\n'),
     options: [{forbid: ['className', 'style']}],
     errors: [{
-      message: STYLE_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'style'},
       line: 4,
       column: 17,
       type: 'JSXAttribute'
@@ -184,7 +185,8 @@ ruleTester.run('forbid-component-props', rule, {
       forbid: [{propName: 'className', allowedFor: ['ReactModal']}]
     }],
     errors: [{
-      message: CLASSNAME_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'className'},
       line: 1,
       column: 20,
       type: 'JSXAttribute'
@@ -195,7 +197,8 @@ ruleTester.run('forbid-component-props', rule, {
       forbid: [{propName: 'className', allowedFor: ['ReactModal']}]
     }],
     errors: [{
-      message: CLASSNAME_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'className'},
       line: 1,
       column: 32,
       type: 'JSXAttribute'
@@ -251,7 +254,8 @@ ruleTester.run('forbid-component-props', rule, {
       ]
     }],
     errors: [{
-      message: 'Prop `className` is forbidden on Components',
+      messageId: 'propIsForbidden',
+      data: {prop: 'className'},
       line: 2,
       column: 6,
       type: 'JSXAttribute'

--- a/tests/lib/rules/forbid-dom-props.js
+++ b/tests/lib/rules/forbid-dom-props.js
@@ -23,8 +23,6 @@ const parserOptions = {
 // Tests
 // -----------------------------------------------------------------------------
 
-const ID_ERROR_MESSAGE = 'Prop `id` is forbidden on DOM Nodes';
-
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('forbid-element-props', rule, {
 
@@ -93,7 +91,8 @@ ruleTester.run('forbid-element-props', rule, {
     ].join('\n'),
     options: [{forbid: ['id']}],
     errors: [{
-      message: ID_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'id'},
       line: 4,
       column: 17,
       type: 'JSXAttribute'
@@ -108,7 +107,8 @@ ruleTester.run('forbid-element-props', rule, {
     ].join('\n'),
     options: [{forbid: ['id']}],
     errors: [{
-      message: ID_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'id'},
       line: 3,
       column: 17,
       type: 'JSXAttribute'
@@ -121,7 +121,8 @@ ruleTester.run('forbid-element-props', rule, {
     ].join('\n'),
     options: [{forbid: ['id']}],
     errors: [{
-      message: ID_ERROR_MESSAGE,
+      messageId: 'propIsForbidden',
+      data: {prop: 'id'},
       line: 2,
       column: 8,
       type: 'JSXAttribute'
@@ -181,7 +182,8 @@ ruleTester.run('forbid-element-props', rule, {
       ]
     }],
     errors: [{
-      message: 'Prop `className` is forbidden on DOM Nodes',
+      messageId: 'propIsForbidden',
+      data: {prop: 'className'},
       line: 2,
       column: 8,
       type: 'JSXAttribute'

--- a/tests/lib/rules/forbid-elements.js
+++ b/tests/lib/rules/forbid-elements.js
@@ -86,22 +86,29 @@ ruleTester.run('forbid-elements', rule, {
     {
       code: '<button />',
       options: [{forbid: ['button']}],
-      errors: [{message: '<button> is forbidden'}]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'button'}
+      }]
     },
     {
       code: '[<Modal />, <button />]',
       options: [{forbid: ['button', 'Modal']}],
-      errors: [
-        {message: '<Modal> is forbidden'},
-        {message: '<button> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'Modal'}
+      }, {
+        messageId: 'forbiddenElement',
+        data: {element: 'button'}
+      }]
     },
     {
       code: '<dotted.component />',
       options: [{forbid: ['dotted.component']}],
-      errors: [
-        {message: '<dotted.component> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'dotted.component'}
+      }]
     },
     {
       code: '<dotted.Component />',
@@ -110,7 +117,10 @@ ruleTester.run('forbid-elements', rule, {
           {element: 'dotted.Component', message: 'that ain\'t cool'}
         ]
       }],
-      errors: [{message: '<dotted.Component> is forbidden, that ain\'t cool'}]
+      errors: [{
+        messageId: 'forbiddenElement_message',
+        data: {element: 'dotted.Component', message: 'that ain\'t cool'}
+      }]
     },
     {
       code: '<button />',
@@ -119,31 +129,43 @@ ruleTester.run('forbid-elements', rule, {
           {element: 'button', message: 'use <Button> instead'}
         ]
       }],
-      errors: [{message: '<button> is forbidden, use <Button> instead'}]
+      errors: [{
+        messageId: 'forbiddenElement_message',
+        data: {element: 'button', message: 'use <Button> instead'}
+      }]
     },
     {
       code: '<button><input /></button>',
       options: [{forbid: [{element: 'button'}, {element: 'input'}]}],
-      errors: [
-        {message: '<button> is forbidden'},
-        {message: '<input> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'button'}
+      }, {
+        messageId: 'forbiddenElement',
+        data: {element: 'input'}
+      }]
     },
     {
       code: '<button><input /></button>',
       options: [{forbid: [{element: 'button'}, 'input']}],
-      errors: [
-        {message: '<button> is forbidden'},
-        {message: '<input> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'button'}
+      }, {
+        messageId: 'forbiddenElement',
+        data: {element: 'input'}
+      }]
     },
     {
       code: '<button><input /></button>',
       options: [{forbid: ['input', {element: 'button'}]}],
-      errors: [
-        {message: '<button> is forbidden'},
-        {message: '<input> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'button'}
+      }, {
+        messageId: 'forbiddenElement',
+        data: {element: 'input'}
+      }]
     },
     {
       code: '<button />',
@@ -153,20 +175,29 @@ ruleTester.run('forbid-elements', rule, {
           {element: 'button', message: 'use <Button2> instead'}
         ]
       }],
-      errors: [{message: '<button> is forbidden, use <Button2> instead'}]
+      errors: [{
+        messageId: 'forbiddenElement_message',
+        data: {element: 'button', message: 'use <Button2> instead'}
+      }]
     },
     {
       code: 'React.createElement("button", {}, child)',
       options: [{forbid: ['button']}],
-      errors: [{message: '<button> is forbidden'}]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'button'}
+      }]
     },
     {
       code: '[React.createElement(Modal), React.createElement("button")]',
       options: [{forbid: ['button', 'Modal']}],
-      errors: [
-        {message: '<Modal> is forbidden'},
-        {message: '<button> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'Modal'}
+      }, {
+        messageId: 'forbiddenElement',
+        data: {element: 'button'}
+      }]
     },
     {
       code: 'React.createElement(dotted.Component)',
@@ -175,21 +206,26 @@ ruleTester.run('forbid-elements', rule, {
           {element: 'dotted.Component', message: 'that ain\'t cool'}
         ]
       }],
-      errors: [{message: '<dotted.Component> is forbidden, that ain\'t cool'}]
+      errors: [{
+        messageId: 'forbiddenElement_message',
+        data: {element: 'dotted.Component', message: 'that ain\'t cool'}
+      }]
     },
     {
       code: 'React.createElement(dotted.component)',
       options: [{forbid: ['dotted.component']}],
-      errors: [
-        {message: '<dotted.component> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'dotted.component'}
+      }]
     },
     {
       code: 'React.createElement(_comp)',
       options: [{forbid: ['_comp']}],
-      errors: [
-        {message: '<_comp> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: '_comp'}
+      }]
     },
     {
       code: 'React.createElement("button")',
@@ -198,15 +234,21 @@ ruleTester.run('forbid-elements', rule, {
           {element: 'button', message: 'use <Button> instead'}
         ]
       }],
-      errors: [{message: '<button> is forbidden, use <Button> instead'}]
+      errors: [{
+        messageId: 'forbiddenElement_message',
+        data: {element: 'button', message: 'use <Button> instead'}
+      }]
     },
     {
       code: 'React.createElement("button", {}, React.createElement("input"))',
       options: [{forbid: [{element: 'button'}, {element: 'input'}]}],
-      errors: [
-        {message: '<button> is forbidden'},
-        {message: '<input> is forbidden'}
-      ]
+      errors: [{
+        messageId: 'forbiddenElement',
+        data: {element: 'button'}
+      }, {
+        messageId: 'forbiddenElement',
+        data: {element: 'input'}
+      }]
     }
   ]
 });

--- a/tests/lib/rules/forbid-foreign-prop-types.js
+++ b/tests/lib/rules/forbid-foreign-prop-types.js
@@ -25,8 +25,6 @@ const parserOptions = {
 // Tests
 // -----------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Using propTypes from another component is not safe because they may be removed in production builds';
-
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('forbid-foreign-prop-types', rule, {
 
@@ -90,7 +88,7 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
       });
     `,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
       type: 'Identifier'
     }]
   },
@@ -104,7 +102,7 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
       });
     `,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
       type: 'Literal'
     }]
   },
@@ -119,7 +117,7 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
       });
     `,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
       type: 'Property'
     }]
   },
@@ -135,7 +133,7 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
       type: 'Property'
     }]
   },
@@ -149,7 +147,7 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
       type: 'Identifier'
     }]
   },
@@ -164,7 +162,7 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
       });
     `,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
       type: 'Property'
     }]
   },
@@ -183,7 +181,7 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
       allowInPropTypes: false
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
       type: 'Identifier'
     }]
   },
@@ -200,7 +198,7 @@ ruleTester.run('forbid-foreign-prop-types', rule, {
       allowInPropTypes: false
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
       type: 'Identifier'
     }]
   }]

--- a/tests/lib/rules/forbid-prop-types.js
+++ b/tests/lib/rules/forbid-prop-types.js
@@ -25,11 +25,6 @@ const parserOptions = {
 // Tests
 // -----------------------------------------------------------------------------
 
-const ANY_ERROR_MESSAGE = 'Prop type `any` is forbidden';
-const ARRAY_ERROR_MESSAGE = 'Prop type `array` is forbidden';
-const NUMBER_ERROR_MESSAGE = 'Prop type `number` is forbidden';
-const OBJECT_ERROR_MESSAGE = 'Prop type `object` is forbidden';
-
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('forbid-prop-types', rule, {
 
@@ -596,7 +591,8 @@ ruleTester.run('forbid-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -613,7 +609,8 @@ ruleTester.run('forbid-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: NUMBER_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'number'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -633,7 +630,8 @@ ruleTester.run('forbid-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -650,7 +648,8 @@ ruleTester.run('forbid-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: ARRAY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'array'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -667,7 +666,8 @@ ruleTester.run('forbid-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: ARRAY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'array'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -684,7 +684,8 @@ ruleTester.run('forbid-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: OBJECT_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'object'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -701,7 +702,8 @@ ruleTester.run('forbid-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: OBJECT_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'object'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -783,7 +785,10 @@ ruleTester.run('forbid-prop-types', rule, {
       'export default function Component() {}',
       'Component.propTypes = propTypes;'
     ].join('\n'),
-    errors: [{message: ANY_ERROR_MESSAGE}]
+    errors: [{
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'}
+    }]
   }, {
     code: [
       'import { forbidExtraProps } from "airbnb-prop-types";',
@@ -791,7 +796,10 @@ ruleTester.run('forbid-prop-types', rule, {
       'export default function Component() {}',
       'Component.propTypes = forbidExtraProps(propTypes);'
     ].join('\n'),
-    errors: [{message: ANY_ERROR_MESSAGE}],
+    errors: [{
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'}
+    }],
     settings: {
       propWrapperFunctions: ['forbidExtraProps']
     }
@@ -904,7 +912,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -923,7 +932,8 @@ ruleTester.run('forbid-prop-types', rule, {
     options: [{checkContextTypes: true}],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -943,7 +953,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 4,
       column: 7,
       type: 'Property'
@@ -961,7 +972,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 7,
       column: 3,
       type: 'Property'
@@ -977,7 +989,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 5,
       column: 3,
       type: 'Property'
@@ -993,7 +1006,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 5,
       column: 3,
       type: 'Property'
@@ -1196,7 +1210,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkChildContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -1215,7 +1230,8 @@ ruleTester.run('forbid-prop-types', rule, {
     options: [{checkChildContextTypes: true}],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 3,
       column: 5,
       type: 'Property'
@@ -1235,7 +1251,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkChildContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 4,
       column: 7,
       type: 'Property'
@@ -1253,7 +1270,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkChildContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 7,
       column: 3,
       type: 'Property'
@@ -1269,7 +1287,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkChildContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 5,
       column: 3,
       type: 'Property'
@@ -1285,7 +1304,8 @@ ruleTester.run('forbid-prop-types', rule, {
     ].join('\n'),
     options: [{checkChildContextTypes: true}],
     errors: [{
-      message: ANY_ERROR_MESSAGE,
+      messageId: 'forbiddenPropType',
+      data: {target: 'any'},
       line: 5,
       column: 3,
       type: 'Property'

--- a/tests/lib/rules/function-component-definition.js
+++ b/tests/lib/rules/function-component-definition.js
@@ -318,7 +318,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.BABEL_ESLINT
   }, {
     code: [
@@ -332,7 +332,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.BABEL_ESLINT
   }, {
     code: [
@@ -346,7 +346,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.BABEL_ESLINT
   }, {
     code: [
@@ -360,7 +360,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.BABEL_ESLINT
   }, {
     code: [
@@ -374,7 +374,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}]
+    errors: [{messageId: 'function-declaration'}]
   }, {
     code: [
       'var Hello = (props) => {',
@@ -387,7 +387,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-expression'}],
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     parser: parsers.BABEL_ESLINT
   }, {
     code: [
@@ -401,7 +401,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-expression'}],
-    errors: [{message: 'Function component is not a function expression'}]
+    errors: [{messageId: 'function-expression'}]
   }, {
     code: [
       'function wrap(Component) {',
@@ -417,7 +417,7 @@ ruleTester.run('function-component-definition', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     options: [{unnamedComponents: 'arrow-function'}]
   }, {
     code: [
@@ -434,7 +434,7 @@ ruleTester.run('function-component-definition', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     options: [{unnamedComponents: 'function-expression'}],
     parser: parsers.BABEL_ESLINT
   }, {
@@ -449,7 +449,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -463,7 +463,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -477,7 +477,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -491,7 +491,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -505,7 +505,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-expression'}],
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -519,7 +519,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-expression'}],
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -533,7 +533,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-expression'}],
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -547,7 +547,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -561,7 +561,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -575,7 +575,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -589,7 +589,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -603,7 +603,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -617,7 +617,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-expression'}],
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -631,7 +631,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -645,7 +645,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-expression'}],
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -659,7 +659,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -673,7 +673,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -687,7 +687,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
     code: [
@@ -704,7 +704,7 @@ ruleTester.run('function-component-definition', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     options: [{unnamedComponents: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
@@ -722,7 +722,7 @@ ruleTester.run('function-component-definition', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     options: [{unnamedComponents: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
@@ -740,7 +740,7 @@ ruleTester.run('function-component-definition', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     options: [{unnamedComponents: 'function-expression'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
@@ -758,7 +758,7 @@ ruleTester.run('function-component-definition', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     options: [{unnamedComponents: 'arrow-function'}],
     parser: parsers.TYPESCRIPT_ESLINT
   }, {
@@ -776,7 +776,7 @@ ruleTester.run('function-component-definition', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{message: 'Function component is not a function expression'}],
+    errors: [{messageId: 'function-expression'}],
     options: [{unnamedComponents: 'function-expression'}],
     parser: parsers.TYPESCRIPT_ESLINT
   },
@@ -792,7 +792,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.BABEL_ESLINT
   }, {
     code: [
@@ -806,7 +806,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.BABEL_ESLINT
   }, {
     code: [
@@ -820,7 +820,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'function-declaration'}],
-    errors: [{message: 'Function component is not a function declaration'}],
+    errors: [{messageId: 'function-declaration'}],
     parser: parsers.BABEL_ESLINT
   },
   {
@@ -835,7 +835,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{namedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.BABEL_ESLINT
   }, {
     code: [
@@ -849,7 +849,7 @@ ruleTester.run('function-component-definition', rule, {
       '}'
     ].join('\n'),
     options: [{unnamedComponents: 'arrow-function'}],
-    errors: [{message: 'Function component is not an arrow function'}],
+    errors: [{messageId: 'arrow-function'}],
     parser: parsers.BABEL_ESLINT
   }]
 });

--- a/tests/lib/rules/jsx-boolean-value.js
+++ b/tests/lib/rules/jsx-boolean-value.js
@@ -37,35 +37,49 @@ ruleTester.run('jsx-boolean-value', rule, {
     code: '<App foo={true} />;',
     output: '<App foo />;',
     options: ['never'],
-    errors: [{message: 'Value must be omitted for boolean attributes'}]
+    errors: [{
+      messageId: 'omitBoolean_noMessage'
+    }]
   }, {
     code: '<App foo={true} bar={true} baz={true} />;',
     output: '<App foo bar baz={true} />;',
     options: ['always', {never: ['foo', 'bar']}],
-    errors: [
-      {message: 'Value must be omitted for boolean attributes for the following props: `foo`, `bar`'},
-      {message: 'Value must be omitted for boolean attributes for the following props: `foo`, `bar`'}
-    ]
+    errors: [{
+      messageId: 'omitBoolean',
+      data: {exceptionsMessage: ' for the following props: `foo`, `bar`'}
+    }, {
+      messageId: 'omitBoolean',
+      data: {exceptionsMessage: ' for the following props: `foo`, `bar`'}
+    }]
   }, {
     code: '<App foo={true} />;',
     output: '<App foo />;',
-    errors: [{message: 'Value must be omitted for boolean attributes'}]
+    errors: [{
+      messageId: 'omitBoolean_noMessage'
+    }]
   }, {
     code: '<App foo = {true} />;',
     output: '<App foo />;',
-    errors: [{message: 'Value must be omitted for boolean attributes'}]
+    errors: [{
+      messageId: 'omitBoolean_noMessage'
+    }]
   }, {
     code: '<App foo />;',
     output: '<App foo={true} />;',
     options: ['always'],
-    errors: [{message: 'Value must be set for boolean attributes'}]
+    errors: [{
+      messageId: 'setBoolean_noMessage'
+    }]
   }, {
     code: '<App foo bar baz />;',
     output: '<App foo={true} bar={true} baz />;',
     options: ['never', {always: ['foo', 'bar']}],
-    errors: [
-      {message: 'Value must be set for boolean attributes for the following props: `foo`, `bar`'},
-      {message: 'Value must be set for boolean attributes for the following props: `foo`, `bar`'}
-    ]
+    errors: [{
+      messageId: 'setBoolean',
+      data: {exceptionsMessage: ' for the following props: `foo`, `bar`'}
+    }, {
+      messageId: 'setBoolean',
+      data: {exceptionsMessage: ' for the following props: `foo`, `bar`'}
+    }]
   }]
 });

--- a/tests/lib/rules/jsx-child-element-spacing.js
+++ b/tests/lib/rules/jsx-child-element-spacing.js
@@ -150,7 +150,8 @@ ruleTester.run('jsx-child-element-spacing', rule, {
     `,
     errors: [
       {
-        message: 'Ambiguous spacing before next element a',
+        messageId: 'spacingBeforeNext',
+        data: {element: 'a'},
         line: 4,
         column: 3
       }
@@ -165,7 +166,8 @@ ruleTester.run('jsx-child-element-spacing', rule, {
     parser: parsers.BABEL_ESLINT,
     errors: [
       {
-        message: 'Ambiguous spacing before next element a',
+        messageId: 'spacingBeforeNext',
+        data: {element: 'a'},
         line: 4,
         column: 3
       }
@@ -179,7 +181,8 @@ ruleTester.run('jsx-child-element-spacing', rule, {
     `,
     errors: [
       {
-        message: 'Ambiguous spacing after previous element a',
+        messageId: 'spacingAfterPrev',
+        data: {element: 'a'},
         line: 3,
         column: 13
       }
@@ -193,7 +196,8 @@ ruleTester.run('jsx-child-element-spacing', rule, {
     `,
     errors: [
       {
-        message: 'Ambiguous spacing after previous element a',
+        messageId: 'spacingAfterPrev',
+        data: {element: 'a'},
         line: 3,
         column: 18
       }
@@ -207,7 +211,8 @@ ruleTester.run('jsx-child-element-spacing', rule, {
     `,
     errors: [
       {
-        message: 'Ambiguous spacing before next element a',
+        messageId: 'spacingBeforeNext',
+        data: {element: 'a'},
         line: 4,
         column: 3
       }
@@ -221,7 +226,8 @@ ruleTester.run('jsx-child-element-spacing', rule, {
     `,
     errors: [
       {
-        message: 'Ambiguous spacing before next element code',
+        messageId: 'spacingBeforeNext',
+        data: {element: 'code'},
         line: 4,
         column: 3
       }
@@ -236,12 +242,14 @@ ruleTester.run('jsx-child-element-spacing', rule, {
     `,
     errors: [
       {
-        message: 'Ambiguous spacing before next element a',
+        messageId: 'spacingBeforeNext',
+        data: {element: 'a'},
         line: 4,
         column: 3
       },
       {
-        message: 'Ambiguous spacing before next element a',
+        messageId: 'spacingBeforeNext',
+        data: {element: 'a'},
         line: 5,
         column: 3
       }

--- a/tests/lib/rules/jsx-closing-bracket-location.js
+++ b/tests/lib/rules/jsx-closing-bracket-location.js
@@ -19,16 +19,16 @@ const parserOptions = {
     jsx: true
   }
 };
-const MESSAGE_AFTER_PROPS = [{message: 'The closing bracket must be placed after the last prop'}];
-const MESSAGE_AFTER_TAG = [{message: 'The closing bracket must be placed after the opening tag'}];
 
-const MESSAGE_PROPS_ALIGNED = 'The closing bracket must be aligned with the last prop';
-const MESSAGE_TAG_ALIGNED = 'The closing bracket must be aligned with the opening tag';
-const MESSAGE_LINE_ALIGNED = 'The closing bracket must be aligned with the line containing the opening tag';
+const MESSAGE_AFTER_PROPS = 'placed after the last prop';
+const MESSAGE_AFTER_TAG = 'placed after the opening tag';
 
-function messageWithDetails(message, expectedColumn, expectedNextLine) {
-  const details = ` (expected column ${expectedColumn}${expectedNextLine ? ' on the next line)' : ')'}`;
-  return message + details;
+const MESSAGE_PROPS_ALIGNED = 'aligned with the last prop';
+const MESSAGE_TAG_ALIGNED = 'aligned with the opening tag';
+const MESSAGE_LINE_ALIGNED = 'aligned with the line containing the opening tag';
+
+function details(expectedColumn, expectedNextLine) {
+  return ` (expected column ${expectedColumn}${expectedNextLine ? ' on the next line)' : ')'}`;
 }
 
 // ------------------------------------------------------------------------------
@@ -664,7 +664,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     output: [
       '<App />'
     ].join('\n'),
-    errors: MESSAGE_AFTER_TAG
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_TAG}
+    }]
   }, {
     code: [
       '<App foo ',
@@ -673,7 +676,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     output: [
       '<App foo/>'
     ].join('\n'),
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App foo',
@@ -682,7 +688,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     output: [
       '<App foo></App>'
     ].join('\n'),
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App ',
@@ -695,7 +704,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_PROPS_ALIGNED,
+        details: details(3, true)
+      },
       line: 2,
       column: 7
     }]
@@ -711,7 +724,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, true)
+      },
       line: 2,
       column: 7
     }]
@@ -727,7 +744,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(1, true)
+      },
       line: 2,
       column: 7
     }]
@@ -742,7 +763,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '  foo/>'
     ].join('\n'),
     options: [{location: 'after-props'}],
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App ',
@@ -756,7 +780,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_PROPS_ALIGNED,
+        details: details(3, false)
+      },
       line: 3,
       column: 1
     }]
@@ -771,7 +799,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '  foo/>'
     ].join('\n'),
     options: [{location: 'after-props'}],
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App ',
@@ -785,7 +816,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 3
     }]
@@ -802,7 +837,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 3
     }]
@@ -817,7 +856,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '  foo></App>'
     ].join('\n'),
     options: [{location: 'after-props'}],
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App',
@@ -831,7 +873,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_PROPS_ALIGNED,
+        details: details(3, false)
+      },
       line: 3,
       column: 1
     }]
@@ -846,7 +892,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '  foo></App>'
     ].join('\n'),
     options: [{location: 'after-props'}],
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App',
@@ -860,7 +909,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 3
     }]
@@ -877,7 +930,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 3
     }]
@@ -901,7 +958,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{selfClosing: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, true)
+      },
       line: 2,
       column: 8
     }]
@@ -932,7 +993,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: ['props-aligned'],
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 7, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_PROPS_ALIGNED,
+        details: details(7, false)
+      },
       line: 6,
       column: 37
     }]
@@ -963,7 +1028,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: ['tag-aligned'],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 5, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(5, false)
+      },
       line: 6,
       column: 37
     }]
@@ -994,7 +1063,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: ['line-aligned'],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 5, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(5, false)
+      },
       line: 6,
       column: 37
     }]
@@ -1019,7 +1092,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{nonEmpty: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(3, false)
+      },
       line: 6,
       column: 5
     }]
@@ -1041,7 +1118,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{selfClosing: 'after-props'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, true)
+      },
       line: 2,
       column: 8
     }]
@@ -1064,7 +1145,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{nonEmpty: 'after-props'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(3, false)
+      },
       line: 5,
       column: 5
     }]
@@ -1085,7 +1170,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(3, false)
+      },
       line: 4,
       column: 10
     }]
@@ -1102,7 +1191,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 9
     }]
@@ -1124,7 +1217,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(3, true)
+      },
       line: 4,
       column: 16
     }]
@@ -1144,7 +1241,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(3, true)
+      },
       line: 3,
       column: 23
     }]
@@ -1161,7 +1262,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       ')'
     ].join('\n'),
     options: [{location: 'line-aligned'}],
-    errors: MESSAGE_AFTER_TAG
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_TAG}
+    }]
   }, {
     code: [
       '<div className={[',
@@ -1182,7 +1286,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, true)
+      },
       line: 4,
       column: 7
     }]
@@ -1198,7 +1306,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 2, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_PROPS_ALIGNED,
+        details: details(2, true)
+      },
       line: 2,
       column: 6
     }]
@@ -1214,7 +1326,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, true)
+      },
       line: 2,
       column: 6
     }]
@@ -1230,7 +1346,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(1, true)
+      },
       line: 2,
       column: 6
     }]
@@ -1245,7 +1365,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '\tfoo/>'
     ].join('\n'),
     options: [{location: 'after-props'}],
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App ',
@@ -1259,7 +1382,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 2, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_PROPS_ALIGNED,
+        details: details(2, false)
+      },
       line: 3,
       column: 1
     }]
@@ -1274,7 +1401,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '\tfoo/>'
     ].join('\n'),
     options: [{location: 'after-props'}],
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App ',
@@ -1288,7 +1418,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 2
     }]
@@ -1305,7 +1439,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 2
     }]
@@ -1320,7 +1458,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '\tfoo></App>'
     ].join('\n'),
     options: [{location: 'after-props'}],
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App',
@@ -1334,7 +1475,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 2, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_PROPS_ALIGNED,
+        details: details(2, false)
+      },
       line: 3,
       column: 1
     }]
@@ -1349,7 +1494,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       '\tfoo></App>'
     ].join('\n'),
     options: [{location: 'after-props'}],
-    errors: MESSAGE_AFTER_PROPS
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_PROPS}
+    }]
   }, {
     code: [
       '<App',
@@ -1363,7 +1511,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 2
     }]
@@ -1380,7 +1532,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 2
     }]
@@ -1404,7 +1560,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{selfClosing: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, true)
+      },
       line: 2,
       column: 7
     }]
@@ -1435,7 +1595,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: ['props-aligned'],
     errors: [{
-      message: messageWithDetails(MESSAGE_PROPS_ALIGNED, 4, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_PROPS_ALIGNED,
+        details: details(4, false)
+      },
       line: 6,
       column: 19
     }]
@@ -1466,7 +1630,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: ['tag-aligned'],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(3, false)
+      },
       line: 6,
       column: 19
     }]
@@ -1497,7 +1665,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: ['line-aligned'],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(3, false)
+      },
       line: 6,
       column: 19
     }]
@@ -1522,7 +1694,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{nonEmpty: 'props-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 2, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(2, false)
+      },
       line: 6,
       column: 3
     }]
@@ -1544,7 +1720,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{selfClosing: 'after-props'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, true)
+      },
       line: 2,
       column: 7
     }]
@@ -1567,7 +1747,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{nonEmpty: 'after-props'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 2, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(2, false)
+      },
       line: 5,
       column: 3
     }]
@@ -1588,7 +1772,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 2, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(2, false)
+      },
       line: 4,
       column: 6
     }]
@@ -1605,7 +1793,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 1, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(1, false)
+      },
       line: 3,
       column: 9
     }]
@@ -1627,7 +1819,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 2, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(2, true)
+      },
       line: 4,
       column: 14
     }]
@@ -1647,7 +1843,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'line-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_LINE_ALIGNED, 2, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_LINE_ALIGNED,
+        details: details(2, true)
+      },
       line: 3,
       column: 21
     }]
@@ -1664,7 +1864,10 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
       ')'
     ].join('\n'),
     options: [{location: 'line-aligned'}],
-    errors: MESSAGE_AFTER_TAG
+    errors: [{
+      messageId: 'bracketLocation',
+      data: {location: MESSAGE_AFTER_TAG}
+    }]
   }, {
     code: [
       '<div className={[',
@@ -1685,7 +1888,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 1, true),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(1, true)
+      },
       line: 4,
       column: 6
     }]
@@ -1706,7 +1913,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(3, false)
+      },
       line: 3,
       column: 3
     }]
@@ -1727,7 +1938,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(3, false)
+      },
       line: 3,
       column: 3
     }]
@@ -1744,7 +1959,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(3, false)
+      },
       line: 3,
       column: 3
     }]
@@ -1761,7 +1980,11 @@ ruleTester.run('jsx-closing-bracket-location', rule, {
     ].join('\n'),
     options: [{location: 'tag-aligned'}],
     errors: [{
-      message: messageWithDetails(MESSAGE_TAG_ALIGNED, 3, false),
+      messageId: 'bracketLocation',
+      data: {
+        location: MESSAGE_TAG_ALIGNED,
+        details: details(3, false)
+      },
       line: 3,
       column: 3
     }]

--- a/tests/lib/rules/jsx-closing-tag-location.js
+++ b/tests/lib/rules/jsx-closing-tag-location.js
@@ -22,9 +22,6 @@ const parserOptions = {
   }
 };
 
-const MESSAGE_MATCH_INDENTATION = [{message: 'Expected closing tag to match indentation of opening.'}];
-const MESSAGE_OWN_LINE = [{message: 'Closing tag of a multiline JSX expression must be on its own line.'}];
-
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -66,7 +63,7 @@ ruleTester.run('jsx-closing-tag-location', rule, {
         foo
       </App>
     `,
-    errors: MESSAGE_MATCH_INDENTATION
+    errors: [{messageId: 'matchIndent'}]
   }, {
     code: `
       <App>
@@ -77,7 +74,7 @@ ruleTester.run('jsx-closing-tag-location', rule, {
         foo
       </App>
     `,
-    errors: MESSAGE_OWN_LINE
+    errors: [{messageId: 'onOwnLine'}]
   }, {
     code: `
       <>
@@ -90,7 +87,7 @@ ruleTester.run('jsx-closing-tag-location', rule, {
         foo
       </>
     `,
-    errors: MESSAGE_MATCH_INDENTATION
+    errors: [{messageId: 'matchIndent'}]
   }, {
     code: `
       <>
@@ -102,6 +99,6 @@ ruleTester.run('jsx-closing-tag-location', rule, {
         foo
       </>
     `,
-    errors: MESSAGE_OWN_LINE
+    errors: [{messageId: 'onOwnLine'}]
   }]
 });

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -24,9 +24,6 @@ const parserOptions = {
   }
 };
 
-const missingCurlyMessage = 'Need to wrap this literal in a JSX expression.';
-const unnecessaryCurlyMessage = 'Curly braces are unnecessary here.';
-
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -447,59 +444,59 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       code: '<App prop={`foo`} />',
       output: '<App prop="foo" />',
       options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: '<App>{<myApp></myApp>}</App>',
       output: '<App><myApp></myApp></App>',
       options: [{children: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: '<App>{<myApp></myApp>}</App>',
       output: '<App><myApp></myApp></App>',
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: '<App prop={`foo`}>foo</App>',
       output: '<App prop="foo">foo</App>',
       options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: '<App>{`foo`}</App>',
       output: '<App>foo</App>',
       options: [{children: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: '<>{`foo`}</>',
       output: '<>foo</>',
       parser: parsers.BABEL_ESLINT,
       options: [{children: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: `<MyComponent>{'foo'}</MyComponent>`,
       output: '<MyComponent>foo</MyComponent>',
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: `<MyComponent prop={'bar'}>foo</MyComponent>`,
       output: `<MyComponent prop="bar">foo</MyComponent>`,
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: `<MyComponent>{'foo'}</MyComponent>`,
       output: '<MyComponent>foo</MyComponent>',
       options: [{children: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: `<MyComponent prop={'bar'}>foo</MyComponent>`,
       output: '<MyComponent prop="bar">foo</MyComponent>',
       options: [{props: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: `
@@ -514,7 +511,7 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       options: [{children: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}]
     },
     {
       code: `
@@ -538,9 +535,9 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       parser: parsers.BABEL_ESLINT,
       options: [{children: 'never'}],
       errors: [
-        {message: unnecessaryCurlyMessage},
-        {message: unnecessaryCurlyMessage},
-        {message: unnecessaryCurlyMessage}
+        {messageId: 'unnecessaryCurly'},
+        {messageId: 'unnecessaryCurly'},
+        {messageId: 'unnecessaryCurly'}
       ]
     },
     {
@@ -566,93 +563,93 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       options: [{children: 'never'}],
-      errors: [{message: unnecessaryCurlyMessage}, {message: unnecessaryCurlyMessage}]
+      errors: [{messageId: 'unnecessaryCurly'}, {messageId: 'unnecessaryCurly'}]
     },
     {
       code: `<MyComponent prop='bar'>foo</MyComponent>`,
       output: '<MyComponent prop={"bar"}>foo</MyComponent>',
       options: [{props: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: `<MyComponent prop="foo 'bar'">foo</MyComponent>`,
       output: `<MyComponent prop={"foo 'bar'"}>foo</MyComponent>`,
       options: [{props: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: `<MyComponent prop='foo "bar"'>foo</MyComponent>`,
       output: `<MyComponent prop={"foo \\"bar\\""}>foo</MyComponent>`,
       options: [{props: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: `<MyComponent prop="foo 'bar'">foo</MyComponent>`,
       output: `<MyComponent prop={"foo 'bar'"}>foo</MyComponent>`,
       options: [{props: 'always'}],
-      errors: [{message: missingCurlyMessage}],
+      errors: [{messageId: 'missingCurly'}],
       parser: parsers.BABEL_ESLINT
     },
     {
       code: '<MyComponent>foo bar </MyComponent>',
       output: `<MyComponent>{"foo bar "}</MyComponent>`,
       options: [{children: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: `<MyComponent prop="foo 'bar' \\n ">foo</MyComponent>`,
       output: `<MyComponent prop={"foo 'bar' \\\\n "}>foo</MyComponent>`,
       options: [{props: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: '<MyComponent>foo bar \\r </MyComponent>',
       output: '<MyComponent>{"foo bar \\\\r "}</MyComponent>',
       options: [{children: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: `<MyComponent>foo bar 'foo'</MyComponent>`,
       output: `<MyComponent>{"foo bar 'foo'"}</MyComponent>`,
       options: [{children: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: '<MyComponent>foo bar "foo"</MyComponent>',
       output: '<MyComponent>{"foo bar \\"foo\\""}</MyComponent>',
       options: [{children: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: '<MyComponent>foo bar <App/></MyComponent>',
       output: '<MyComponent>{"foo bar "}<App/></MyComponent>',
       options: [{children: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: '<MyComponent>foo \\n bar</MyComponent>',
       output: '<MyComponent>{"foo \\\\n bar"}</MyComponent>',
       options: [{children: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: '<MyComponent>foo \\u1234 bar</MyComponent>',
       output: '<MyComponent>{"foo \\\\u1234 bar"}</MyComponent>',
       options: [{children: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: `<MyComponent prop='foo \\u1234 bar' />`,
       output: '<MyComponent prop={"foo \\\\u1234 bar"} />',
       options: [{props: 'always'}],
-      errors: [{message: missingCurlyMessage}]
+      errors: [{messageId: 'missingCurly'}]
     },
     {
       code: `<MyComponent prop={'bar'}>{'foo'}</MyComponent>`,
       output: '<MyComponent prop="bar">foo</MyComponent>',
       options: ['never'],
       errors: [
-        {message: unnecessaryCurlyMessage}, {message: unnecessaryCurlyMessage}
+        {messageId: 'unnecessaryCurly'}, {messageId: 'unnecessaryCurly'}
       ]
     },
     {
@@ -660,14 +657,14 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       output: '<MyComponent prop={"bar"}>{"foo"}</MyComponent>',
       options: ['always'],
       errors: [
-        {message: missingCurlyMessage}, {message: missingCurlyMessage}
+        {messageId: 'missingCurly'}, {messageId: 'missingCurly'}
       ]
     },
     {
       code: `<App prop={'foo'} attr={" foo "} />`,
       output: '<App prop="foo" attr=" foo " />',
       errors: [
-        {message: unnecessaryCurlyMessage}, {message: unnecessaryCurlyMessage}
+        {messageId: 'unnecessaryCurly'}, {messageId: 'unnecessaryCurly'}
       ],
       options: [{props: 'never'}]
     },
@@ -675,44 +672,44 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       code: `<App prop='foo' attr="bar" />`,
       output: '<App prop={"foo"} attr={"bar"} />',
       errors: [
-        {message: missingCurlyMessage}, {message: missingCurlyMessage}
+        {messageId: 'missingCurly'}, {messageId: 'missingCurly'}
       ],
       options: [{props: 'always'}]
     },
     {
       code: `<App prop='foo' attr={"bar"} />`,
       output: `<App prop={"foo"} attr={"bar"} />`,
-      errors: [{message: missingCurlyMessage}],
+      errors: [{messageId: 'missingCurly'}],
       options: [{props: 'always'}]
     },
     {
       code: `<App prop={'foo'} attr='bar' />`,
       output: `<App prop={'foo'} attr={"bar"} />`,
-      errors: [{message: missingCurlyMessage}],
+      errors: [{messageId: 'missingCurly'}],
       options: [{props: 'always'}]
     },
     {
       code: `<App prop='foo &middot; bar' />`,
-      errors: [{message: missingCurlyMessage}],
+      errors: [{messageId: 'missingCurly'}],
       options: [{props: 'always'}],
       output: `<App prop={"foo &middot; bar"} />`
     },
     {
       code: '<App>foo &middot; bar</App>',
-      errors: [{message: missingCurlyMessage}],
+      errors: [{messageId: 'missingCurly'}],
       options: [{children: 'always'}],
       output: '<App>{"foo &middot; bar"}</App>'
     },
     {
       code: `<App>{'foo "bar"'}</App>`,
       output: `<App>foo "bar"</App>`,
-      errors: [{message: unnecessaryCurlyMessage}],
+      errors: [{messageId: 'unnecessaryCurly'}],
       options: [{children: 'never'}]
     },
     {
       code: `<App>{"foo 'bar'"}</App>`,
       output: `<App>foo 'bar'</App>`,
-      errors: [{message: unnecessaryCurlyMessage}],
+      errors: [{messageId: 'unnecessaryCurly'}],
       options: [{children: 'never'}]
     },
     {
@@ -728,7 +725,7 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
         '</App>'
       ].join('\n'),
       errors: [
-        {message: missingCurlyMessage}, {message: missingCurlyMessage}
+        {messageId: 'missingCurly'}, {messageId: 'missingCurly'}
       ],
       options: ['always'],
       output: [
@@ -756,7 +753,7 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
         '</App>'
       ].join('\n'),
       errors: [
-        {message: missingCurlyMessage}, {message: missingCurlyMessage}
+        {messageId: 'missingCurly'}, {messageId: 'missingCurly'}
       ],
       options: ['always'],
       output: [
@@ -797,11 +794,11 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
         </App>
       `,
       errors: [
-        {message: missingCurlyMessage},
-        {message: missingCurlyMessage},
-        {message: missingCurlyMessage},
-        {message: missingCurlyMessage},
-        {message: missingCurlyMessage}
+        {messageId: 'missingCurly'},
+        {messageId: 'missingCurly'},
+        {messageId: 'missingCurly'},
+        {messageId: 'missingCurly'},
+        {messageId: 'missingCurly'}
       ],
       options: [{children: 'always'}]
     },
@@ -821,7 +818,7 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
         </App>
       `,
       errors: [
-        {message: missingCurlyMessage}
+        {messageId: 'missingCurly'}
       ],
       options: [{children: 'always'}]
     },
@@ -833,7 +830,7 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
         <Box mb="1rem" />
       `,
       errors: [
-        {message: unnecessaryCurlyMessage}
+        {messageId: 'unnecessaryCurly'}
       ],
       options: [{props: 'never'}]
     },
@@ -844,19 +841,19 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       output: `
         <Box mb="1rem {}" />
       `,
-      errors: [{message: unnecessaryCurlyMessage}],
+      errors: [{messageId: 'unnecessaryCurly'}],
       options: ['never']
     },
     {
       code: '<MyComponent prop={"{ style: true }"}>bar</MyComponent>',
       output: '<MyComponent prop="{ style: true }">bar</MyComponent>',
-      errors: [{message: unnecessaryCurlyMessage}],
+      errors: [{messageId: 'unnecessaryCurly'}],
       options: ['never']
     },
     {
       code: '<MyComponent prop={"< style: true >"}>foo</MyComponent>',
       output: '<MyComponent prop="< style: true >">foo</MyComponent>',
-      errors: [{message: unnecessaryCurlyMessage}],
+      errors: [{messageId: 'unnecessaryCurly'}],
       options: ['never']
     }
   ]

--- a/tests/lib/rules/jsx-curly-spacing.js
+++ b/tests/lib/rules/jsx-curly-spacing.js
@@ -692,60 +692,74 @@ ruleTester.run('jsx-curly-spacing', rule, {
     code: '<App foo={ bar }>{bar}</App>;',
     output: '<App foo={bar}>{bar}</App>;',
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar }>{ bar }</App>;',
     output: '<App foo={bar}>{ bar }</App>;',
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ { bar: true, baz: true } }>{{ bar: true, baz: true }}</App>;',
     output: '<App foo={{ bar: true, baz: true }}>{{ bar: true, baz: true }}</App>;',
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ { bar: true, baz: true } }>{ { bar: true, baz: true } }</App>;',
     output: '<App foo={{ bar: true, baz: true }}>{ { bar: true, baz: true } }</App>;',
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } />;',
     output: '<App foo={bar} />;',
     options: [{attributes: true}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ { bar: true, baz: true } } />;',
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: [{attributes: true}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar }</App>;',
     output: '<App>{bar}</App>;',
     options: [{children: true}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<>{ bar }</>;',
@@ -753,27 +767,33 @@ ruleTester.run('jsx-curly-spacing', rule, {
     parser: parsers.BABEL_ESLINT,
     options: [{children: true}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ { bar: true, baz: true } }</App>;',
     output: '<App>{{ bar: true, baz: true }}</App>;',
     options: [{children: true}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } />;',
     output: '<App foo={bar} />;',
     options: [{when: 'never'}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -784,18 +804,22 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={bar} />;',
     options: [{when: 'never', allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ { bar: true, baz: true } } />;',
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: [{when: 'never', spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -806,18 +830,22 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: [{when: 'never', allowMultiline: false, spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={{ bar: true, baz: true }} />;',
     output: '<App foo={ { bar: true, baz: true } } />;',
     options: [{when: 'never', spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -828,18 +856,22 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ { bar: true, baz: true } } />;',
     options: [{when: 'never', allowMultiline: false, spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} />;',
     output: '<App foo={ bar } />;',
     options: [{when: 'always'}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -850,18 +882,22 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ bar } />;',
     options: [{when: 'always', allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ { bar: true, baz: true } } />;',
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: [{when: 'always', spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -872,18 +908,22 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: [{when: 'always', allowMultiline: false, spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={{ bar: true, baz: true }} />;',
     output: '<App foo={ { bar: true, baz: true } } />;',
     options: [{when: 'always', spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -894,18 +934,22 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ { bar: true, baz: true } } />;',
     options: [{when: 'always', allowMultiline: false, spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } />;',
     output: '<App foo={bar} />;',
     options: [{attributes: true, when: 'never'}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -916,36 +960,44 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={bar} />;',
     options: [{attributes: true, when: 'never', allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ { bar: true, baz: true } } />;',
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: [{attributes: true, when: 'never', spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={{ bar: true, baz: true }} />;',
     output: '<App foo={ { bar: true, baz: true } } />;',
     options: [{attributes: true, when: 'never', spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} />;',
     output: '<App foo={ bar } />;',
     options: [{attributes: true, when: 'always'}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -956,91 +1008,109 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ bar } />;',
     options: [{attributes: true, when: 'always', allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ { bar: true, baz: true } } />;',
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: [{attributes: true, when: 'always', spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={{ bar: true, baz: true }} />;',
     output: '<App foo={ { bar: true, baz: true } } />;',
     options: [{attributes: true, when: 'always', spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } />;',
     output: '<App foo={bar} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } />;',
     output: '<App foo={bar} />;',
     options: [{attributes: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} />;',
     output: '<App foo={ bar } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} />;',
     output: '<App foo={ bar } />;',
     options: [{attributes: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar} />;',
     output: '<App foo={ bar } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar } />;',
     output: '<App foo={ bar } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={ bar} />;',
     output: '<App foo={bar} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={bar } />;',
     output: '<App foo={bar} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1051,9 +1121,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={bar} />;',
     options: [{attributes: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1064,50 +1136,60 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ bar } />;',
     options: [{attributes: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} />;',
     output: '<App foo={ bar } />;',
     options: [{attributes: {when: 'always', spacing: {}}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar} />;',
     output: '<App foo={ bar } />;',
     options: [{attributes: {when: 'always', spacing: {}}}],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar } />;',
     output: '<App foo={ bar } />;',
     options: [{attributes: {when: 'always', spacing: {}}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={ {bar: true, baz: true} } />;',
     output: '<App foo={{bar: true, baz: true}} />;',
     options: [{attributes: {when: 'always', spacing: {objectLiterals: 'never'}}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar }</App>;',
     output: '<App>{bar}</App>;',
     options: [{children: true, when: 'never'}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1118,36 +1200,44 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App>{bar}</App>;',
     options: [{children: true, when: 'never', allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ { bar: true, baz: true } }</App>;',
     output: '<App>{{ bar: true, baz: true }}</App>;',
     options: [{children: true, when: 'never', spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{{ bar: true, baz: true }}</App>;',
     output: '<App>{ { bar: true, baz: true } }</App>;',
     options: [{children: true, when: 'never', spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar}</App>;',
     output: '<App>{ bar }</App>;',
     options: [{children: true, when: 'always'}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1158,91 +1248,109 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App>{ bar }</App>;',
     options: [{children: true, when: 'always', allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ { bar: true, baz: true } }</App>;',
     output: '<App>{{ bar: true, baz: true }}</App>;',
     options: [{children: true, when: 'always', spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{{ bar: true, baz: true }}</App>;',
     output: '<App>{ { bar: true, baz: true } }</App>;',
     options: [{children: true, when: 'always', spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar }</App>;',
     output: '<App>{bar}</App>;',
     options: [{children: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar }</App>;',
     output: '<App>{bar}</App>;',
     options: [{children: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar}</App>;',
     output: '<App>{ bar }</App>;',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar}</App>;',
     output: '<App>{ bar }</App>;',
     options: [{children: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar}</App>;',
     output: '<App>{ bar }</App>;',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar }</App>;',
     output: '<App>{ bar }</App>;',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App>{ bar}</App>;',
     output: '<App>{bar}</App>;',
     options: [{children: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App>{bar }</App>;',
     output: '<App>{bar}</App>;',
     options: [{children: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1253,9 +1361,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App>{bar}</App>;',
     options: [{children: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1266,105 +1376,125 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App>{ bar }</App>;',
     options: [{children: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar}</App>;',
     output: '<App>{ bar }</App>;',
     options: [{children: {when: 'always', spacing: {}}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar}</App>;',
     output: '<App>{ bar }</App>;',
     options: [{children: {when: 'always', spacing: {}}}],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar }</App>;',
     output: '<App>{ bar }</App>;',
     options: [{children: {when: 'always', spacing: {}}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App>{ {bar: true, baz: true} }</App>;',
     output: '<App>{{bar: true, baz: true}}</App>;',
     options: [{children: {when: 'always', spacing: {objectLiterals: 'never'}}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App { ...bar } />;',
     output: '<App {...bar} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App { ...bar } />;',
     output: '<App {...bar} />;',
     options: [{attributes: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App {...bar} />;',
     output: '<App { ...bar } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App {...bar} />;',
     output: '<App { ...bar } />;',
     options: [{attributes: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App { ...bar} />;',
     output: '<App { ...bar } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App {...bar } />;',
     output: '<App { ...bar } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App { ...bar} />;',
     output: '<App {...bar} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App {...bar } />;',
     output: '<App {...bar} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1375,9 +1505,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App {...bar} />;',
     options: [{attributes: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1388,97 +1520,123 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App { ...bar } />;',
     options: [{attributes: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } { ...baz } />;',
     output: '<App foo={bar} {...baz} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } { ...baz } />;',
     output: '<App foo={bar} {...baz} />;',
     options: [{attributes: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} {...baz} />;',
     output: '<App foo={ bar } { ...baz } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} {...baz} />;',
     output: '<App foo={ bar } { ...baz } />;',
     options: [{attributes: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar} { ...baz} />;',
     output: '<App foo={ bar } { ...baz } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar } {...baz } />;',
     output: '<App foo={ bar } { ...baz } />;',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={ bar} { ...baz} />;',
     output: '<App foo={bar} {...baz} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={bar } {...baz } />;',
     output: '<App foo={bar} {...baz} />;',
     options: [{attributes: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1491,13 +1649,17 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={bar} {...baz} />;',
     options: [{attributes: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1510,148 +1672,188 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ bar } { ...baz } />;',
     options: [{attributes: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ 3 } bar={{a: 2}} />',
     output: '<App foo={3} bar={ {a: 2} } />',
     options: [{attributes: {when: 'never', spacing: {objectLiterals: 'always'}}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ foo /* comment 16 */ } />',
     output: '<App foo={foo /* comment 16 */} />',
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={foo /* comment 17 */} />',
     output: '<App foo={ foo /* comment 17 */ } />',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ /* comment 18 */ foo } />',
     output: '<App foo={/* comment 18 */ foo} />',
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={/* comment 19 */ foo} />',
     output: '<App foo={ /* comment 19 */ foo } />',
     options: [{attributes: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar } { baz }</App>;',
     output: '<App>{bar} {baz}</App>;',
     options: [{children: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar } { baz }</App>;',
     output: '<App>{bar} {baz}</App>;',
     options: [{children: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar} {baz}</App>;',
     output: '<App>{ bar } { baz }</App>;',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar} {baz}</App>;',
     output: '<App>{ bar } { baz }</App>;',
     options: [{children: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ bar} { baz}</App>;',
     output: '<App>{ bar } { baz }</App>;',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{bar } {baz }</App>;',
     output: '<App>{ bar } { baz }</App>;',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App>{ bar} { baz}</App>;',
     output: '<App>{bar} {baz}</App>;',
     options: [{children: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App>{bar } {baz }</App>;',
     output: '<App>{bar} {baz}</App>;',
     options: [{children: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1664,13 +1866,17 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App>{bar} {baz}</App>;',
     options: [{children: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1683,62 +1889,78 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App>{ bar } { baz }</App>;',
     options: [{children: {when: 'always', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ 3 } bar={{a: 2}}</App>',
     output: '<App>{3} bar={ {a: 2} }</App>',
     options: [{children: {when: 'never', spacing: {objectLiterals: 'always'}}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{foo /* comment 20 */}</App>',
     output: '<App>{ foo /* comment 20 */ }</App>',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{/* comment 21 */ foo}</App>',
     output: '<App>{ /* comment 21 */ foo }</App>',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } />;',
     output: '<App foo={bar} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } />;',
     output: '<App foo={bar} />;',
     options: ['never', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1749,9 +1971,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: ['never', {allowMultiline: false, spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1762,9 +1986,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ { bar: true, baz: true } } />;',
     options: ['never', {allowMultiline: false, spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1775,9 +2001,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={{ bar: true, baz: true }} />;',
     options: ['always', {allowMultiline: false, spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1788,55 +2016,65 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ { bar: true, baz: true } } />;',
     options: ['always', {allowMultiline: false, spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} />;',
     output: '<App foo={ bar } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} />;',
     output: '<App foo={ bar } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar} />;',
     output: '<App foo={ bar } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar } />;',
     output: '<App foo={ bar } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={ bar} />;',
     output: '<App foo={bar} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={bar } />;',
     output: '<App foo={bar} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1847,9 +2085,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={bar} />;',
     options: ['never', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1860,105 +2100,125 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ bar } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} />;',
     output: '<App foo={ bar } />;',
     options: ['always', {spacing: {}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar} />;',
     output: '<App foo={ bar } />;',
     options: ['always', {spacing: {}}],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar } />;',
     output: '<App foo={ bar } />;',
     options: ['always', {spacing: {}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={ {bar: true, baz: true} } />;',
     output: '<App foo={{bar: true, baz: true}} />;',
     options: ['always', {spacing: {objectLiterals: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App { ...bar } />;',
     output: '<App {...bar} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App { ...bar } />;',
     output: '<App {...bar} />;',
     options: ['never', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App {...bar} />;',
     output: '<App { ...bar } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App {...bar} />;',
     output: '<App { ...bar } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App { ...bar} />;',
     output: '<App { ...bar } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App {...bar } />;',
     output: '<App { ...bar } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App { ...bar} />;',
     output: '<App {...bar} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App {...bar } />;',
     output: '<App {...bar} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1969,9 +2229,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App {...bar} />;',
     options: ['never', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -1982,97 +2244,123 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App { ...bar } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } { ...baz } />;',
     output: '<App foo={bar} {...baz} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar } { ...baz } />;',
     output: '<App foo={bar} {...baz} />;',
     options: ['never', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} {...baz} />;',
     output: '<App foo={ bar } { ...baz } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar} {...baz} />;',
     output: '<App foo={ bar } { ...baz } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ bar} { ...baz} />;',
     output: '<App foo={ bar } { ...baz } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={bar } {...baz } />;',
     output: '<App foo={ bar } { ...baz } />;',
     options: ['always'],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={ bar} { ...baz} />;',
     output: '<App foo={bar} {...baz} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App foo={bar } {...baz } />;',
     output: '<App foo={bar} {...baz} />;',
     options: ['never'],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -2085,13 +2373,17 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={bar} {...baz} />;',
     options: ['never', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -2104,67 +2396,83 @@ ruleTester.run('jsx-curly-spacing', rule, {
     output: '<App foo={ bar } { ...baz } />;',
     options: ['always', {allowMultiline: false}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }, {
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={ 3 } bar={{a: 2}} />',
     output: '<App foo={3} bar={ {a: 2} } />',
     options: ['never', {spacing: {objectLiterals: 'always'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }, {
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={foo /* comment 22 */} />',
     output: '<App foo={ foo /* comment 22 */ } />',
     options: ['always'],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App foo={/* comment 23 */ foo} />',
     output: '<App foo={ /* comment 23 */ foo } />',
     options: ['always'],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{/*comment24*/ }</App>',
     output: '<App>{/*comment24*/}</App>',
     options: [{children: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: '<App>{ /*comment25*/}</App>',
     output: '<App>{/*comment25*/}</App>',
     options: [{children: {when: 'never'}}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }]
   }, {
     code: '<App>{/*comment26*/}</App>',
     output: '<App>{ /*comment26*/ }</App>',
     options: [{children: {when: 'always'}}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -2179,9 +2487,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     ].join('\n'),
     options: [{when: 'never', children: true}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -2196,9 +2506,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     ].join('\n'),
     options: [{when: 'always', children: true}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -2214,7 +2526,8 @@ ruleTester.run('jsx-curly-spacing', rule, {
     ].join('\n'),
     options: [{children: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline before \'}\''
+      messageId: 'noNewlineBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -2230,7 +2543,8 @@ ruleTester.run('jsx-curly-spacing', rule, {
     ].join('\n'),
     options: [{children: {when: 'never', allowMultiline: false}}],
     errors: [{
-      message: 'There should be no newline after \'{\''
+      messageId: 'noNewlineAfter',
+      data: {token: '{'}
     }]
   }, {
     code: [
@@ -2249,9 +2563,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     ].join('\n'),
     options: [{when: 'never', children: true}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -2270,9 +2586,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     ].join('\n'),
     options: [{when: 'always', children: true}],
     errors: [{
-      message: 'A space is required after \'{\''
+      messageId: 'spaceNeededAfter',
+      data: {token: '{'}
     }, {
-      message: 'A space is required before \'}\''
+      messageId: 'spaceNeededBefore',
+      data: {token: '}'}
     }]
   }, {
     code: [
@@ -2283,9 +2601,11 @@ ruleTester.run('jsx-curly-spacing', rule, {
     ].join('\n'),
     options: ['never', {allowMultiline: true}],
     errors: [{
-      message: 'There should be no space after \'{\''
+      messageId: 'noSpaceAfter',
+      data: {token: '{'}
     }, {
-      message: 'There should be no space before \'}\''
+      messageId: 'noSpaceBefore',
+      data: {token: '}'}
     }]
   }]
 });

--- a/tests/lib/rules/jsx-equals-spacing.js
+++ b/tests/lib/rules/jsx-equals-spacing.js
@@ -72,70 +72,70 @@ ruleTester.run('jsx-equals-spacing', rule, {
     code: '<App foo = {bar} />',
     output: '<App foo={bar} />',
     errors: [
-      {message: 'There should be no space before \'=\''},
-      {message: 'There should be no space after \'=\''}
+      {messageId: 'noSpaceBefore'},
+      {messageId: 'noSpaceAfter'}
     ]
   }, {
     code: '<App foo = {bar} />',
     output: '<App foo={bar} />',
     options: ['never'],
     errors: [
-      {message: 'There should be no space before \'=\''},
-      {message: 'There should be no space after \'=\''}
+      {messageId: 'noSpaceBefore'},
+      {messageId: 'noSpaceAfter'}
     ]
   }, {
     code: '<App foo ={bar} />',
     output: '<App foo={bar} />',
     options: ['never'],
     errors: [
-      {message: 'There should be no space before \'=\''}
+      {messageId: 'noSpaceBefore'}
     ]
   }, {
     code: '<App foo= {bar} />',
     output: '<App foo={bar} />',
     options: ['never'],
     errors: [
-      {message: 'There should be no space after \'=\''}
+      {messageId: 'noSpaceAfter'}
     ]
   }, {
     code: '<App foo= {bar} bar = {baz} />',
     output: '<App foo={bar} bar={baz} />',
     options: ['never'],
     errors: [
-      {message: 'There should be no space after \'=\''},
-      {message: 'There should be no space before \'=\''},
-      {message: 'There should be no space after \'=\''}
+      {messageId: 'noSpaceAfter'},
+      {messageId: 'noSpaceBefore'},
+      {messageId: 'noSpaceAfter'}
     ]
   }, {
     code: '<App foo={bar} />',
     output: '<App foo = {bar} />',
     options: ['always'],
     errors: [
-      {message: 'A space is required before \'=\''},
-      {message: 'A space is required after \'=\''}
+      {messageId: 'needSpaceBefore'},
+      {messageId: 'needSpaceAfter'}
     ]
   }, {
     code: '<App foo ={bar} />',
     output: '<App foo = {bar} />',
     options: ['always'],
     errors: [
-      {message: 'A space is required after \'=\''}
+      {messageId: 'needSpaceAfter'}
     ]
   }, {
     code: '<App foo= {bar} />',
     output: '<App foo = {bar} />',
     options: ['always'],
     errors: [
-      {message: 'A space is required before \'=\''}
+      {messageId: 'needSpaceBefore'}
     ]
   }, {
     code: '<App foo={bar} bar ={baz} />',
     output: '<App foo = {bar} bar = {baz} />',
     options: ['always'],
     errors: [
-      {message: 'A space is required before \'=\''},
-      {message: 'A space is required after \'=\''},
-      {message: 'A space is required after \'=\''}
+      {messageId: 'needSpaceBefore'},
+      {messageId: 'needSpaceAfter'},
+      {messageId: 'needSpaceAfter'}
     ]
   }]
 });

--- a/tests/lib/rules/jsx-filename-extension.js
+++ b/tests/lib/rules/jsx-filename-extension.js
@@ -81,33 +81,51 @@ ruleTester.run('jsx-filename-extension', rule, {
     {
       filename: 'MyComponent.js',
       code: withJSXElement,
-      errors: [{message: 'JSX not allowed in files with extension \'.js\''}]
+      errors: [{
+        messageId: 'noJSXWithExtension',
+        data: {ext: '.js'}
+      }]
     }, {
       filename: 'MyComponent.jsx',
       code: withoutJSX,
       options: [{allow: 'as-needed'}],
-      errors: [{message: 'Only files containing JSX may use the extension \'.jsx\''}]
+      errors: [{
+        messageId: 'extensionOnlyForJSX',
+        data: {ext: '.jsx'}
+      }]
     }, {
       filename: 'notAComponent.js',
       code: withJSXElement,
       options: [{allow: 'as-needed'}],
-      errors: [{message: 'JSX not allowed in files with extension \'.js\''}]
+      errors: [{
+        messageId: 'noJSXWithExtension',
+        data: {ext: '.js'}
+      }]
     }, {
       filename: 'MyComponent.jsx',
       code: withJSXElement,
       options: [{extensions: ['.js']}],
-      errors: [{message: 'JSX not allowed in files with extension \'.jsx\''}]
+      errors: [{
+        messageId: 'noJSXWithExtension',
+        data: {ext: '.jsx'}
+      }]
     }, {
       filename: 'MyComponent.js',
       code: withJSXFragment,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: 'JSX not allowed in files with extension \'.js\''}]
+      errors: [{
+        messageId: 'noJSXWithExtension',
+        data: {ext: '.js'}
+      }]
     }, {
       filename: 'MyComponent.jsx',
       code: withJSXFragment,
       parser: parsers.BABEL_ESLINT,
       options: [{extensions: ['.js']}],
-      errors: [{message: 'JSX not allowed in files with extension \'.jsx\''}]
+      errors: [{
+        messageId: 'noJSXWithExtension',
+        data: {ext: '.jsx'}
+      }]
     }
   ]
 

--- a/tests/lib/rules/jsx-first-prop-new-line.js
+++ b/tests/lib/rules/jsx-first-prop-new-line.js
@@ -179,7 +179,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         'propOne="one" propTwo="two" />'
       ].join('\n'),
       options: ['always'],
-      errors: [{message: 'Property should be placed on a new line'}],
+      errors: [{messageId: 'propOnNewLine'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -189,7 +189,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         'propOne="one" propTwo="two" />'
       ].join('\n'),
       options: ['always'],
-      errors: [{message: 'Property should be placed on a new line'}],
+      errors: [{messageId: 'propOnNewLine'}],
       parser: parsers.TYPESCRIPT_ESLINT
     },
     {
@@ -205,7 +205,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '/>'
       ].join('\n'),
       options: ['always'],
-      errors: [{message: 'Property should be placed on a new line'}],
+      errors: [{messageId: 'propOnNewLine'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -221,7 +221,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '/>'
       ].join('\n'),
       options: ['always'],
-      errors: [{message: 'Property should be placed on a new line'}],
+      errors: [{messageId: 'propOnNewLine'}],
       parser: parsers.TYPESCRIPT_ESLINT
     },
     {
@@ -237,7 +237,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '/>'
       ].join('\n'),
       options: ['never'],
-      errors: [{message: 'Property should be placed on the same line as the component declaration'}],
+      errors: [{messageId: 'propOnSameLine'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -253,7 +253,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '/>'
       ].join('\n'),
       options: ['never'],
-      errors: [{message: 'Property should be placed on the same line as the component declaration'}],
+      errors: [{messageId: 'propOnSameLine'}],
       parser: parsers.TYPESCRIPT_ESLINT
     },
     {
@@ -267,7 +267,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '}} />'
       ].join('\n'),
       options: ['multiline'],
-      errors: [{message: 'Property should be placed on a new line'}],
+      errors: [{messageId: 'propOnNewLine'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -281,7 +281,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '}} />'
       ].join('\n'),
       options: ['multiline'],
-      errors: [{message: 'Property should be placed on a new line'}],
+      errors: [{messageId: 'propOnNewLine'}],
       parser: parsers.TYPESCRIPT_ESLINT
     },
     {
@@ -295,7 +295,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '}} baz />'
       ].join('\n'),
       options: ['multiline-multiprop'],
-      errors: [{message: 'Property should be placed on a new line'}],
+      errors: [{messageId: 'propOnNewLine'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -309,7 +309,7 @@ ruleTester.run('jsx-first-prop-new-line', rule, {
         '}} baz />'
       ].join('\n'),
       options: ['multiline-multiprop'],
-      errors: [{message: 'Property should be placed on a new line'}],
+      errors: [{messageId: 'propOnNewLine'}],
       parser: parsers.TYPESCRIPT_ESLINT
     }
   ]

--- a/tests/lib/rules/jsx-fragments.js
+++ b/tests/lib/rules/jsx-fragments.js
@@ -99,22 +99,19 @@ ruleTester.run('jsx-fragments', rule, {
     parser: parsers.BABEL_ESLINT,
     settings: settingsOld,
     errors: [{
-      message: 'Fragments are only supported starting from React v16.2. '
-        + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
+      messageId: 'fragmentsNotSupported'
     }]
   }, {
     code: '<Act.Frag><Foo /></Act.Frag>',
     settings: settingsOld,
     errors: [{
-      message: 'Fragments are only supported starting from React v16.2. '
-        + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
+      messageId: 'fragmentsNotSupported'
     }]
   }, {
     code: '<Act.Frag />',
     settings: settingsOld,
     errors: [{
-      message: 'Fragments are only supported starting from React v16.2. '
-        + 'Please disable the `react/jsx-fragments` rule in ESLint settings or upgrade your version of React.'
+      messageId: 'fragmentsNotSupported'
     }]
   }, {
     code: '<><Foo /></>',
@@ -122,7 +119,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['element'],
     settings,
     errors: [{
-      message: 'Prefer Act.Frag over fragment shorthand'
+      messageId: 'preferPragma',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: '<Act.Frag><Foo /></Act.Frag>'
   }, {
@@ -130,7 +128,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['syntax'],
     settings,
     errors: [{
-      message: 'Prefer fragment shorthand over Act.Frag'
+      messageId: 'preferFragment',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: '<><Foo /></>'
   }, {
@@ -138,7 +137,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['syntax'],
     settings,
     errors: [{
-      message: 'Prefer fragment shorthand over Act.Frag'
+      messageId: 'preferFragment',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: '<></>'
   }, {
@@ -149,7 +149,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['syntax'],
     settings,
     errors: [{
-      message: 'Prefer fragment shorthand over Act.Frag'
+      messageId: 'preferFragment',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: `
       import Act, { Frag as F } from 'react';
@@ -163,7 +164,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['syntax'],
     settings,
     errors: [{
-      message: 'Prefer fragment shorthand over Act.Frag'
+      messageId: 'preferFragment',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: `
       import Act, { Frag as F } from 'react';
@@ -177,7 +179,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['syntax'],
     settings,
     errors: [{
-      message: 'Prefer fragment shorthand over Act.Frag'
+      messageId: 'preferFragment',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: `
       import Act, { Frag } from 'react';
@@ -191,7 +194,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['syntax'],
     settings,
     errors: [{
-      message: 'Prefer fragment shorthand over Act.Frag'
+      messageId: 'preferFragment',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: `
       const F = Act.Frag;
@@ -205,7 +209,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['syntax'],
     settings,
     errors: [{
-      message: 'Prefer fragment shorthand over Act.Frag'
+      messageId: 'preferFragment',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: `
       const { Frag } = Act;
@@ -219,7 +224,8 @@ ruleTester.run('jsx-fragments', rule, {
     options: ['syntax'],
     settings,
     errors: [{
-      message: 'Prefer fragment shorthand over Act.Frag'
+      messageId: 'preferFragment',
+      data: {react: 'Act', fragment: 'Frag'}
     }],
     output: `
       const { Frag } = require('react');

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -158,56 +158,95 @@ ruleTester.run('jsx-handler-names', rule, {
 
   invalid: [{
     code: '<TestComponent onChange={this.doSomethingOnChange} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }, {
     code: '<TestComponent onChange={this.handlerChange} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }, {
     code: '<TestComponent onChange={this.handle} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }, {
     code: '<TestComponent onChange={this.handle2} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }, {
     code: '<TestComponent onChange={this.handl3Change} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }, {
     code: '<TestComponent onChange={this.handle4change} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }, {
     code: '<TestComponent onChange={takeCareOfChange} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}],
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }],
     options: [{
       checkLocalVariables: true
     }]
   }, {
     code: '<TestComponent onChange={() => this.takeCareOfChange()} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}],
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }],
     options: [{
       checkInlineFunction: true
     }]
   }, {
     code: '<TestComponent only={this.handleChange} />',
-    errors: [{message: 'Prop key for handleChange must begin with \'on\''}]
+    errors: [{
+      messageId: 'badPropKey',
+      data: {propValue: 'handleChange', handlerPropPrefix: 'on'}
+    }]
   }, {
     code: '<TestComponent handleChange={this.handleChange} />',
-    errors: [{message: 'Prop key for handleChange must begin with \'on\''}]
+    errors: [{
+      messageId: 'badPropKey',
+      data: {propValue: 'handleChange', handlerPropPrefix: 'on'}
+    }]
   }, {
     code: '<TestComponent whenChange={handleChange} />',
-    errors: [{message: 'Prop key for handleChange must begin with \'on\''}],
+    errors: [{
+      messageId: 'badPropKey',
+      data: {propValue: 'handleChange', handlerPropPrefix: 'on'}
+    }],
     options: [{
       checkLocalVariables: true
     }]
   }, {
     code: '<TestComponent whenChange={() => handleChange()} />',
-    errors: [{message: 'Prop key for handleChange must begin with \'on\''}],
+    errors: [{
+      messageId: 'badPropKey',
+      data: {propValue: 'handleChange', handlerPropPrefix: 'on'}
+    }],
     options: [{
       checkInlineFunction: true,
       checkLocalVariables: true
     }]
   }, {
     code: '<TestComponent onChange={handleChange} />',
-    errors: [{message: 'Prop key for handleChange must begin with \'when\''}],
+    errors: [{
+      messageId: 'badPropKey',
+      data: {propValue: 'handleChange', handlerPropPrefix: 'when'}
+    }],
     options: [{
       checkLocalVariables: true,
       eventHandlerPrefix: 'handle',
@@ -215,7 +254,10 @@ ruleTester.run('jsx-handler-names', rule, {
     }]
   }, {
     code: '<TestComponent onChange={() => handleChange()} />',
-    errors: [{message: 'Prop key for handleChange must begin with \'when\''}],
+    errors: [{
+      messageId: 'badPropKey',
+      data: {propValue: 'handleChange', handlerPropPrefix: 'when'}
+    }],
     options: [{
       checkInlineFunction: true,
       checkLocalVariables: true,
@@ -224,14 +266,23 @@ ruleTester.run('jsx-handler-names', rule, {
     }]
   }, {
     code: '<TestComponent onChange={this.onChange} />',
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }, {
     code: '<TestComponent onChange={props::onChange} />',
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }, {
     code: '<TestComponent onChange={props.foo::onChange} />',
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'Handler function for onChange prop key must be a camelCase name beginning with \'handle\' only'}]
+    errors: [{
+      messageId: 'badHandlerName',
+      data: {propKey: 'onChange', handlerPrefix: 'handle'}
+    }]
   }]
 });

--- a/tests/lib/rules/jsx-indent-props.js
+++ b/tests/lib/rules/jsx-indent-props.js
@@ -208,7 +208,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '    foo',
       '/>'
     ].join('\n'),
-    errors: [{message: 'Expected indentation of 4 space characters but found 2.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 2
+      }
+    }]
   }, {
     code: [
       '<App',
@@ -221,7 +226,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '/>'
     ].join('\n'),
     options: [2],
-    errors: [{message: 'Expected indentation of 2 space characters but found 4.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 2, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       'const test = true',
@@ -243,8 +253,17 @@ ruleTester.run('jsx-indent-props', rule, {
     ].join('\n'),
     options: [2],
     errors: [
-      {message: 'Expected indentation of 6 space characters but found 4.'},
-      {message: 'Expected indentation of 6 space characters but found 4.'}
+      {
+        messageId: 'wrongIndent',
+        data: {
+          needed: 6, type: 'space', characters: 'characters', gotten: 4
+        }
+      }, {
+        messageId: 'wrongIndent',
+        data: {
+          needed: 6, type: 'space', characters: 'characters', gotten: 4
+        }
+      }
     ]
   }, {
     code: [
@@ -266,9 +285,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '  )'
     ].join('\n'),
     options: [2],
-    errors: [
-      {message: 'Expected indentation of 6 space characters but found 8.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 6, type: 'space', characters: 'characters', gotten: 8
+      }
+    }]
   }, {
     code: [
       '{test.isLoading',
@@ -285,9 +307,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '}'
     ].join('\n'),
     options: [2],
-    errors: [
-      {message: 'Expected indentation of 6 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 6, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       '{test.isLoading',
@@ -307,8 +332,18 @@ ruleTester.run('jsx-indent-props', rule, {
     ].join('\n'),
     options: [2],
     errors: [
-      {message: 'Expected indentation of 6 space characters but found 4.'},
-      {message: 'Expected indentation of 6 space characters but found 4.'}
+      {
+        messageId: 'wrongIndent',
+        data: {
+          needed: 6, type: 'space', characters: 'characters', gotten: 4
+        }
+      },
+      {
+        messageId: 'wrongIndent',
+        data: {
+          needed: 6, type: 'space', characters: 'characters', gotten: 4
+        }
+      }
     ]
   }, {
     code: [
@@ -329,8 +364,17 @@ ruleTester.run('jsx-indent-props', rule, {
     ].join('\n'),
     options: [2],
     errors: [
-      {message: 'Expected indentation of 6 space characters but found 4.'},
-      {message: 'Expected indentation of 6 space characters but found 4.'}
+      {
+        messageId: 'wrongIndent',
+        data: {
+          needed: 6, type: 'space', characters: 'characters', gotten: 4
+        }
+      }, {
+        messageId: 'wrongIndent',
+        data: {
+          needed: 6, type: 'space', characters: 'characters', gotten: 4
+        }
+      }
     ]
   }, {
     code: [
@@ -344,7 +388,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '/>'
     ].join('\n'),
     options: ['tab'],
-    errors: [{message: 'Expected indentation of 1 tab character but found 0.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 1, type: 'tab', characters: 'character', gotten: 0
+      }
+    }]
   }, {
     code: [
       '<App',
@@ -357,7 +406,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '/>'
     ].join('\n'),
     options: ['tab'],
-    errors: [{message: 'Expected indentation of 1 tab character but found 3.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 1, type: 'tab', characters: 'character', gotten: 3
+      }
+    }]
   }, {
     code: [
       '<App a',
@@ -370,7 +424,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '/>'
     ].join('\n'),
     options: ['first'],
-    errors: [{message: 'Expected indentation of 5 space characters but found 2.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 5, type: 'space', characters: 'characters', gotten: 2
+      }
+    }]
   }, {
     code: [
       '<App  a',
@@ -383,7 +442,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '/>'
     ].join('\n'),
     options: ['first'],
-    errors: [{message: 'Expected indentation of 6 space characters but found 3.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 6, type: 'space', characters: 'characters', gotten: 3
+      }
+    }]
   }, {
     code: [
       '<App',
@@ -398,7 +462,12 @@ ruleTester.run('jsx-indent-props', rule, {
       '/>'
     ].join('\n'),
     options: ['first'],
-    errors: [{message: 'Expected indentation of 6 space characters but found 3.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 6, type: 'space', characters: 'characters', gotten: 3
+      }
+    }]
   }, {
     code: [
       '<App',
@@ -416,8 +485,18 @@ ruleTester.run('jsx-indent-props', rule, {
     ].join('\n'),
     options: ['first'],
     errors: [
-      {message: 'Expected indentation of 2 space characters but found 1.'},
-      {message: 'Expected indentation of 2 space characters but found 3.'}
+      {
+        messageId: 'wrongIndent',
+        data: {
+          needed: 2, type: 'space', characters: 'characters', gotten: 1
+        }
+      },
+      {
+        messageId: 'wrongIndent',
+        data: {
+          needed: 2, type: 'space', characters: 'characters', gotten: 3
+        }
+      }
     ]
   }]
 });

--- a/tests/lib/rules/jsx-indent.js
+++ b/tests/lib/rules/jsx-indent.js
@@ -1016,12 +1016,27 @@ const Component = () => (
       '    bar </div>',
       '</div>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'},
-      {message: 'Expected indentation of 4 space characters but found 3.'},
-      {message: 'Expected indentation of 4 space characters but found 3.'},
-      {message: 'Expected indentation of 4 space characters but found 3.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }, {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 3
+      }
+    }, {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 3
+      }
+    }, {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 3
+      }
+    }]
   }, {
     code: [
       '<App>',
@@ -1033,7 +1048,12 @@ const Component = () => (
       '    <Foo />',
       '</App>'
     ].join('\n'),
-    errors: [{message: 'Expected indentation of 4 space characters but found 2.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 2
+      }
+    }]
   }, {
     code: [
       '<App>',
@@ -1046,7 +1066,12 @@ const Component = () => (
       '    <></>',
       '</App>'
     ].join('\n'),
-    errors: [{message: 'Expected indentation of 4 space characters but found 2.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 2
+      }
+    }]
   }, {
     code: [
       '<>',
@@ -1059,7 +1084,12 @@ const Component = () => (
       '    <Foo />',
       '</>'
     ].join('\n'),
-    errors: [{message: 'Expected indentation of 4 space characters but found 2.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 2
+      }
+    }]
   }, {
     code: [
       '<App>',
@@ -1072,7 +1102,12 @@ const Component = () => (
       '</App>'
     ].join('\n'),
     options: [2],
-    errors: [{message: 'Expected indentation of 2 space characters but found 4.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 2, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       '<App>',
@@ -1085,7 +1120,12 @@ const Component = () => (
       '</App>'
     ].join('\n'),
     options: ['tab'],
-    errors: [{message: 'Expected indentation of 1 tab character but found 0.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 1, type: 'tab', characters: 'character', gotten: 0
+      }
+    }]
   }, {
     code: [
       'function App() {',
@@ -1102,7 +1142,12 @@ const Component = () => (
       '}'
     ].join('\n'),
     options: [2],
-    errors: [{message: 'Expected indentation of 2 space characters but found 9.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 2, type: 'space', characters: 'characters', gotten: 9
+      }
+    }]
   }, {
     code: [
       'function App() {',
@@ -1119,7 +1164,12 @@ const Component = () => (
       '}'
     ].join('\n'),
     options: [2],
-    errors: [{message: 'Expected indentation of 2 space characters but found 4.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 2, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       'function App() {',
@@ -1144,7 +1194,12 @@ const Component = () => (
       '}'
     ].join('\n'),
     options: [2],
-    errors: [{message: 'Expected indentation of 4 space characters but found 0.'}]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       '<App>',
@@ -1156,9 +1211,12 @@ const Component = () => (
       '    {test}',
       '</App>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 3.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 3
+      }
+    }]
   }, {
     code: [
       '<App>',
@@ -1178,9 +1236,12 @@ const Component = () => (
       '    ))}',
       '</App>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 12 space characters but found 11.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 12, type: 'space', characters: 'characters', gotten: 11
+      }
+    }]
   }, {
     code: [
       '<App>',
@@ -1193,9 +1254,12 @@ const Component = () => (
       '</App>'
     ].join('\n'),
     options: ['tab'],
-    errors: [
-      {message: 'Expected indentation of 1 tab character but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 1, type: 'tab', characters: 'character', gotten: 0
+      }
+    }]
   }, {
     code: [
       '<App>',
@@ -1216,9 +1280,12 @@ const Component = () => (
       '</App>'
     ].join('\n'),
     options: ['tab'],
-    errors: [
-      {message: 'Expected indentation of 3 tab characters but found 2.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 3, type: 'tab', characters: 'characters', gotten: 2
+      }
+    }]
   }, {
     code: [
       '<App>\n',
@@ -1231,9 +1298,12 @@ const Component = () => (
       '</App>'
     ].join('\n'),
     options: ['tab'],
-    errors: [
-      {message: 'Expected indentation of 1 tab character but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 1, type: 'tab', characters: 'character', gotten: 0
+      }
+    }]
   }, {
     code: [
       '[',
@@ -1248,9 +1318,12 @@ const Component = () => (
       ']'
     ].join('\n'),
     options: [2],
-    errors: [
-      {message: 'Expected indentation of 2 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 2, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       '[',
@@ -1266,9 +1339,12 @@ const Component = () => (
       ']'
     ].join('\n'),
     options: [2],
-    errors: [
-      {message: 'Expected indentation of 2 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 2, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       '<App>\n',
@@ -1281,9 +1357,12 @@ const Component = () => (
       '</App>'
     ].join('\n'),
     options: ['tab'],
-    errors: [
-      {message: 'Expected indentation of 1 tab character but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 1, type: 'tab', characters: 'character', gotten: 0
+      }
+    }]
   }, {
     code: [
       '<App>\n',
@@ -1296,9 +1375,12 @@ const Component = () => (
       '</App>'
     ].join('\n'),
     options: [2],
-    errors: [
-      {message: 'Expected indentation of 2 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 2, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       '<div>',
@@ -1320,9 +1402,12 @@ const Component = () => (
       '    }',
       '</div>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 12 space characters but found 8.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 12, type: 'space', characters: 'characters', gotten: 8
+      }
+    }]
   }, {
     code: [
       '<div>',
@@ -1344,9 +1429,12 @@ const Component = () => (
       '    }',
       '</div>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 12 space characters but found 8.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 12, type: 'space', characters: 'characters', gotten: 8
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon at the end of the first expression)
@@ -1360,9 +1448,12 @@ const Component = () => (
       '    <Foo /> :',
       '    <Bar />'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       'foo ?',
@@ -1375,9 +1466,12 @@ const Component = () => (
       '    <Foo /> :',
       '    <></>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon on its own line)
@@ -1393,9 +1487,12 @@ const Component = () => (
       ':',
       '    <Bar />'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (first expression on test line, colon at the end of the first expression)
@@ -1407,9 +1504,12 @@ const Component = () => (
       'foo ? <Foo /> :',
       '<Bar />'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 0 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 0, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       'foo ?',
@@ -1424,9 +1524,12 @@ const Component = () => (
       ':',
       '    <></>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (first expression on test line, colon on its own line)
@@ -1440,9 +1543,12 @@ const Component = () => (
       ':',
       '<Bar />'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 0 space characters but found 6.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 0, type: 'space', characters: 'characters', gotten: 6
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon at the end of the first expression, parenthesized first expression)
@@ -1458,9 +1564,12 @@ const Component = () => (
       ') :',
       '    <Bar />'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       'foo ? (',
@@ -1475,9 +1584,12 @@ const Component = () => (
       ') :',
       '    <></>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon on its own line, parenthesized first expression)
@@ -1495,9 +1607,12 @@ const Component = () => (
       ':',
       '    <Bar />'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon at the end of the first expression, parenthesized second expression)
@@ -1513,9 +1628,12 @@ const Component = () => (
       '        <Bar />',
       '    )'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       'foo ?',
@@ -1530,9 +1648,12 @@ const Component = () => (
       '        <></>',
       '    )'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon on its own line, parenthesized second expression)
@@ -1550,9 +1671,12 @@ const Component = () => (
       '    <Bar />',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon indented on its own line, parenthesized second expression)
@@ -1570,9 +1694,12 @@ const Component = () => (
       '        <Bar />',
       '    )'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       'foo ?',
@@ -1589,9 +1716,12 @@ const Component = () => (
       '        <></>',
       '    )'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon at the end of the first expression, both expression parenthesized)
@@ -1609,10 +1739,18 @@ const Component = () => (
       '    <Bar />',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'},
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    },
+    {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       'foo ? (',
@@ -1629,10 +1767,18 @@ const Component = () => (
       '    <></>',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'},
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    },
+    {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon on its own line, both expression parenthesized)
@@ -1652,10 +1798,18 @@ const Component = () => (
       '    <Bar />',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'},
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    },
+    {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (colon on its own line, both expression parenthesized)
@@ -1677,10 +1831,18 @@ const Component = () => (
       '    <Bar />',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'},
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    },
+    {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       'foo ? (',
@@ -1701,10 +1863,18 @@ const Component = () => (
       '    <></>',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'},
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    },
+    {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (first expression on test line, colon at the end of the first expression, parenthesized second expression)
@@ -1718,9 +1888,12 @@ const Component = () => (
       '    <Bar />',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       'foo ? <Foo /> : (',
@@ -1733,9 +1906,12 @@ const Component = () => (
       '    <></>',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     // Multiline ternary
     // (first expression on test line, colon on its own line, parenthesized second expression)
@@ -1751,9 +1927,12 @@ const Component = () => (
       '    <Bar />',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       'foo ? <Foo />',
@@ -1768,9 +1947,12 @@ const Component = () => (
       '    <></>',
       ')'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       '<p>',
@@ -1779,9 +1961,12 @@ const Component = () => (
       '  </div>',
       '</p>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 2.'}
-    ],
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 2
+      }
+    }],
     output: [
       '<p>',
       '    <div>',
@@ -1815,9 +2000,12 @@ const Component = () => (
     );
     `,
     options: [2, {checkAttributes: true}],
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: `
 const Component = () => (
@@ -1844,9 +2032,12 @@ const Component = () => (
 );
     `,
     options: ['tab', {checkAttributes: true}],
-    errors: [
-      {message: 'Expected indentation of 2 tab characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 2, type: 'tab', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: `
     function Foo() {
@@ -1871,9 +2062,12 @@ const Component = () => (
     }
     `,
     options: [2, {indentLogicalExpressions: true}],
-    errors: [
-      {message: 'Expected indentation of 12 space characters but found 10.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 12, type: 'space', characters: 'characters', gotten: 10
+      }
+    }]
   }, {
     code: [
       '<span>',
@@ -1892,9 +2086,12 @@ const Component = () => (
       '    }}',
       '</span>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 12.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 12
+      }
+    }]
   }, {
     code: [
       '<span>',
@@ -1913,9 +2110,12 @@ const Component = () => (
       '    })}',
       '</span>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 12.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 12
+      }
+    }]
   }, {
     code: [
       '<span>',
@@ -1932,9 +2132,12 @@ const Component = () => (
       '    }}',
       '</span>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       '<span>',
@@ -1951,9 +2154,12 @@ const Component = () => (
       '    })}',
       '</span>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 8 space characters but found 4.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 8, type: 'space', characters: 'characters', gotten: 4
+      }
+    }]
   }, {
     code: [
       '<div>',
@@ -1965,9 +2171,12 @@ const Component = () => (
       '    text',
       '</div>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       '<div>',
@@ -1981,10 +2190,18 @@ const Component = () => (
       '    text',
       '</div>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 2.'},
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 2
+      }
+    },
+    {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }, {
     code: [
       '<div>',
@@ -1998,10 +2215,18 @@ const Component = () => (
       '    text',
       '</div>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'},
-      {message: 'Expected indentation of 4 space characters but found 2.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    },
+    {
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 2
+      }
+    }]
   }, {
     code: [
       '<div>',
@@ -2015,9 +2240,12 @@ const Component = () => (
       '\ttext',
       '</div>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 1 tab character but found 2.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 1, type: 'tab', characters: 'character', gotten: 2
+      }
+    }]
   }, {
     code: [
       '<>',
@@ -2030,8 +2258,11 @@ const Component = () => (
       '    aaa',
       '</>'
     ].join('\n'),
-    errors: [
-      {message: 'Expected indentation of 4 space characters but found 0.'}
-    ]
+    errors: [{
+      messageId: 'wrongIndent',
+      data: {
+        needed: 4, type: 'space', characters: 'characters', gotten: 0
+      }
+    }]
   }]
 });

--- a/tests/lib/rules/jsx-key.js
+++ b/tests/lib/rules/jsx-key.js
@@ -57,65 +57,77 @@ ruleTester.run('jsx-key', rule, {
   ],
   invalid: [].concat({
     code: '[<App />];',
-    errors: [{message: 'Missing "key" prop for element in array'}]
+    errors: [{messageId: 'missingArrayKey'}]
   }, {
     code: '[<App {...key} />];',
-    errors: [{message: 'Missing "key" prop for element in array'}]
+    errors: [{messageId: 'missingArrayKey'}]
   }, {
     code: '[<App key={0}/>, <App />];',
-    errors: [{message: 'Missing "key" prop for element in array'}]
+    errors: [{messageId: 'missingArrayKey'}]
   }, {
     code: '[1, 2 ,3].map(function(x) { return <App /> });',
-    errors: [{message: 'Missing "key" prop for element in iterator'}]
+    errors: [{messageId: 'missingIterKey'}]
   }, {
     code: '[1, 2 ,3].map(x => <App />);',
-    errors: [{message: 'Missing "key" prop for element in iterator'}]
+    errors: [{messageId: 'missingIterKey'}]
   }, {
     code: '[1, 2 ,3].map(x => { return <App /> });',
-    errors: [{message: 'Missing "key" prop for element in iterator'}]
+    errors: [{messageId: 'missingIterKey'}]
   }, {
     code: '[1, 2, 3]?.map(x => <BabelEslintApp />)',
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'Missing "key" prop for element in iterator'}]
+    errors: [{messageId: 'missingIterKey'}]
   }, parsers.TS({
     code: '[1, 2, 3]?.map(x => <TypescriptEslintApp />)',
     parser: parsers['@TYPESCRIPT_ESLINT'],
-    errors: [{message: 'Missing "key" prop for element in iterator'}]
+    errors: [{messageId: 'missingIterKey'}]
   }), {
     code: '[1, 2, 3].map(x => <>{x}</>);',
     parser: parsers.BABEL_ESLINT,
     options: [{checkFragmentShorthand: true}],
     settings,
-    errors: [{message: 'Missing "key" prop for element in iterator. Shorthand fragment syntax does not support providing keys. Use Act.Frag instead'}]
+    errors: [{
+      messageId: 'missingIterKeyUsePrag',
+      data: {
+        reactPrag: 'Act',
+        fragPrag: 'Frag'
+      }
+    }]
   }, {
     code: '[<></>];',
     parser: parsers.BABEL_ESLINT,
     options: [{checkFragmentShorthand: true}],
     settings,
-    errors: [{message: 'Missing "key" prop for element in array. Shorthand fragment syntax does not support providing keys. Use Act.Frag instead'}]
+    errors: [{
+      messageId: 'missingArrayKeyUsePrag',
+      data: {
+        reactPrag: 'Act',
+        fragPrag: 'Frag'
+      }
+    }]
   }, {
     code: '[<App {...obj} key="keyAfterSpread" />];',
     parser: parsers.BABEL_ESLINT,
     options: [{checkKeyMustBeforeSpread: true}],
     settings,
-    errors: [{message: '`key` prop must before any `{...spread}, to avoid conflicting with React’s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`'}]
+    errors: [{messageId: 'keyBeforeSpread'}]
   }, {
     code: '[<App {...obj} key="keyAfterSpread" />];',
     parser: parsers.TYPESCRIPT_ESLINT,
     options: [{checkKeyMustBeforeSpread: true}],
     settings,
-    errors: [{message: '`key` prop must before any `{...spread}, to avoid conflicting with React’s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`'}]
+    errors: [{messageId: 'keyBeforeSpread'}]
   }, {
     code: '[<div {...obj} key="keyAfterSpread" />];',
     parser: parsers.BABEL_ESLINT,
     options: [{checkKeyMustBeforeSpread: true}],
     settings,
-    errors: [{message: '`key` prop must before any `{...spread}, to avoid conflicting with React’s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`'}]
+    errors: [{messageId: 'keyBeforeSpread'}]
   }, {
     code: '[<div {...obj} key="keyAfterSpread" />];',
     parser: parsers.TYPESCRIPT_ESLINT,
     options: [{checkKeyMustBeforeSpread: true}],
     settings,
-    errors: [{message: '`key` prop must before any `{...spread}, to avoid conflicting with React’s new JSX transform: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html`'}]
+    errors: [{messageId: 'keyBeforeSpread'}]
   })
 });

--- a/tests/lib/rules/jsx-max-depth.js
+++ b/tests/lib/rules/jsx-max-depth.js
@@ -123,7 +123,10 @@ ruleTester.run('jsx-max-depth', rule, {
       '</App>'
     ].join('\n'),
     options: [{max: 0}],
-    errors: [{message: 'Expected the depth of nested jsx elements to be <= 0, but found 1.'}]
+    errors: [{
+      messageId: 'wrongDepth',
+      data: {needed: 0, found: 1}
+    }]
   }, {
     code: [
       '<App>',
@@ -131,7 +134,10 @@ ruleTester.run('jsx-max-depth', rule, {
       '</App>'
     ].join('\n'),
     options: [{max: 0}],
-    errors: [{message: 'Expected the depth of nested jsx elements to be <= 0, but found 1.'}]
+    errors: [{
+      messageId: 'wrongDepth',
+      data: {needed: 0, found: 1}
+    }]
   }, {
     code: [
       '<App>',
@@ -141,14 +147,20 @@ ruleTester.run('jsx-max-depth', rule, {
       '</App>'
     ].join('\n'),
     options: [{max: 1}],
-    errors: [{message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'}]
+    errors: [{
+      messageId: 'wrongDepth',
+      data: {needed: 1, found: 2}
+    }]
   }, {
     code: [
       'const x = <div><span /></div>;',
       '<div>{x}</div>'
     ].join('\n'),
     options: [{max: 1}],
-    errors: [{message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'}]
+    errors: [{
+      messageId: 'wrongDepth',
+      data: {needed: 1, found: 2}
+    }]
   }, {
     code: [
       'const x = <div><span /></div>;',
@@ -156,7 +168,10 @@ ruleTester.run('jsx-max-depth', rule, {
       '<div>{y}</div>'
     ].join('\n'),
     options: [{max: 1}],
-    errors: [{message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'}]
+    errors: [{
+      messageId: 'wrongDepth',
+      data: {needed: 1, found: 2}
+    }]
   }, {
     code: [
       'const x = <div><span /></div>;',
@@ -165,8 +180,14 @@ ruleTester.run('jsx-max-depth', rule, {
     ].join('\n'),
     options: [{max: 1}],
     errors: [
-      {message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'},
-      {message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'}
+      {
+        messageId: 'wrongDepth',
+        data: {needed: 1, found: 2}
+      },
+      {
+        messageId: 'wrongDepth',
+        data: {needed: 1, found: 2}
+      }
     ]
   }, {
     code: [
@@ -175,7 +196,10 @@ ruleTester.run('jsx-max-depth', rule, {
       '</div>'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'Expected the depth of nested jsx elements to be <= 2, but found 3.'}]
+    errors: [{
+      messageId: 'wrongDepth',
+      data: {needed: 2, found: 3}
+    }]
   }, {
     code: [
       '<>',
@@ -184,7 +208,10 @@ ruleTester.run('jsx-max-depth', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     options: [{max: 0}],
-    errors: [{message: 'Expected the depth of nested jsx elements to be <= 0, but found 1.'}]
+    errors: [{
+      messageId: 'wrongDepth',
+      data: {needed: 0, found: 1}
+    }]
   }, {
     code: [
       '<>',
@@ -195,7 +222,10 @@ ruleTester.run('jsx-max-depth', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     options: [{max: 1}],
-    errors: [{message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'}]
+    errors: [{
+      messageId: 'wrongDepth',
+      data: {needed: 1, found: 2}
+    }]
   }, {
     code: [
       'const x = <><span /></>;',
@@ -205,8 +235,14 @@ ruleTester.run('jsx-max-depth', rule, {
     parser: parsers.BABEL_ESLINT,
     options: [{max: 1}],
     errors: [
-      {message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'},
-      {message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'}
+      {
+        messageId: 'wrongDepth',
+        data: {needed: 1, found: 2}
+      },
+      {
+        messageId: 'wrongDepth',
+        data: {needed: 1, found: 2}
+      }
     ]
   }, {
     code: `
@@ -222,8 +258,14 @@ ruleTester.run('jsx-max-depth', rule, {
     `,
     options: [{max: 1}],
     errors: [
-      {message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'},
-      {message: 'Expected the depth of nested jsx elements to be <= 1, but found 2.'}
+      {
+        messageId: 'wrongDepth',
+        data: {needed: 1, found: 2}
+      },
+      {
+        messageId: 'wrongDepth',
+        data: {needed: 1, found: 2}
+      }
     ]
   }]
 });

--- a/tests/lib/rules/jsx-max-props-per-line.js
+++ b/tests/lib/rules/jsx-max-props-per-line.js
@@ -69,7 +69,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       'bar',
       'baz />;'
     ].join('\n'),
-    errors: [{message: 'Prop `bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'bar'}
+    }],
     parserOptions
   }, {
     code: '<App foo bar baz />;',
@@ -78,14 +81,20 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       'baz />;'
     ].join('\n'),
     options: [{maximum: 2}],
-    errors: [{message: 'Prop `baz` must be placed on a new line'}]
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'baz'}
+    }]
   }, {
     code: '<App {...this.props} bar />;',
     output: [
       '<App {...this.props}',
       'bar />;'
     ].join('\n'),
-    errors: [{message: 'Prop `bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'bar'}
+    }],
     parserOptions
   }, {
     code: '<App bar {...this.props} />;',
@@ -93,7 +102,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       '<App bar',
       '{...this.props} />;'
     ].join('\n'),
-    errors: [{message: 'Prop `this.props` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'this.props'}
+    }],
     parserOptions
   }, {
     code: [
@@ -109,7 +121,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       '  baz',
       '/>'
     ].join('\n'),
-    errors: [{message: 'Prop `bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -125,7 +140,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       '  baz',
       '/>'
     ].join('\n'),
-    errors: [{message: 'Prop `this.props` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'this.props'}
+    }],
     parserOptions
   }, {
     code: [
@@ -141,7 +159,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       'bar',
       '/>'
     ].join('\n'),
-    errors: [{message: 'Prop `bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -153,7 +174,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       '}}',
       'bar />'
     ].join('\n'),
-    errors: [{message: 'Prop `bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -166,7 +190,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       'baz />'
     ].join('\n'),
     options: [{maximum: 2}],
-    errors: [{message: 'Prop `baz` must be placed on a new line'}]
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'baz'}
+    }]
   }, {
     code: [
       '<App foo={{',
@@ -177,7 +204,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       '}}',
       '{...rest} />'
     ].join('\n'),
-    errors: [{message: 'Prop `rest` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'rest'}
+    }],
     parserOptions
   }, {
     code: [
@@ -191,7 +221,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       '}',
       'bar />'
     ].join('\n'),
-    errors: [{message: 'Prop `bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -209,7 +242,10 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       '  ...rest',
       '} />'
     ].join('\n'),
-    errors: [{message: 'Prop `rest` must be placed on a new line'}],
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'rest'}
+    }],
     parserOptions
   }, {
     code: [
@@ -226,6 +262,9 @@ ruleTester.run('jsx-max-props-per-line', rule, {
       '/>'
     ].join('\n'),
     options: [{maximum: 2}],
-    errors: [{message: 'Prop `baz` must be placed on a new line'}]
+    errors: [{
+      messageId: 'newLine',
+      data: {prop: 'baz'}
+    }]
   }]
 });

--- a/tests/lib/rules/jsx-newline.js
+++ b/tests/lib/rules/jsx-newline.js
@@ -68,7 +68,7 @@ const tests = {
         </div>
       `,
       errors: [{
-        message: 'JSX element should start in a new line'
+        messageId: 'newLine'
       }]
     },
     {
@@ -86,7 +86,7 @@ const tests = {
         </div>
       `,
       errors: [{
-        message: 'JSX element should start in a new line'
+        messageId: 'newLine'
       }]
     },
     {
@@ -104,7 +104,7 @@ const tests = {
         </div>
       `,
       errors: [{
-        message: 'JSX element should start in a new line'
+        messageId: 'newLine'
       }]
     },
     {
@@ -130,7 +130,7 @@ const tests = {
         </div>
       `,
       errors: [{
-        message: 'JSX element should start in a new line'
+        messageId: 'newLine'
       }]
     },
     {
@@ -162,9 +162,9 @@ const tests = {
         </div>
       `,
       errors: [
-        {message: 'JSX element should start in a new line'},
-        {message: 'JSX element should start in a new line'},
-        {message: 'JSX element should start in a new line'}
+        {messageId: 'newLine'},
+        {messageId: 'newLine'},
+        {messageId: 'newLine'}
       ]
     }
   ]
@@ -201,7 +201,7 @@ const advanceFeatTest = {
         </>
       `,
       errors: [
-        {message: 'JSX element should start in a new line'}
+        {messageId: 'newLine'}
       ]
     }
   ]

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -297,19 +297,19 @@ ruleTester.run('jsx-no-bind', rule, {
     // .bind()
     {
       code: '<div onClick={this._handleClick.bind(this)}></div>',
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: '<div onClick={someGlobalFunction.bind(this)}></div>',
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: '<div onClick={window.lol.bind(this)}></div>',
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: '<div ref={this._refCallback.bind(this)}></div>',
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: `
@@ -320,7 +320,7 @@ ruleTester.run('jsx-no-bind', rule, {
           }
         });
       `,
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: `
@@ -331,7 +331,7 @@ ruleTester.run('jsx-no-bind', rule, {
           }
         };
       `,
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: [
@@ -342,7 +342,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: [
@@ -353,7 +353,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use .bind()'}],
+      errors: [{messageId: 'bindCall'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -365,7 +365,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use .bind()'}],
+      errors: [{messageId: 'bindCall'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -376,7 +376,7 @@ ruleTester.run('jsx-no-bind', rule, {
           )
         };
       `,
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: [
@@ -386,7 +386,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: [
@@ -397,7 +397,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: [
@@ -413,8 +413,8 @@ ruleTester.run('jsx-no-bind', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: 'JSX props should not use .bind()'},
-        {message: 'JSX props should not use arrow functions'}
+        {messageId: 'bindCall'},
+        {messageId: 'arrowFunc'}
       ],
       parser: parsers.BABEL_ESLINT
     },
@@ -426,7 +426,7 @@ ruleTester.run('jsx-no-bind', rule, {
           )
         };
       `,
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: `
@@ -436,7 +436,7 @@ ruleTester.run('jsx-no-bind', rule, {
           )
         };
       `,
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: `
@@ -446,7 +446,7 @@ ruleTester.run('jsx-no-bind', rule, {
           )
         };
       `,
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
     {
       code: `
@@ -456,29 +456,29 @@ ruleTester.run('jsx-no-bind', rule, {
           )
         };
       `,
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     },
 
     // Arrow functions
     {
       code: '<div onClick={() => alert("1337")}></div>',
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: '<div onClick={async () => alert("1337")}></div>',
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: '<div onClick={() => 42}></div>',
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: '<div onClick={param => { first(); second(); }}></div>',
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: '<div ref={c => this._input = c}></div>',
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: [
@@ -489,7 +489,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use arrow functions'}],
+      errors: [{messageId: 'arrowFunc'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -501,7 +501,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use arrow functions'}],
+      errors: [{messageId: 'arrowFunc'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -513,7 +513,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use arrow functions'}],
+      errors: [{messageId: 'arrowFunc'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -524,7 +524,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: [
@@ -534,7 +534,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: [
@@ -545,7 +545,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: [
@@ -556,7 +556,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use arrow functions'}]
+      errors: [{messageId: 'arrowFunc'}]
     },
     {
       code: [
@@ -572,8 +572,8 @@ ruleTester.run('jsx-no-bind', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: 'JSX props should not use arrow functions'},
-        {message: 'JSX props should not use ::'}
+        {messageId: 'arrowFunc'},
+        {messageId: 'bindExpression'}
       ],
       parser: parsers.BABEL_ESLINT
     },
@@ -581,19 +581,19 @@ ruleTester.run('jsx-no-bind', rule, {
     // Functions
     {
       code: '<div onClick={function () { alert("1337") }}></div>',
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: '<div onClick={function * () { alert("1337") }}></div>',
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: '<div onClick={async function () { alert("1337") }}></div>',
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: '<div ref={function (c) { this._input = c }}></div>',
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: [
@@ -604,7 +604,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}],
+      errors: [{messageId: 'func'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -616,7 +616,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}],
+      errors: [{messageId: 'func'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -628,7 +628,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}],
+      errors: [{messageId: 'func'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -640,7 +640,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}],
+      errors: [{messageId: 'func'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -651,7 +651,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: [
@@ -661,7 +661,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: [
@@ -671,7 +671,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: [
@@ -682,7 +682,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: [
@@ -693,7 +693,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: [
@@ -704,7 +704,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '});'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use functions'}]
+      errors: [{messageId: 'func'}]
     },
     {
       code: [
@@ -720,8 +720,8 @@ ruleTester.run('jsx-no-bind', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: 'JSX props should not use functions'},
-        {message: 'JSX props should not use ::'}
+        {messageId: 'func'},
+        {messageId: 'bindExpression'}
       ],
       parser: parsers.BABEL_ESLINT
     },
@@ -729,17 +729,17 @@ ruleTester.run('jsx-no-bind', rule, {
     // Bind expression
     {
       code: '<div foo={::this.onChange} />',
-      errors: [{message: 'JSX props should not use ::'}],
+      errors: [{messageId: 'bindExpression'}],
       parser: parsers.BABEL_ESLINT
     },
     {
       code: '<div foo={foo.bar::baz} />',
-      errors: [{message: 'JSX props should not use ::'}],
+      errors: [{messageId: 'bindExpression'}],
       parser: parsers.BABEL_ESLINT
     },
     {
       code: '<div foo={foo::bar} />',
-      errors: [{message: 'JSX props should not use ::'}],
+      errors: [{messageId: 'bindExpression'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -751,7 +751,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use ::'}],
+      errors: [{messageId: 'bindExpression'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -763,7 +763,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use ::'}],
+      errors: [{messageId: 'bindExpression'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -775,7 +775,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use ::'}],
+      errors: [{messageId: 'bindExpression'}],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -791,7 +791,7 @@ ruleTester.run('jsx-no-bind', rule, {
         '  }',
         '};'
       ].join('\n'),
-      errors: [{message: 'JSX props should not use ::'}],
+      errors: [{messageId: 'bindExpression'}],
       parser: parsers.BABEL_ESLINT
     },
 
@@ -799,7 +799,7 @@ ruleTester.run('jsx-no-bind', rule, {
     {
       code: '<Foo onClick={this._handleClick.bind(this)} />',
       options: [{ignoreDOMComponents: true}],
-      errors: [{message: 'JSX props should not use .bind()'}]
+      errors: [{messageId: 'bindCall'}]
     }
   ]
 });

--- a/tests/lib/rules/jsx-no-comment-textnodes.js
+++ b/tests/lib/rules/jsx-no-comment-textnodes.js
@@ -311,7 +311,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -321,7 +321,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -331,7 +331,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -345,7 +345,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -361,7 +361,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -377,7 +377,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     },
     {
       code: `
@@ -385,7 +385,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
           return <span>/*</span>;
         };
       `,
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }
   ].concat(parsers.TS([
     {
@@ -397,7 +397,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
         }
       `,
       parser: parsers['@TYPESCRIPT_ESLINT'],
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -407,7 +407,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers['@TYPESCRIPT_ESLINT'],
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -417,7 +417,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers['@TYPESCRIPT_ESLINT'],
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -431,7 +431,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers['@TYPESCRIPT_ESLINT'],
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -447,7 +447,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers['@TYPESCRIPT_ESLINT'],
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }, {
       code: `
       class Comp1 extends Component {
@@ -463,7 +463,7 @@ ruleTester.run('jsx-no-comment-textnodes', rule, {
       }
     `,
       parser: parsers['@TYPESCRIPT_ESLINT'],
-      errors: [{message: 'Comments inside children section of tag should be placed inside braces'}]
+      errors: [{messageId: 'putCommentInBraces'}]
     }
   ]))
 });

--- a/tests/lib/rules/jsx-no-duplicate-props.js
+++ b/tests/lib/rules/jsx-no-duplicate-props.js
@@ -27,7 +27,7 @@ const parserOptions = {
 const ruleTester = new RuleTester({parserOptions});
 
 const expectedError = {
-  message: 'No duplicate props allowed',
+  messageId: 'noDuplicateProps',
   type: 'JSXAttribute'
 };
 

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -27,22 +27,6 @@ const parserOptions = {
 // Tests
 // ------------------------------------------------------------------------------
 
-function stringsMessage(str) {
-  return `Strings not allowed in JSX files: “${str}”`;
-}
-
-function jsxMessage(str) {
-  return `Missing JSX expression container around literal string: “${str}”`;
-}
-
-function invalidProp(str) {
-  return `Invalid prop value: “${str}”`;
-}
-
-function attributeMessage(str) {
-  return `Strings not allowed in attributes: “${str}”`;
-}
-
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('jsx-no-literals', rule, {
 
@@ -353,7 +337,10 @@ ruleTester.run('jsx-no-literals', rule, {
         }
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: jsxMessage('test')}]
+      errors: [{
+        messageId: 'literalNotInJSXExpression',
+        data: {text: 'test'}
+      }]
     }, {
       code: `
         class Comp1 extends Component {
@@ -363,7 +350,10 @@ ruleTester.run('jsx-no-literals', rule, {
         }
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: jsxMessage('test')}]
+      errors: [{
+        messageId: 'literalNotInJSXExpression',
+        data: {text: 'test'}
+      }]
     }, {
       code: `
         class Comp1 extends Component {
@@ -374,7 +364,10 @@ ruleTester.run('jsx-no-literals', rule, {
         }
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: jsxMessage('test')}]
+      errors: [{
+        messageId: 'literalNotInJSXExpression',
+        data: {text: 'test'}
+      }]
     }, {
       code: `
         class Comp1 extends Component {
@@ -385,7 +378,10 @@ ruleTester.run('jsx-no-literals', rule, {
         }
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: jsxMessage('test')}]
+      errors: [{
+        messageId: 'literalNotInJSXExpression',
+        data: {text: 'test'}
+      }]
     }, {
       code: `
         var Hello = createReactClass({
@@ -396,7 +392,10 @@ ruleTester.run('jsx-no-literals', rule, {
         });
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: jsxMessage('hello')}]
+      errors: [{
+        messageId: 'literalNotInJSXExpression',
+        data: {text: 'hello'}
+      }]
     }, {
       code: `
         class Comp1 extends Component {
@@ -410,7 +409,10 @@ ruleTester.run('jsx-no-literals', rule, {
         }
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: jsxMessage('asdjfl')}]
+      errors: [{
+        messageId: 'literalNotInJSXExpression',
+        data: {text: 'asdjfl'}
+      }]
     }, {
       code: `
         class Comp1 extends Component {
@@ -426,7 +428,10 @@ ruleTester.run('jsx-no-literals', rule, {
         }
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: jsxMessage('asdjfl\n                test\n                foo')}]
+      errors: [{
+        messageId: 'literalNotInJSXExpression',
+        data: {text: 'asdjfl\n                test\n                foo'}
+      }]
     }, {
       code: `
         class Comp1 extends Component {
@@ -442,7 +447,10 @@ ruleTester.run('jsx-no-literals', rule, {
         }
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: jsxMessage('test')}]
+      errors: [{
+        messageId: 'literalNotInJSXExpression',
+        data: {text: 'test'}
+      }]
     }, {
       code: `
         <Foo bar="test">
@@ -450,10 +458,14 @@ ruleTester.run('jsx-no-literals', rule, {
         </Foo>
       `,
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [
-        {message: invalidProp('bar="test"')},
-        {message: stringsMessage('\'Test\'')}
-      ]
+      errors: [{
+        messageId: 'invalidPropValue',
+        data: {text: 'bar="test"'}
+      },
+      {
+        messageId: 'noStringsInJSX',
+        data: {text: '\'Test\''}
+      }]
     }, {
       code: `
         <Foo bar="test">
@@ -461,10 +473,14 @@ ruleTester.run('jsx-no-literals', rule, {
         </Foo>
       `,
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [
-        {message: invalidProp('bar="test"')},
-        {message: stringsMessage('\'Test\'')}
-      ]
+      errors: [{
+        messageId: 'invalidPropValue',
+        data: {text: 'bar="test"'}
+      },
+      {
+        messageId: 'noStringsInJSX',
+        data: {text: '\'Test\''}
+      }]
     }, {
       code: `
         <Foo bar="test">
@@ -472,10 +488,14 @@ ruleTester.run('jsx-no-literals', rule, {
         </Foo>
       `,
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [
-        {message: invalidProp('bar="test"')},
-        {message: stringsMessage('Test')}
-      ]
+      errors: [{
+        messageId: 'invalidPropValue',
+        data: {text: 'bar="test"'}
+      },
+      {
+        messageId: 'noStringsInJSX',
+        data: {text: 'Test'}
+      }]
     }, {
       code: `
         <Foo>
@@ -483,40 +503,64 @@ ruleTester.run('jsx-no-literals', rule, {
         </Foo>
       `,
       options: [{noStrings: true}],
-      errors: [{message: stringsMessage('`Test`')}]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '`Test`'}
+      }]
     }, {
       code: '<Foo bar={`Test`} />',
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [{message: stringsMessage('`Test`')}]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '`Test`'}
+      }]
     }, {
       code: '<Foo bar={`${baz}`} />',
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [{message: stringsMessage('`${baz}`')}]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '`${baz}`'}
+      }]
     }, {
       code: '<Foo bar={`Test ${baz}`} />',
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [{message: stringsMessage('`Test ${baz}`')}]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '`Test ${baz}`'}
+      }]
     }, {
       code: '<Foo bar={`foo` + \'bar\'} />',
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [
-        {message: stringsMessage('`foo`')},
-        {message: stringsMessage('\'bar\'')}
-      ]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '`foo`'}
+      },
+      {
+        messageId: 'noStringsInJSX',
+        data: {text: '\'bar\''}
+      }]
     }, {
       code: '<Foo bar={`foo` + `bar`} />',
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [
-        {message: stringsMessage('`foo`')},
-        {message: stringsMessage('`bar`')}
-      ]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '`foo`'}
+      },
+      {
+        messageId: 'noStringsInJSX',
+        data: {text: '`bar`'}
+      }]
     }, {
       code: '<Foo bar={\'foo\' + `bar`} />',
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [
-        {message: stringsMessage('\'foo\'')},
-        {message: stringsMessage('`bar`')}
-      ]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '\'foo\''}
+      },
+      {
+        messageId: 'noStringsInJSX',
+        data: {text: '`bar`'}
+      }]
     }, {
       code: `
         class Comp1 extends Component {
@@ -526,24 +570,31 @@ ruleTester.run('jsx-no-literals', rule, {
         }
       `,
       options: [{noStrings: true, allowedStrings: ['asd'], ignoreProps: false}],
-      errors: [
-        {message: stringsMessage('\'foo\'')},
-        {message: stringsMessage('asdf')}
-      ]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '\'foo\''}
+      },
+      {
+        messageId: 'noStringsInJSX',
+        data: {text: 'asdf'}
+      }]
     }, {
       code: '<Foo bar={\'bar\'} />',
       options: [{noStrings: true, ignoreProps: false}],
-      errors: [
-        {message: stringsMessage('\'bar\'')}
-      ]
+      errors: [{
+        messageId: 'noStringsInJSX',
+        data: {text: '\'bar\''}
+      }]
     },
     {
       code: `
         <img alt='blank image'></img>
       `,
       options: [{noAttributeStrings: true}],
-      errors: [
-        {message: attributeMessage('\'blank image\'')}]
+      errors: [{
+        messageId: 'noStringsInAttributes',
+        data: {text: '\'blank image\''}
+      }]
     }
   ]
 });

--- a/tests/lib/rules/jsx-no-script-url.js
+++ b/tests/lib/rules/jsx-no-script-url.js
@@ -25,9 +25,6 @@ const parserOptions = {
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({parserOptions});
-const message = 'A future version of React will block javascript: URLs as a security precaution. '
-  + 'Use event handlers instead if you can. If you need to generate unsafe HTML, try using dangerouslySetInnerHTML instead.';
-const defaultErrors = [{message}];
 
 ruleTester.run('jsx-no-script-url', rule, {
   valid: [
@@ -42,20 +39,20 @@ ruleTester.run('jsx-no-script-url', rule, {
   ],
   invalid: [{
     code: '<a href="javascript:"></a>',
-    errors: defaultErrors
+    errors: [{messageId: 'noScriptURL'}]
   }, {
     code: '<a href="javascript:void(0)"></a>',
-    errors: defaultErrors
+    errors: [{messageId: 'noScriptURL'}]
   }, {
     code: '<a href="j\n\n\na\rv\tascript:"></a>',
-    errors: defaultErrors
+    errors: [{messageId: 'noScriptURL'}]
   }, {
     code: '<Foo to="javascript:"></Foo>',
-    errors: defaultErrors,
+    errors: [{messageId: 'noScriptURL'}],
     options: [[{name: 'Foo', props: ['to', 'href']}]]
   }, {
     code: '<Foo href="javascript:"></Foo>',
-    errors: defaultErrors,
+    errors: [{messageId: 'noScriptURL'}],
     options: [[{name: 'Foo', props: ['to', 'href']}]]
   }, {
     code: `
@@ -64,7 +61,7 @@ ruleTester.run('jsx-no-script-url', rule, {
         <Bar link="javascript:"></Bar>
       </div>
     `,
-    errors: [{message}, {message}],
+    errors: [{messageId: 'noScriptURL'}, {messageId: 'noScriptURL'}],
     options: [[{name: 'Foo', props: ['to', 'href']}, {name: 'Bar', props: ['link']}]]
   }]
 });

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -25,10 +25,7 @@ const parserOptions = {
 // ------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({parserOptions});
-const defaultErrors = [{
-  message: 'Using target="_blank" without rel="noreferrer" is a security risk:'
-  + ' see https://html.spec.whatwg.org/multipage/links.html#link-type-noopener'
-}];
+const defaultErrors = [{messageId: 'noTargetBlank'}];
 
 ruleTester.run('jsx-no-target-blank', rule, {
   valid: [

--- a/tests/lib/rules/jsx-no-undef.js
+++ b/tests/lib/rules/jsx-no-undef.js
@@ -78,27 +78,32 @@ ruleTester.run('jsx-no-undef', rule, {
   invalid: [{
     code: '/*eslint no-undef:1*/ var React; React.render(<App />);',
     errors: [{
-      message: '\'App\' is not defined.'
+      messageId: 'undefined',
+      data: {identifier: 'App'}
     }]
   }, {
     code: '/*eslint no-undef:1*/ var React; React.render(<Appp.Foo />);',
     errors: [{
-      message: '\'Appp\' is not defined.'
+      messageId: 'undefined',
+      data: {identifier: 'Appp'}
     }]
   }, {
     code: '/*eslint no-undef:1*/ var React; React.render(<Apppp:Foo />);',
     errors: [{
-      message: '\'Apppp\' is not defined.'
+      messageId: 'undefined',
+      data: {identifier: 'Apppp'}
     }]
   }, {
     code: '/*eslint no-undef:1*/ var React; React.render(<appp.Foo />);',
     errors: [{
-      message: '\'appp\' is not defined.'
+      messageId: 'undefined',
+      data: {identifier: 'appp'}
     }]
   }, {
     code: '/*eslint no-undef:1*/ var React; React.render(<appp.foo.Bar />);',
     errors: [{
-      message: '\'appp\' is not defined.'
+      messageId: 'undefined',
+      data: {identifier: 'appp'}
     }]
   }, {
     code: `
@@ -111,7 +116,8 @@ ruleTester.run('jsx-no-undef', rule, {
     `,
     parserOptions: Object.assign({sourceType: 'module'}, parserOptions),
     errors: [{
-      message: '\'Text\' is not defined.'
+      messageId: 'undefined',
+      data: {identifier: 'Text'}
     }],
     options: [{
       allowGlobals: false
@@ -123,7 +129,8 @@ ruleTester.run('jsx-no-undef', rule, {
   }, {
     code: '/*eslint no-undef:1*/ var React; React.render(<Foo />);',
     errors: [{
-      message: '\'Foo\' is not defined.'
+      messageId: 'undefined',
+      data: {identifier: 'Foo'}
     }]
   }]
 });

--- a/tests/lib/rules/jsx-one-expression-per-line.js
+++ b/tests/lib/rules/jsx-one-expression-per-line.js
@@ -167,7 +167,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '{"foo"}',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`{"foo"}` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: '{"foo"}'}
+    }],
     parserOptions
   }, {
     code: '<App>foo</App>',
@@ -176,7 +179,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'foo',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -192,7 +198,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '`{"bar"}` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{"bar"}'}
+      }
     ],
     parserOptions
   }, {
@@ -209,7 +218,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '` bar` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: ' bar'}
+      }
     ],
     parserOptions
   }, {
@@ -224,7 +236,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Bar />',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -238,7 +253,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'foo',
       '</div>'
     ].join('\n'),
-    errors: [{message: '`foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -252,7 +270,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '{"foo"}',
       '</div>'
     ].join('\n'),
-    errors: [{message: '`{"foo"}` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: '{"foo"}'}
+    }],
     parserOptions
   }, {
     code: [
@@ -268,7 +289,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '`{ I18n.t(\'baz\') }` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{ I18n.t(\'baz\') }'}
+      }
     ],
     parserOptions
   }, {
@@ -285,9 +309,18 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</Text>'
     ].join('\n'),
     errors: [
-      {message: '`{ bar }` must be placed on a new line'},
-      {message: '`Text` must be placed on a new line'},
-      {message: '`{ I18n.t(\'baz\') }` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{ bar }'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Text'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{ I18n.t(\'baz\') }'}
+      }
     ],
     parserOptions
 
@@ -304,8 +337,14 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</Text>'
     ].join('\n'),
     errors: [
-      {message: '`Bar` must be placed on a new line'},
-      {message: '`Baz` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Bar'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Baz'}
+      }
     ],
     parserOptions
   }, {
@@ -326,10 +365,22 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       ' </Text>'
     ].join('\n'),
     errors: [
-      {message: '`Bar` must be placed on a new line'},
-      {message: '`Baz` must be placed on a new line'},
-      {message: '`Bunk` must be placed on a new line'},
-      {message: '`Bruno` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Bar'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Baz'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Bunk'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Bruno'}
+      }
     ],
     parserOptions
   }, {
@@ -343,7 +394,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</Text>'
     ].join('\n'),
     errors: [
-      {message: '`Bar` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Bar'}
+      }
     ],
     parserOptions
   }, {
@@ -358,7 +412,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</Text>'
     ].join('\n'),
     errors: [
-      {message: '`Bar` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Bar'}
+      }
     ],
     parserOptions
   }, {
@@ -375,7 +432,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</Text>'
     ].join('\n'),
     errors: [
-      {message: '`Baz` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'Baz'}
+      }
     ],
     parserOptions
   }, {
@@ -392,7 +452,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</Text>'
     ].join('\n'),
     errors: [
-      {message: '`{ I18n.t(\'baz\') }` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{ I18n.t(\'baz\') }'}
+      }
     ],
     parserOptions
   }, {
@@ -408,7 +471,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '`input` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'input'}
+      }
     ],
     parserOptions
   }, {
@@ -423,7 +489,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<span />',
       '</div>'
     ].join('\n'),
-    errors: [{message: '`span` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'span'}
+    }],
     parserOptions
   }, {
     code: [
@@ -438,7 +507,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<input />',
       '</div>'
     ].join('\n'),
-    errors: [{message: '`input` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'input'}
+    }],
     parserOptions
   }, {
     code: [
@@ -453,7 +525,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'foo',
       '</div>'
     ].join('\n'),
-    errors: [{message: '` foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: ' foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -469,7 +544,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '`input` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'input'}
+      }
     ],
     parserOptions
   }, {
@@ -487,7 +565,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '`input` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'input'}
+      }
     ],
     parserOptions
   }, {
@@ -504,7 +585,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '`input` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'input'}
+      }
     ],
     parserOptions
   }, {
@@ -520,7 +604,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'bar',
       '</div>'
     ].join('\n'),
-    errors: [{message: '` bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: ' bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -536,7 +623,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '`{"foo"}` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{"foo"}'}
+      }
     ],
     parserOptions
   }, {
@@ -551,7 +641,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Bar></Bar>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -563,7 +656,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Foo></Foo>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -575,7 +671,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Foo />',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -587,7 +686,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Foo/>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -601,7 +703,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '/>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -615,7 +720,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Foo />',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -631,7 +739,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '/>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -645,7 +756,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Foo />',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -659,7 +773,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -673,7 +790,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'Foo>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions
   }, {
     code: [
@@ -687,7 +807,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'Foo>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parserOptions,
     parser: parsers.BABEL_ESLINT
   }, {
@@ -704,7 +827,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Bar />',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -720,7 +846,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</Foo>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Bar` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Bar'}
+    }],
     parserOptions
   }, {
     code: [
@@ -742,7 +871,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</App>'
     ].join('\n'),
     errors: [
-      {message: '` baz ` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: ' baz '}
+      }
     ],
     parserOptions
   }, {
@@ -760,8 +892,14 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</App>'
     ].join('\n'),
     errors: [
-      {message: '`{"bar"}` must be placed on a new line'},
-      {message: '` baz` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{"bar"}'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: ' baz'}
+      }
     ],
     parserOptions
   }, {
@@ -779,7 +917,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</App>'
     ].join('\n'),
     errors: [
-      {message: '`{"bar"}` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{"bar"}'}
+      }
     ],
     parserOptions
   }, {
@@ -801,7 +942,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</App>'
     ].join('\n'),
     errors: [
-      {message: '` baz` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: ' baz'}
+      }
     ],
     parserOptions
   }, {
@@ -823,8 +967,14 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</App>'
     ].join('\n'),
     errors: [
-      {message: '`{"bar"}` must be placed on a new line'},
-      {message: '` baz` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{"bar"}'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: ' baz'}
+      }
     ],
     parserOptions
   }, {
@@ -850,7 +1000,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</App>'
     ].join('\n'),
     errors: [
-      {message: '` baz` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: ' baz'}
+      }
     ],
     parserOptions
   }, {
@@ -867,7 +1020,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</App>'
     ].join('\n'),
     errors: [
-      {message: '`{  foo}` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{  foo}'}
+      }
     ],
     parserOptions
   }, {
@@ -886,7 +1042,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       ' </App>'
     ].join('\n'),
     errors: [
-      {message: '`{  foo}` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{  foo}'}
+      }
     ],
     parserOptions
   }, {
@@ -907,7 +1066,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       ' </App>'
     ].join('\n'),
     errors: [
-      {message: '`{  foo}` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{  foo}'}
+      }
     ],
     parserOptions
   }, {
@@ -918,7 +1080,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Foo />',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}]
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }]
   }, {
     code: '<App>foo</App>',
     options: [{allow: 'none'}],
@@ -927,7 +1092,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'foo',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`foo` must be placed on a new line'}]
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'foo'}
+    }]
   }, {
     code: '<App>{"foo"}</App>',
     options: [{allow: 'none'}],
@@ -936,7 +1104,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '{"foo"}',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`{"foo"}` must be placed on a new line'}]
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: '{"foo"}'}
+    }]
   }, {
     code: [
       '<App>foo',
@@ -948,7 +1119,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'foo',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`foo` must be placed on a new line'}]
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'foo'}
+    }]
   }, {
     code: '<App><Foo /></App>',
     options: [{allow: 'literal'}],
@@ -957,7 +1131,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Foo />',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}]
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }]
   }, {
     code: [
       '<App',
@@ -974,7 +1151,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'baz',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`baz` must be placed on a new line'}]
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'baz'}
+    }]
   }, {
     code: [
       '<App>foo',
@@ -988,7 +1168,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       'bar',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`foobar` must be placed on a new line'}]
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'foobar'}
+    }]
   }, {
     code: '<>{"foo"}</>',
     output: [
@@ -996,7 +1179,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '{"foo"}',
       '</>'
     ].join('\n'),
-    errors: [{message: '`{"foo"}` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: '{"foo"}'}
+    }],
     parser: parsers.BABEL_ESLINT,
     parserOptions
   }, {
@@ -1011,7 +1197,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<></>',
       '</App>'
     ].join('\n'),
-    errors: [{message: '`<></>` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: '<></>'}
+    }],
     parser: parsers.BABEL_ESLINT,
     parserOptions
   }, {
@@ -1026,7 +1215,10 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '<Foo />',
       '</>'
     ].join('\n'),
-    errors: [{message: '`Foo` must be placed on a new line'}],
+    errors: [{
+      messageId: 'moveToNewLine',
+      data: {descriptor: 'Foo'}
+    }],
     parser: parsers.BABEL_ESLINT,
     parserOptions
   }, {
@@ -1047,8 +1239,14 @@ ruleTester.run('jsx-one-expression-per-line', rule, {
       '</div>'
     ].join('\n'),
     errors: [
-      {message: '`a` must be placed on a new line'},
-      {message: '`{a}` must be placed on a new line'}
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: 'a'}
+      },
+      {
+        messageId: 'moveToNewLine',
+        data: {descriptor: '{a}'}
+      }
     ],
     parser: parsers.BABEL_ESLINT,
     parserOptions

--- a/tests/lib/rules/jsx-pascal-case.js
+++ b/tests/lib/rules/jsx-pascal-case.js
@@ -94,31 +94,55 @@ ruleTester.run('jsx-pascal-case', rule, {
 
   invalid: [{
     code: '<Test_component />',
-    errors: [{message: 'Imported JSX component Test_component must be in PascalCase'}]
+    errors: [{
+      messageId: 'usePascalCase',
+      data: {name: 'Test_component'}
+    }]
   }, {
     code: '<TEST_COMPONENT />',
-    errors: [{message: 'Imported JSX component TEST_COMPONENT must be in PascalCase'}]
+    errors: [{
+      messageId: 'usePascalCase',
+      data: {name: 'TEST_COMPONENT'}
+    }]
   }, {
     code: '<YMCA />',
-    errors: [{message: 'Imported JSX component YMCA must be in PascalCase'}]
+    errors: [{
+      messageId: 'usePascalCase',
+      data: {name: 'YMCA'}
+    }]
   }, {
     code: '<_TEST_COMPONENT />',
     options: [{allowAllCaps: true}],
-    errors: [{message: 'Imported JSX component _TEST_COMPONENT must be in PascalCase or SCREAMING_SNAKE_CASE'}]
+    errors: [{
+      messageId: 'usePascalOrSnakeCase',
+      data: {name: '_TEST_COMPONENT'}
+    }]
   }, {
     code: '<TEST_COMPONENT_ />',
     options: [{allowAllCaps: true}],
-    errors: [{message: 'Imported JSX component TEST_COMPONENT_ must be in PascalCase or SCREAMING_SNAKE_CASE'}]
+    errors: [{
+      messageId: 'usePascalOrSnakeCase',
+      data: {name: 'TEST_COMPONENT_'}
+    }]
   }, {
     code: '<__ />',
     options: [{allowAllCaps: true}],
-    errors: [{message: 'Imported JSX component __ must be in PascalCase or SCREAMING_SNAKE_CASE'}]
+    errors: [{
+      messageId: 'usePascalOrSnakeCase',
+      data: {name: '__'}
+    }]
   }, {
     code: '<$a />',
-    errors: [{message: 'Imported JSX component $a must be in PascalCase'}]
+    errors: [{
+      messageId: 'usePascalCase',
+      data: {name: '$a'}
+    }]
   }, {
     code: '<Foo_DEPRECATED />',
     options: [{ignore: ['*_FOO']}],
-    errors: [{message: 'Imported JSX component Foo_DEPRECATED must be in PascalCase'}]
+    errors: [{
+      messageId: 'usePascalCase',
+      data: {name: 'Foo_DEPRECATED'}
+    }]
   }]
 });

--- a/tests/lib/rules/jsx-props-no-multi-spaces.js
+++ b/tests/lib/rules/jsx-props-no-multi-spaces.js
@@ -138,7 +138,10 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
     output: [
       '<App foo />'
     ].join('\n'),
-    errors: [{message: 'Expected only one space between "App" and "foo"'}]
+    errors: [{
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'App', prop2: 'foo'}
+    }]
   }, {
     code: [
       '<App foo="with  spaces   "   bar />'
@@ -146,7 +149,10 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
     output: [
       '<App foo="with  spaces   " bar />'
     ].join('\n'),
-    errors: [{message: 'Expected only one space between "foo" and "bar"'}]
+    errors: [{
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'foo', prop2: 'bar'}
+    }]
   }, {
     code: [
       '<App foo  bar />'
@@ -154,7 +160,10 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
     output: [
       '<App foo bar />'
     ].join('\n'),
-    errors: [{message: 'Expected only one space between "foo" and "bar"'}]
+    errors: [{
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'foo', prop2: 'bar'}
+    }]
   }, {
     code: [
       '<App  foo   bar />'
@@ -162,10 +171,14 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
     output: [
       '<App foo bar />'
     ].join('\n'),
-    errors: [
-      {message: 'Expected only one space between "App" and "foo"'},
-      {message: 'Expected only one space between "foo" and "bar"'}
-    ]
+    errors: [{
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'App', prop2: 'foo'}
+    },
+    {
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'foo', prop2: 'bar'}
+    }]
   }, {
     code: [
       '<App foo  {...test}  bar />'
@@ -173,22 +186,28 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
     output: [
       '<App foo {...test} bar />'
     ].join('\n'),
-    errors: [
-      {message: 'Expected only one space between "foo" and "test"'},
-      {message: 'Expected only one space between "test" and "bar"'}
-    ]
+    errors: [{
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'foo', prop2: 'test'}
+    },
+    {
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'test', prop2: 'bar'}
+    }]
   }, {
     code: '<Foo.Bar  baz="quux" />',
     output: '<Foo.Bar baz="quux" />',
-    errors: [
-      {message: 'Expected only one space between "Foo.Bar" and "baz"'}
-    ]
+    errors: [{
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'Foo.Bar', prop2: 'baz'}
+    }]
   }, {
     code: '<Foobar.Foo.Bar.Baz.Qux.Quux.Quuz.Corge.Grault.Garply.Waldo.Fred.Plugh  xyzzy="thud" />',
     output: '<Foobar.Foo.Bar.Baz.Qux.Quux.Quuz.Corge.Grault.Garply.Waldo.Fred.Plugh xyzzy="thud" />',
-    errors: [
-      {message: 'Expected only one space between "Foobar.Foo.Bar.Baz.Qux.Quux.Quuz.Corge.Grault.Garply.Waldo.Fred.Plugh" and "xyzzy"'}
-    ]
+    errors: [{
+      messageId: 'onlyOneSpace',
+      data: {prop1: 'Foobar.Foo.Bar.Baz.Qux.Quux.Quuz.Corge.Grault.Garply.Waldo.Fred.Plugh', prop2: 'xyzzy'}
+    }]
   }, {
     code: `
       <button
@@ -197,7 +216,10 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
         type="button"
       />
     `,
-    errors: [{message: 'Expected no line gap between “title” and “type”'}]
+    errors: [{
+      messageId: 'noLineGap',
+      data: {prop1: 'title', prop2: 'type'}
+    }]
   }, {
     code: `
       <button
@@ -210,10 +232,14 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
         type="button"
       />
     `,
-    errors: [
-      {message: 'Expected no line gap between “title” and “onClick”'},
-      {message: 'Expected no line gap between “onClick” and “type”'}
-    ]
+    errors: [{
+      messageId: 'noLineGap',
+      data: {prop1: 'title', prop2: 'onClick'}
+    },
+    {
+      messageId: 'noLineGap',
+      data: {prop1: 'onClick', prop2: 'type'}
+    }]
   }, {
     code: `
       <button
@@ -226,9 +252,10 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
         type="button"
       />
     `,
-    errors: [
-      {message: 'Expected no line gap between “onClick” and “type”'}
-    ]
+    errors: [{
+      messageId: 'noLineGap',
+      data: {prop1: 'onClick', prop2: 'type'}
+    }]
   }, {
     code: `
       <button
@@ -243,10 +270,14 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
         type="button"
       />
     `,
-    errors: [
-      {message: 'Expected no line gap between “title” and “onClick”'},
-      {message: 'Expected no line gap between “onClick” and “type”'}
-    ]
+    errors: [{
+      messageId: 'noLineGap',
+      data: {prop1: 'title', prop2: 'onClick'}
+    },
+    {
+      messageId: 'noLineGap',
+      data: {prop1: 'onClick', prop2: 'type'}
+    }]
   }, {
     code: `
       <button
@@ -263,9 +294,13 @@ ruleTester.run('jsx-props-no-multi-spaces', rule, {
         type="button"
       />
     `,
-    errors: [
-      {message: 'Expected no line gap between “title” and “onClick”'},
-      {message: 'Expected no line gap between “onClick” and “type”'}
-    ]
+    errors: [{
+      messageId: 'noLineGap',
+      data: {prop1: 'title', prop2: 'onClick'}
+    },
+    {
+      messageId: 'noLineGap',
+      data: {prop1: 'onClick', prop2: 'type'}
+    }]
   }]
 });

--- a/tests/lib/rules/jsx-props-no-spreading.js
+++ b/tests/lib/rules/jsx-props-no-spreading.js
@@ -24,7 +24,7 @@ const parserOptions = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({parserOptions});
-const expectedError = {message: 'Prop spreading is forbidden'};
+const expectedError = {messageId: 'noSpreading'};
 
 ruleTester.run('jsx-props-no-spreading', rule, {
   valid: [{

--- a/tests/lib/rules/jsx-sort-default-props.js
+++ b/tests/lib/rules/jsx-sort-default-props.js
@@ -26,8 +26,6 @@ const parserOptions = {
 // Tests
 // -----------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Default prop types declarations should be sorted alphabetically';
-
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('jsx-sort-default-props', rule, {
   valid: [{
@@ -370,7 +368,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 10,
       column: 5,
       type: 'Property'
@@ -450,7 +448,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
       ignoreCase: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 8,
       column: 5,
       type: 'Property'
@@ -488,7 +486,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 8,
       column: 5,
       type: 'Property'
@@ -526,7 +524,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 12,
       column: 3,
       type: 'Property'
@@ -601,7 +599,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 12,
       column: 3,
       type: 'Property'
@@ -642,7 +640,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
   //   ].join('\n'),
   //   parser: parsers.BABEL_ESLINT,
   //   errors: [{
-  //     message: ERROR_MESSAGE,
+  //     messageId: 'propsNotSorted',
   //     line: 14,
   //     column: 3,
   //     type: 'Property'
@@ -685,7 +683,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
       ignoreCase: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 12,
       column: 3,
       type: 'Property'
@@ -720,7 +718,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
       'First.defaultProps = defaultProps;'
     ].join('\n'),
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 8,
       column: 3,
       type: 'Property'
@@ -755,7 +753,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 9,
       column: 5,
       type: 'Property'
@@ -839,7 +837,7 @@ ruleTester.run('jsx-sort-default-props', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 15,
       column: 3,
       type: 'Property'

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -27,30 +27,31 @@ const parserOptions = {
 const ruleTester = new RuleTester({parserOptions});
 
 const expectedError = {
-  message: 'Props should be sorted alphabetically',
+  messageId: 'sortPropsByAlpha',
   type: 'JSXIdentifier'
 };
 const expectedCallbackError = {
-  message: 'Callbacks must be listed after all other props',
+  messageId: 'listCallbacksLast',
   type: 'JSXIdentifier'
 };
 const expectedShorthandFirstError = {
-  message: 'Shorthand props must be listed before all other props',
+  messageId: 'listShorthandFirst',
   type: 'JSXIdentifier'
 };
 const expectedShorthandLastError = {
-  message: 'Shorthand props must be listed after all other props',
+  messageId: 'listShorthandLast',
   type: 'JSXIdentifier'
 };
 const expectedReservedFirstError = {
-  message: 'Reserved props must be listed before all other props',
+  messageId: 'listReservedPropsFirst',
   type: 'JSXIdentifier'
 };
 const expectedEmptyReservedFirstError = {
-  message: 'A customized reserved first list must not be empty'
+  messageId: 'listIsEmpty'
 };
 const expectedInvalidReservedFirstError = {
-  message: 'A customized reserved first list must only contain a subset of React reserved props. Remove: notReserved'
+  messageId: 'noUnreservedProps',
+  data: {unreservedWords: 'notReserved'}
 };
 const callbacksLastArgs = [{
   callbacksLast: true

--- a/tests/lib/rules/jsx-space-before-closing.js
+++ b/tests/lib/rules/jsx-space-before-closing.js
@@ -70,53 +70,53 @@ ruleTester.run('jsx-space-before-closing', rule, {
     code: '<App/>',
     output: '<App />',
     errors: [
-      {message: 'A space is required before closing bracket'}
+      {messageId: 'needSpaceBeforeClose'}
     ]
   }, {
     code: '<App foo/>',
     output: '<App foo />',
     errors: [
-      {message: 'A space is required before closing bracket'}
+      {messageId: 'needSpaceBeforeClose'}
     ]
   }, {
     code: '<App foo={bar}/>',
     output: '<App foo={bar} />',
     errors: [
-      {message: 'A space is required before closing bracket'}
+      {messageId: 'needSpaceBeforeClose'}
     ]
   }, {
     code: '<App {...props}/>',
     output: '<App {...props} />',
     errors: [
-      {message: 'A space is required before closing bracket'}
+      {messageId: 'needSpaceBeforeClose'}
     ]
   }, {
     code: '<App />',
     output: '<App/>',
     options: ['never'],
     errors: [
-      {message: 'A space is forbidden before closing bracket'}
+      {messageId: 'noSpaceBeforeClose'}
     ]
   }, {
     code: '<App foo />',
     output: '<App foo/>',
     options: ['never'],
     errors: [
-      {message: 'A space is forbidden before closing bracket'}
+      {messageId: 'noSpaceBeforeClose'}
     ]
   }, {
     code: '<App foo={bar} />',
     output: '<App foo={bar}/>',
     options: ['never'],
     errors: [
-      {message: 'A space is forbidden before closing bracket'}
+      {messageId: 'noSpaceBeforeClose'}
     ]
   }, {
     code: '<App {...props} />',
     output: '<App {...props}/>',
     options: ['never'],
     errors: [
-      {message: 'A space is forbidden before closing bracket'}
+      {messageId: 'noSpaceBeforeClose'}
     ]
   }]
 });

--- a/tests/lib/rules/jsx-tag-spacing.js
+++ b/tests/lib/rules/jsx-tag-spacing.js
@@ -214,61 +214,61 @@ ruleTester.run('jsx-tag-spacing', rule, {
     output: '<App />',
     options: beforeSelfClosingOptions('always'),
     errors: [
-      {message: 'A space is required before closing bracket'}
+      {messageId: 'beforeSelfCloseNeedSpace'}
     ]
   }, {
     code: '<App foo/>',
     output: '<App foo />',
     options: beforeSelfClosingOptions('always'),
     errors: [
-      {message: 'A space is required before closing bracket'}
+      {messageId: 'beforeSelfCloseNeedSpace'}
     ]
   }, {
     code: '<App foo={bar}/>',
     output: '<App foo={bar} />',
     options: beforeSelfClosingOptions('always'),
     errors: [
-      {message: 'A space is required before closing bracket'}
+      {messageId: 'beforeSelfCloseNeedSpace'}
     ]
   }, {
     code: '<App {...props}/>',
     output: '<App {...props} />',
     options: beforeSelfClosingOptions('always'),
     errors: [
-      {message: 'A space is required before closing bracket'}
+      {messageId: 'beforeSelfCloseNeedSpace'}
     ]
   }, {
     code: '<App />',
     output: '<App/>',
     options: beforeSelfClosingOptions('never'),
     errors: [
-      {message: 'A space is forbidden before closing bracket'}
+      {messageId: 'beforeSelfCloseNoSpace'}
     ]
   }, {
     code: '<App foo />',
     output: '<App foo/>',
     options: beforeSelfClosingOptions('never'),
     errors: [
-      {message: 'A space is forbidden before closing bracket'}
+      {messageId: 'beforeSelfCloseNoSpace'}
     ]
   }, {
     code: '<App foo={bar} />',
     output: '<App foo={bar}/>',
     options: beforeSelfClosingOptions('never'),
     errors: [
-      {message: 'A space is forbidden before closing bracket'}
+      {messageId: 'beforeSelfCloseNoSpace'}
     ]
   }, {
     code: '<App {...props} />',
     output: '<App {...props}/>',
     options: beforeSelfClosingOptions('never'),
     errors: [
-      {message: 'A space is forbidden before closing bracket'}
+      {messageId: 'beforeSelfCloseNoSpace'}
     ]
   }, {
     code: '<App/ >;',
     output: '<App/>;',
-    errors: [{message: 'Whitespace is forbidden between `/` and `>`; write `/>`'}],
+    errors: [{messageId: 'selfCloseSlashNoSpace'}],
     options: closingSlashOptions('never')
   }, {
     code: [
@@ -276,12 +276,12 @@ ruleTester.run('jsx-tag-spacing', rule, {
       '>'
     ].join('\n'),
     output: '<App/>',
-    errors: [{message: 'Whitespace is forbidden between `/` and `>`; write `/>`'}],
+    errors: [{messageId: 'selfCloseSlashNoSpace'}],
     options: closingSlashOptions('never')
   }, {
     code: '<div className="bar">< /div>;',
     output: '<div className="bar"></div>;',
-    errors: [{message: 'Whitespace is forbidden between `<` and `/`; write `</`'}],
+    errors: [{messageId: 'closeSlashNoSpace'}],
     options: closingSlashOptions('never')
   }, {
     code: [
@@ -289,39 +289,39 @@ ruleTester.run('jsx-tag-spacing', rule, {
       '/div>;'
     ].join('\n'),
     output: '<div className="bar"></div>;',
-    errors: [{message: 'Whitespace is forbidden between `<` and `/`; write `</`'}],
+    errors: [{messageId: 'closeSlashNoSpace'}],
     options: closingSlashOptions('never')
   }, {
     code: '<App prop="foo"></App>',
     output: '<App prop="foo">< /App>',
-    errors: [{message: 'Whitespace is required between `<` and `/`; write `< /`'}],
+    errors: [{messageId: 'closeSlashNeedSpace'}],
     options: closingSlashOptions('always')
   }, {
     code: '<p/>',
     output: '<p/ >',
-    errors: [{message: 'Whitespace is required between `/` and `>`; write `/ >`'}],
+    errors: [{messageId: 'selfCloseSlashNeedSpace'}],
     options: closingSlashOptions('always')
   }, {
     code: '< App/>',
     output: '<App/>',
-    errors: [{message: 'A space is forbidden after opening bracket'}],
+    errors: [{messageId: 'afterOpenNoSpace'}],
     options: afterOpeningOptions('never')
   }, {
     code: '< App></App>',
     output: '<App></App>',
-    errors: [{message: 'A space is forbidden after opening bracket'}],
+    errors: [{messageId: 'afterOpenNoSpace'}],
     options: afterOpeningOptions('never')
   }, {
     code: '<App></ App>',
     output: '<App></App>',
-    errors: [{message: 'A space is forbidden after opening bracket'}],
+    errors: [{messageId: 'afterOpenNoSpace'}],
     options: afterOpeningOptions('never')
   }, {
     code: '< App></ App>',
     output: '<App></App>',
     errors: [
-      {message: 'A space is forbidden after opening bracket'},
-      {message: 'A space is forbidden after opening bracket'}
+      {messageId: 'afterOpenNoSpace'},
+      {messageId: 'afterOpenNoSpace'}
     ],
     options: afterOpeningOptions('never')
   }, {
@@ -330,45 +330,45 @@ ruleTester.run('jsx-tag-spacing', rule, {
       'App/>'
     ].join('\n'),
     output: '<App/>',
-    errors: [{message: 'A space is forbidden after opening bracket'}],
+    errors: [{messageId: 'afterOpenNoSpace'}],
     options: afterOpeningOptions('never')
   }, {
     code: '<App></ App>',
     output: '< App></ App>',
-    errors: [{message: 'A space is required after opening bracket'}],
+    errors: [{messageId: 'afterOpenNeedSpace'}],
     options: afterOpeningOptions('always')
   }, {
     code: '< App></App>',
     output: '< App></ App>',
-    errors: [{message: 'A space is required after opening bracket'}],
+    errors: [{messageId: 'afterOpenNeedSpace'}],
     options: afterOpeningOptions('always')
   }, {
     code: '<App></App>',
     output: '< App></ App>',
     errors: [
-      {message: 'A space is required after opening bracket'},
-      {message: 'A space is required after opening bracket'}
+      {messageId: 'afterOpenNeedSpace'},
+      {messageId: 'afterOpenNeedSpace'}
     ],
     options: afterOpeningOptions('always')
   }, {
     code: '<App/>',
     output: '< App/>',
-    errors: [{message: 'A space is required after opening bracket'}],
+    errors: [{messageId: 'afterOpenNeedSpace'}],
     options: afterOpeningOptions('always')
   }, {
     code: '< App/>',
     output: '<App/>',
-    errors: [{message: 'A space is forbidden after opening bracket'}],
+    errors: [{messageId: 'afterOpenNoSpace'}],
     options: afterOpeningOptions('allow-multiline')
   }, {
     code: '<App ></App>',
     output: '<App></App>',
-    errors: [{message: 'A space is forbidden before closing bracket'}],
+    errors: [{messageId: 'beforeCloseNoSpace'}],
     options: beforeClosingOptions('never')
   }, {
     code: '<App></App >',
     output: '<App></App>',
-    errors: [{message: 'A space is forbidden before closing bracket'}],
+    errors: [{messageId: 'beforeCloseNoSpace'}],
     options: beforeClosingOptions('never')
   }, {
     code: [
@@ -383,17 +383,17 @@ ruleTester.run('jsx-tag-spacing', rule, {
       '>',
       '</App>'
     ].join('\n'),
-    errors: [{message: 'A space is forbidden before closing bracket'}],
+    errors: [{messageId: 'beforeCloseNoSpace'}],
     options: beforeClosingOptions('never')
   }, {
     code: '<App></App >',
     output: '<App ></App >',
-    errors: [{message: 'Whitespace is required before closing bracket'}],
+    errors: [{messageId: 'beforeCloseNeedSpace'}],
     options: beforeClosingOptions('always')
   }, {
     code: '<App ></App>',
     output: '<App ></App >',
-    errors: [{message: 'Whitespace is required before closing bracket'}],
+    errors: [{messageId: 'beforeCloseNeedSpace'}],
     options: beforeClosingOptions('always')
   }, {
     code: [
@@ -408,7 +408,7 @@ ruleTester.run('jsx-tag-spacing', rule, {
       '>',
       '</App >'
     ].join('\n'),
-    errors: [{message: 'Whitespace is required before closing bracket'}],
+    errors: [{messageId: 'beforeCloseNeedSpace'}],
     options: beforeClosingOptions('always')
   }]
 });

--- a/tests/lib/rules/jsx-wrap-multilines.js
+++ b/tests/lib/rules/jsx-wrap-multilines.js
@@ -26,9 +26,6 @@ const parserOptions = {
 // Constants/Code Snippets
 // ------------------------------------------------------------------------------
 
-const MISSING_PARENS = 'Missing parentheses around multilines JSX';
-const PARENS_NEW_LINES = 'Parentheses around JSX should be on separate lines';
-
 const OPTIONS_ALL_NEW_LINES = {
   declaration: 'parens-new-line',
   assignment: 'parens-new-line',
@@ -844,45 +841,45 @@ ruleTester.run('jsx-wrap-multilines', rule, {
     {
       code: RETURN_NO_PAREN,
       output: RETURN_PAREN,
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: RETURN_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: RETURN_PAREN_FRAGMENT,
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: RETURN_NO_PAREN,
       output: RETURN_PAREN,
       options: [{return: true}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: RETURN_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: RETURN_PAREN_FRAGMENT,
       options: [{return: true}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: DECLARATION_TERNARY_NO_PAREN,
       output: DECLARATION_TERNARY_PAREN,
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: DECLARATION_TERNARY_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: DECLARATION_TERNARY_PAREN_FRAGMENT,
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: DECLARATION_TERNARY_NO_PAREN,
       output: DECLARATION_TERNARY_PAREN,
       options: [{declaration: true}],
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: DECLARATION_TERNARY_NO_PAREN_FRAGMENT,
@@ -890,31 +887,31 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       output: DECLARATION_TERNARY_PAREN_FRAGMENT,
       options: [{declaration: true}],
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_NO_PAREN,
       output: ASSIGNMENT_TERNARY_PAREN,
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: ASSIGNMENT_TERNARY_PAREN_FRAGMENT,
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_NO_PAREN,
       output: ASSIGNMENT_TERNARY_PAREN,
       options: [{assignment: true}],
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_NO_PAREN_FRAGMENT,
@@ -922,138 +919,138 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       output: ASSIGNMENT_TERNARY_PAREN_FRAGMENT,
       options: [{assignment: true}],
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: DECLARATION_NO_PAREN,
       output: DECLARATION_PAREN,
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: DECLARATION_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: DECLARATION_PAREN_FRAGMENT,
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: DECLARATION_NO_PAREN,
       output: DECLARATION_PAREN,
       options: [{declaration: true}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ASSIGNMENT_NO_PAREN,
       output: ASSIGNMENT_PAREN,
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ASSIGNMENT_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: ASSIGNMENT_PAREN_FRAGMENT,
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ASSIGNMENT_NO_PAREN,
       output: ASSIGNMENT_PAREN,
       options: [{assignment: true}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ARROW_NO_PAREN,
       output: ARROW_PAREN,
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ARROW_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: ARROW_PAREN_FRAGMENT,
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ARROW_NO_PAREN,
       output: ARROW_PAREN,
       options: [{arrow: true}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: CONDITION_NO_PAREN,
       output: CONDITION_PAREN,
       options: [{condition: 'parens'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: CONDITION_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: CONDITION_PAREN_FRAGMENT,
       options: [{condition: 'parens'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: CONDITION_NO_PAREN,
       output: CONDITION_PAREN,
       options: [{condition: true}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: LOGICAL_NO_PAREN,
       output: LOGICAL_PAREN,
       options: [{logical: 'parens'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: LOGICAL_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: LOGICAL_PAREN_FRAGMENT,
       options: [{logical: 'parens'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: LOGICAL_NO_PAREN,
       output: LOGICAL_PAREN,
       options: [{logical: true}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ATTR_NO_PAREN,
       output: ATTR_PAREN,
       options: [{prop: 'parens'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ATTR_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: ATTR_PAREN_FRAGMENT,
       options: [{prop: 'parens'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ATTR_NO_PAREN,
       output: ATTR_PAREN,
       options: [{prop: true}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: RETURN_NO_PAREN,
       output: addNewLineSymbols(RETURN_PAREN),
       options: [{return: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: RETURN_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: addNewLineSymbols(RETURN_PAREN_FRAGMENT),
       options: [{return: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: RETURN_PAREN,
       output: addNewLineSymbols(RETURN_PAREN),
       options: [{return: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: RETURN_PAREN_NEW_LINE_OPENING,
       output: RETURN_PAREN_NEW_LINE_OPENING_FIXED,
       options: [{return: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: RETURN_PAREN_NEW_LINE_CLOSING,
       output: RETURN_PAREN_NEW_LINE_CLOSING_FIXED,
       options: [{return: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: RETURN_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: addNewLineSymbols(RETURN_PAREN_FRAGMENT),
       options: [{return: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: DECLARATION_TERNARY_NO_PAREN,
       output: addNewLineSymbols(DECLARATION_TERNARY_PAREN),
       options: [{declaration: 'parens-new-line'}],
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: DECLARATION_TERNARY_NO_PAREN_FRAGMENT,
@@ -1061,8 +1058,8 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       output: addNewLineSymbols(DECLARATION_TERNARY_PAREN_FRAGMENT),
       options: [{declaration: 'parens-new-line'}],
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: DECLARATION_TERNARY_PAREN_FRAGMENT,
@@ -1070,16 +1067,16 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       output: addNewLineSymbols(DECLARATION_TERNARY_PAREN_FRAGMENT),
       options: [{declaration: 'parens-new-line'}],
       errors: [
-        {message: PARENS_NEW_LINES},
-        {message: PARENS_NEW_LINES}
+        {messageId: 'parensOnNewLines'},
+        {messageId: 'parensOnNewLines'}
       ]
     }, {
       code: DECLARATION_TERNARY_PAREN,
       output: addNewLineSymbols(DECLARATION_TERNARY_PAREN),
       options: [{declaration: 'parens-new-line'}],
       errors: [
-        {message: PARENS_NEW_LINES},
-        {message: PARENS_NEW_LINES}
+        {messageId: 'parensOnNewLines'},
+        {messageId: 'parensOnNewLines'}
       ]
     }, {
       code: DECLARATION_TERNARY_PAREN_FRAGMENT,
@@ -1087,16 +1084,16 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       output: addNewLineSymbols(DECLARATION_TERNARY_PAREN_FRAGMENT),
       options: [{declaration: 'parens-new-line'}],
       errors: [
-        {message: PARENS_NEW_LINES},
-        {message: PARENS_NEW_LINES}
+        {messageId: 'parensOnNewLines'},
+        {messageId: 'parensOnNewLines'}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_NO_PAREN,
       output: addNewLineSymbols(ASSIGNMENT_TERNARY_PAREN),
       options: [{assignment: 'parens-new-line'}],
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_NO_PAREN_FRAGMENT,
@@ -1104,16 +1101,16 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       output: addNewLineSymbols(ASSIGNMENT_TERNARY_PAREN_FRAGMENT),
       options: [{assignment: 'parens-new-line'}],
       errors: [
-        {message: MISSING_PARENS},
-        {message: MISSING_PARENS}
+        {messageId: 'missingParens'},
+        {messageId: 'missingParens'}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_PAREN,
       output: addNewLineSymbols(ASSIGNMENT_TERNARY_PAREN),
       options: [{assignment: 'parens-new-line'}],
       errors: [
-        {message: PARENS_NEW_LINES},
-        {message: PARENS_NEW_LINES}
+        {messageId: 'parensOnNewLines'},
+        {messageId: 'parensOnNewLines'}
       ]
     }, {
       code: ASSIGNMENT_TERNARY_PAREN_FRAGMENT,
@@ -1121,117 +1118,117 @@ ruleTester.run('jsx-wrap-multilines', rule, {
       output: addNewLineSymbols(ASSIGNMENT_TERNARY_PAREN_FRAGMENT),
       options: [{assignment: 'parens-new-line'}],
       errors: [
-        {message: PARENS_NEW_LINES},
-        {message: PARENS_NEW_LINES}
+        {messageId: 'parensOnNewLines'},
+        {messageId: 'parensOnNewLines'}
       ]
     }, {
       code: DECLARATION_NO_PAREN,
       output: addNewLineSymbols(DECLARATION_PAREN),
       options: [{declaration: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: DECLARATION_PAREN,
       output: addNewLineSymbols(DECLARATION_PAREN),
       options: [{declaration: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: ASSIGNMENT_NO_PAREN,
       output: addNewLineSymbols(ASSIGNMENT_PAREN),
       options: [{assignment: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ASSIGNMENT_PAREN,
       output: addNewLineSymbols(ASSIGNMENT_PAREN),
       options: [{assignment: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: ARROW_PAREN,
       output: addNewLineSymbols(ARROW_PAREN),
       options: [{arrow: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: ARROW_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: addNewLineSymbols(ARROW_PAREN_FRAGMENT),
       options: [{arrow: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: ARROW_NO_PAREN,
       output: addNewLineSymbols(ARROW_PAREN),
       options: [{arrow: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ARROW_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: addNewLineSymbols(ARROW_PAREN_FRAGMENT),
       options: [{arrow: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: CONDITION_PAREN,
       output: addNewLineSymbols(CONDITION_PAREN),
       options: [{condition: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: CONDITION_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: addNewLineSymbols(CONDITION_PAREN_FRAGMENT),
       options: [{condition: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: CONDITION_NO_PAREN,
       output: addNewLineSymbols(CONDITION_PAREN),
       options: [{condition: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: CONDITION_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: addNewLineSymbols(CONDITION_PAREN_FRAGMENT),
       options: [{condition: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: LOGICAL_PAREN,
       output: addNewLineSymbols(LOGICAL_PAREN),
       options: [{logical: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: LOGICAL_NO_PAREN,
       output: LOGICAL_PAREN_NEW_LINE_AUTOFIX,
       options: [{logical: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: LOGICAL_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: LOGICAL_PAREN_NEW_LINE_AUTOFIX_FRAGMENT,
       options: [{logical: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ATTR_PAREN,
       output: addNewLineSymbols(ATTR_PAREN),
       options: [{prop: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: ATTR_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: addNewLineSymbols(ATTR_PAREN_FRAGMENT),
       options: [{prop: 'parens-new-line'}],
-      errors: [{message: PARENS_NEW_LINES}]
+      errors: [{messageId: 'parensOnNewLines'}]
     }, {
       code: ATTR_NO_PAREN,
       output: ATTR_PAREN_NEW_LINE_AUTOFIX,
       options: [{prop: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ATTR_NO_PAREN_FRAGMENT,
       parser: parsers.BABEL_ESLINT,
       output: ATTR_PAREN_NEW_LINE_AUTOFIX_FRAGMENT,
       options: [{prop: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     },
     {
       code: SFC_NO_PARENS_NO_NEWLINE,
       output: SFC_NO_PARENS_AUTOFIX,
       options: [OPTIONS_ALL_NEW_LINES],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ARROW_WITH_EXPORT,
       output: ARROW_WITH_EXPORT_AUTOFIX,
@@ -1244,12 +1241,12 @@ ruleTester.run('jsx-wrap-multilines', rule, {
         logical: 'ignore',
         prop: 'ignore'
       }],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: ARROW_WITH_LOGICAL,
       output: ARROW_WITH_LOGICAL_AUTOFIX,
       options: [{logical: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }, {
       code: [
         'import React from \'react\';',
@@ -1269,6 +1266,6 @@ ruleTester.run('jsx-wrap-multilines', rule, {
         ');'
       ].join('\n'),
       options: [{declaration: 'parens-new-line'}],
-      errors: [{message: MISSING_PARENS}]
+      errors: [{messageId: 'missingParens'}]
     }]
 });

--- a/tests/lib/rules/no-access-state-in-setstate.js
+++ b/tests/lib/rules/no-access-state-in-setstate.js
@@ -148,9 +148,7 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '});'
     ].join('\n'),
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }, {
     code: [
       'var Hello = React.createClass({',
@@ -160,9 +158,7 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '});'
     ].join('\n'),
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }, {
     code: [
       'var Hello = React.createClass({',
@@ -173,9 +169,7 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '});'
     ].join('\n'),
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }, {
     code: [
       'var Hello = React.createClass({',
@@ -186,9 +180,7 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '});'
     ].join('\n'),
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }, {
     code: [
       'function nextState(state) {',
@@ -201,9 +193,7 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '});'
     ].join('\n'),
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }, {
     code: `
       var Hello = React.createClass({
@@ -213,9 +203,7 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       });
     `,
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }, {
     code: `
       var Hello = React.createClass({
@@ -225,9 +213,7 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       });
     `,
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }, {
     code: [
       'var Hello = React.createClass({',
@@ -240,9 +226,7 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       '});'
     ].join('\n'),
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }, {
     code: `
       class Hello extends React.Component {
@@ -252,8 +236,6 @@ ruleTester.run('no-access-state-in-setstate', rule, {
       }
     `,
     parserOptions,
-    errors: [{
-      message: 'Use callback in setState when referencing the previous state.'
-    }]
+    errors: [{messageId: 'useCallback'}]
   }]
 });

--- a/tests/lib/rules/no-adjacent-inline-elements.js
+++ b/tests/lib/rules/no-adjacent-inline-elements.js
@@ -12,8 +12,6 @@
 const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/no-adjacent-inline-elements');
 
-const ERROR = rule.ERROR;
-
 const parserOptions = {
   ecmaVersion: 6,
   ecmaFeatures: {
@@ -90,17 +88,17 @@ ruleTester.run('no-adjacent-inline-elements', rule, {
   invalid: [
     {
       code: '<div><a></a><a></a></div>;',
-      errors: [{message: ERROR}],
+      errors: [{messageId: 'inlineElement'}],
       parserOptions
     },
     {
       code: '<div><a></a><span></span></div>;',
-      errors: [{message: ERROR}],
+      errors: [{messageId: 'inlineElement'}],
       parserOptions
     },
     {
       code: 'React.createElement("div", undefined, [React.createElement("a"), React.createElement("span")]);',
-      errors: [{message: ERROR}],
+      errors: [{messageId: 'inlineElement'}],
       parserOptions
     }
   ]

--- a/tests/lib/rules/no-array-index-key.js
+++ b/tests/lib/rules/no-array-index-key.js
@@ -128,37 +128,37 @@ ruleTester.run('no-array-index-key', rule, {
   invalid: [].concat(
     {
       code: 'foo.map((bar, i) => <Foo key={i} />)',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: '[{}, {}].map((bar, i) => <Foo key={i} />)',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((bar, anything) => <Foo key={anything} />)',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((bar, i) => <Foo key={`foo-${i}`} />)',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((bar, i) => <Foo key={\'foo-\' + i} />)',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((bar, i) => <Foo key={\'foo-\' + i + \'-bar\'} />)',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((baz, i) => React.cloneElement(someChild, { ...someChild.props, key: i }))',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
@@ -169,97 +169,97 @@ ruleTester.run('no-array-index-key', rule, {
           })
         })
       `,
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.forEach((bar, i) => { baz.push(<Foo key={i} />); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.filter((bar, i) => { baz.push(<Foo key={i} />); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.some((bar, i) => { baz.push(<Foo key={i} />); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.every((bar, i) => { baz.push(<Foo key={i} />); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.find((bar, i) => { baz.push(<Foo key={i} />); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.findIndex((bar, i) => { baz.push(<Foo key={i} />); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.reduce((a, b, i) => a.concat(<Foo key={i} />), [])',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.reduceRight((a, b, i) => a.concat(<Foo key={i} />), [])',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((bar, i) => React.createElement(\'Foo\', { key: i }))',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((bar, i) => React.createElement(\'Foo\', { key: `foo-${i}` }))',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((bar, i) => React.createElement(\'Foo\', { key: \'foo-\' + i }))',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.map((bar, i) => React.createElement(\'Foo\', { key: \'foo-\' + i + \'-bar\' }))',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.forEach((bar, i) => { baz.push(React.createElement(\'Foo\', { key: i })); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.filter((bar, i) => { baz.push(React.createElement(\'Foo\', { key: i })); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.some((bar, i) => { baz.push(React.createElement(\'Foo\', { key: i })); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.every((bar, i) => { baz.push(React.createElement(\'Foo\', { key: i })); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.find((bar, i) => { baz.push(React.createElement(\'Foo\', { key: i })); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
       code: 'foo.findIndex((bar, i) => { baz.push(React.createElement(\'Foo\', { key: i })); })',
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
@@ -268,7 +268,7 @@ ruleTester.run('no-array-index-key', rule, {
         return React.cloneElement(child, { key: index });
       })
       `,
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
@@ -277,7 +277,7 @@ ruleTester.run('no-array-index-key', rule, {
         return React.cloneElement(child, { key: index });
       })
       `,
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
@@ -286,7 +286,7 @@ ruleTester.run('no-array-index-key', rule, {
         return React.cloneElement(child, { key: index });
       })
       `,
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     {
@@ -295,26 +295,26 @@ ruleTester.run('no-array-index-key', rule, {
         return React.cloneElement(child, { key: index });
       })
       `,
-      errors: [{message: 'Do not use Array index in keys'}]
+      errors: [{messageId: 'noArrayIndex'}]
     },
 
     parsers.ES2020({
       code: 'foo?.map((child, i) => <Foo key={i} />)',
-      errors: [{message: 'Do not use Array index in keys'}],
+      errors: [{messageId: 'noArrayIndex'}],
       parserOptions: {
         ecmaVersion: 2020
       }
     }, {
       code: 'foo?.map((child, i) => <Foo key={i} />)',
-      errors: [{message: 'Do not use Array index in keys'}],
+      errors: [{messageId: 'noArrayIndex'}],
       parser: parsers.BABEL_ESLINT
     }, {
       code: 'foo?.map((child, i) => <Foo key={i} />)',
-      errors: [{message: 'Do not use Array index in keys'}],
+      errors: [{messageId: 'noArrayIndex'}],
       parser: parsers.TYPESCRIPT_ESLINT
     }, {
       code: 'foo?.map((child, i) => <Foo key={i} />)',
-      errors: [{message: 'Do not use Array index in keys'}],
+      errors: [{messageId: 'noArrayIndex'}],
       parser: parsers['@TYPESCRIPT_ESLINT']
     })
   )

--- a/tests/lib/rules/no-children-prop.js
+++ b/tests/lib/rules/no-children-prop.js
@@ -20,9 +20,6 @@ const parserOptions = {
   }
 };
 
-const JSX_ERROR = 'Do not pass children as props. Instead, nest children between the opening and closing tags.';
-const CREATE_ELEMENT_ERROR = 'Do not pass children as props. Instead, pass them as additional arguments to React.createElement.';
-
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -145,59 +142,59 @@ ruleTester.run('no-children-prop', rule, {
   invalid: [
     {
       code: '<div children="Children" />;',
-      errors: [{message: JSX_ERROR}]
+      errors: [{messageId: 'nestChildren'}]
     },
     {
       code: '<div children={<div />} />;',
-      errors: [{message: JSX_ERROR}]
+      errors: [{messageId: 'nestChildren'}]
     },
     {
       code: '<div children={[<div />, <div />]} />;',
-      errors: [{message: JSX_ERROR}]
+      errors: [{messageId: 'nestChildren'}]
     },
     {
       code: '<div children="Children">Children</div>;',
-      errors: [{message: JSX_ERROR}]
+      errors: [{messageId: 'nestChildren'}]
     },
     {
       code: 'React.createElement("div", {children: "Children"});',
-      errors: [{message: CREATE_ELEMENT_ERROR}]
+      errors: [{messageId: 'passChildrenAsArgs'}]
     },
     {
       code: 'React.createElement("div", {children: "Children"}, "Children");',
-      errors: [{message: CREATE_ELEMENT_ERROR}]
+      errors: [{messageId: 'passChildrenAsArgs'}]
     },
     {
       code: 'React.createElement("div", {children: React.createElement("div")});',
-      errors: [{message: CREATE_ELEMENT_ERROR}]
+      errors: [{messageId: 'passChildrenAsArgs'}]
     },
     {
       code: 'React.createElement("div", {children: [React.createElement("div"), React.createElement("div")]});',
-      errors: [{message: CREATE_ELEMENT_ERROR}]
+      errors: [{messageId: 'passChildrenAsArgs'}]
     },
     {
       code: '<MyComponent children="Children" />',
-      errors: [{message: JSX_ERROR}]
+      errors: [{messageId: 'nestChildren'}]
     },
     {
       code: 'React.createElement(MyComponent, {children: "Children"});',
-      errors: [{message: CREATE_ELEMENT_ERROR}]
+      errors: [{messageId: 'passChildrenAsArgs'}]
     },
     {
       code: '<MyComponent className="class-name" children="Children" />;',
-      errors: [{message: JSX_ERROR}]
+      errors: [{messageId: 'nestChildren'}]
     },
     {
       code: 'React.createElement(MyComponent, {children: "Children", className: "class-name"});',
-      errors: [{message: CREATE_ELEMENT_ERROR}]
+      errors: [{messageId: 'passChildrenAsArgs'}]
     },
     {
       code: '<MyComponent {...props} children="Children" />;',
-      errors: [{message: JSX_ERROR}]
+      errors: [{messageId: 'nestChildren'}]
     },
     {
       code: 'React.createElement(MyComponent, {...props, children: "Children"})',
-      errors: [{message: CREATE_ELEMENT_ERROR}]
+      errors: [{messageId: 'passChildrenAsArgs'}]
     }
   ]
 });

--- a/tests/lib/rules/no-danger-with-children.js
+++ b/tests/lib/rules/no-danger-with-children.js
@@ -106,25 +106,25 @@ ruleTester.run('no-danger-with-children', rule, {
           Children
         </div>
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: '<div dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />',
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
         const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
         <div {...props}>Children</div>
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
         const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
         <div {...props} />
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
@@ -132,15 +132,15 @@ ruleTester.run('no-danger-with-children', rule, {
           Children
         </Hello>
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: '<Hello dangerouslySetInnerHTML={{ __html: "HTML" }} children="Children" />',
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: '<Hello dangerouslySetInnerHTML={{ __html: "HTML" }}> </Hello>',
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
@@ -150,7 +150,7 @@ ruleTester.run('no-danger-with-children', rule, {
           "Children"
         );
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
@@ -162,7 +162,7 @@ ruleTester.run('no-danger-with-children', rule, {
           }
         );
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
@@ -172,7 +172,7 @@ ruleTester.run('no-danger-with-children', rule, {
           "Children"
         );
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
@@ -184,21 +184,21 @@ ruleTester.run('no-danger-with-children', rule, {
           }
         );
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
         const props = { dangerouslySetInnerHTML: { __html: "HTML" } };
         React.createElement("div", props, "Children");
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
         const props = { children: "Children", dangerouslySetInnerHTML: { __html: "HTML" } };
         React.createElement("div", props);
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     },
     {
       code: `
@@ -207,7 +207,7 @@ ruleTester.run('no-danger-with-children', rule, {
         const props = { ...otherProps, dangerouslySetInnerHTML: { __html: "HTML" } };
         React.createElement("div", props);
       `,
-      errors: [{message: 'Only set one of `children` or `props.dangerouslySetInnerHTML`'}]
+      errors: [{messageId: 'dangerWithChildren'}]
     }
   ]
 });

--- a/tests/lib/rules/no-danger.js
+++ b/tests/lib/rules/no-danger.js
@@ -33,6 +33,9 @@ ruleTester.run('no-danger', rule, {
   ],
   invalid: [{
     code: '<div dangerouslySetInnerHTML={{ __html: "" }}></div>;',
-    errors: [{message: 'Dangerous property \'dangerouslySetInnerHTML\' found'}]
+    errors: [{
+      messageId: 'dangerousProp',
+      data: {name: 'dangerouslySetInnerHTML'}
+    }]
   }]
 });

--- a/tests/lib/rules/no-deprecated.js
+++ b/tests/lib/rules/no-deprecated.js
@@ -24,10 +24,18 @@ const parserOptions = {
   }
 };
 
-function errorMessage(oldMethod, version, newMethod, refs) {
-  newMethod = newMethod ? `, use ${newMethod} instead` : '';
-  refs = refs ? `, see ${refs}` : '';
-  return `${oldMethod} is deprecated since React ${version}${newMethod}${refs}`;
+function errorMessage(oldMethod, version, newMethod, refs, extraProps) {
+  return (
+    Object.assign({
+      messageId: 'deprecated',
+      data: {
+        oldMethod,
+        version,
+        newMethod: newMethod ? `, use ${newMethod} instead` : '',
+        refs: refs ? `, see ${refs}` : ''
+      }
+    }, extraProps)
+  );
 }
 
 // ------------------------------------------------------------------------------
@@ -101,86 +109,86 @@ ruleTester.run('no-deprecated', rule, {
   invalid: [
     {
       code: 'React.renderComponent()',
-      errors: [{message: errorMessage('React.renderComponent', '0.12.0', 'React.render')}]
+      errors: [errorMessage('React.renderComponent', '0.12.0', 'React.render')]
     },
     {
       code: 'Foo.renderComponent()',
       settings: {react: {pragma: 'Foo'}},
-      errors: [{message: errorMessage('Foo.renderComponent', '0.12.0', 'Foo.render')}]
+      errors: [errorMessage('Foo.renderComponent', '0.12.0', 'Foo.render')]
     },
     {
       code: '/** @jsx Foo */ Foo.renderComponent()',
-      errors: [{message: errorMessage('Foo.renderComponent', '0.12.0', 'Foo.render')}]
+      errors: [errorMessage('Foo.renderComponent', '0.12.0', 'Foo.render')]
     },
     {
       code: 'this.transferPropsTo()',
-      errors: [{message: errorMessage('this.transferPropsTo', '0.12.0', 'spread operator ({...})')}]
+      errors: [errorMessage('this.transferPropsTo', '0.12.0', 'spread operator ({...})')]
     },
     {
       code: 'React.addons.TestUtils',
-      errors: [{message: errorMessage('React.addons.TestUtils', '15.5.0', 'ReactDOM.TestUtils')}]
+      errors: [errorMessage('React.addons.TestUtils', '15.5.0', 'ReactDOM.TestUtils')]
     },
     {
       code: 'React.addons.classSet()',
-      errors: [{message: errorMessage('React.addons.classSet', '0.13.0', 'the npm module classnames')}]
+      errors: [errorMessage('React.addons.classSet', '0.13.0', 'the npm module classnames')]
     },
     {
       code: 'React.render(element, container);',
-      errors: [{message: errorMessage('React.render', '0.14.0', 'ReactDOM.render')}]
+      errors: [errorMessage('React.render', '0.14.0', 'ReactDOM.render')]
     },
     {
       code: 'React.unmountComponentAtNode(container);',
-      errors: [{message: errorMessage('React.unmountComponentAtNode', '0.14.0', 'ReactDOM.unmountComponentAtNode')}]
+      errors: [errorMessage('React.unmountComponentAtNode', '0.14.0', 'ReactDOM.unmountComponentAtNode')]
     },
     {
       code: 'React.findDOMNode(instance);',
-      errors: [{message: errorMessage('React.findDOMNode', '0.14.0', 'ReactDOM.findDOMNode')}]
+      errors: [errorMessage('React.findDOMNode', '0.14.0', 'ReactDOM.findDOMNode')]
     },
     {
       code: 'React.renderToString(element);',
-      errors: [{message: errorMessage('React.renderToString', '0.14.0', 'ReactDOMServer.renderToString')}]
+      errors: [errorMessage('React.renderToString', '0.14.0', 'ReactDOMServer.renderToString')]
     },
     {
       code: 'React.renderToStaticMarkup(element);',
-      errors: [{message: errorMessage('React.renderToStaticMarkup', '0.14.0', 'ReactDOMServer.renderToStaticMarkup')}]
+      errors: [errorMessage('React.renderToStaticMarkup', '0.14.0', 'ReactDOMServer.renderToStaticMarkup')]
     },
     {
       code: 'React.createClass({});',
-      errors: [{message: errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')}]
+      errors: [errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')]
     },
     {
       code: 'Foo.createClass({});',
       settings: {react: {pragma: 'Foo'}},
-      errors: [{message: errorMessage('Foo.createClass', '15.5.0', 'the npm module create-react-class')}]
+      errors: [errorMessage('Foo.createClass', '15.5.0', 'the npm module create-react-class')]
     },
     {
       code: 'React.PropTypes',
-      errors: [{message: errorMessage('React.PropTypes', '15.5.0', 'the npm module prop-types')}]
+      errors: [errorMessage('React.PropTypes', '15.5.0', 'the npm module prop-types')]
     },
     {
       code: 'var {createClass} = require(\'react\');',
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')}]
+      errors: [errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')]
     },
     {
       code: 'var {createClass, PropTypes} = require(\'react\');',
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')},
-        {message: errorMessage('React.PropTypes', '15.5.0', 'the npm module prop-types')}
+        errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class'),
+        errorMessage('React.PropTypes', '15.5.0', 'the npm module prop-types')
       ]
     },
     {
       code: 'import {createClass} from \'react\';',
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')}]
+      errors: [errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')]
     },
     {
       code: 'import {createClass, PropTypes} from \'react\';',
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')},
-        {message: errorMessage('React.PropTypes', '15.5.0', 'the npm module prop-types')}
+        errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class'),
+        errorMessage('React.PropTypes', '15.5.0', 'the npm module prop-types')
       ]
     },
     {
@@ -190,14 +198,14 @@ ruleTester.run('no-deprecated', rule, {
     `,
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class')},
-        {message: errorMessage('React.PropTypes', '15.5.0', 'the npm module prop-types')}
+        errorMessage('React.createClass', '15.5.0', 'the npm module create-react-class'),
+        errorMessage('React.PropTypes', '15.5.0', 'the npm module prop-types')
       ]
     },
     {
       code: 'import {printDOM} from \'react-addons-perf\';',
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: errorMessage('ReactPerf.printDOM', '15.0.0', 'ReactPerf.printOperations')}]
+      errors: [errorMessage('ReactPerf.printDOM', '15.0.0', 'ReactPerf.printOperations')]
     },
     {
       code: `
@@ -205,11 +213,11 @@ ruleTester.run('no-deprecated', rule, {
         const {printDOM} = ReactPerf;
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: errorMessage('ReactPerf.printDOM', '15.0.0', 'ReactPerf.printOperations')}]
+      errors: [errorMessage('ReactPerf.printDOM', '15.0.0', 'ReactPerf.printOperations')]
     },
     {
       code: 'React.DOM.div',
-      errors: [{message: errorMessage('React.DOM', '15.6.0', 'the npm module react-dom-factories')}]
+      errors: [errorMessage('React.DOM', '15.6.0', 'the npm module react-dom-factories')]
     },
     {
       code: `
@@ -220,35 +228,23 @@ ruleTester.run('no-deprecated', rule, {
         };
       `,
       errors: [
-        {
-          message: errorMessage(
-            'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 3,
-          column: 11
-        },
-        {
-          message: errorMessage(
-            'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 4,
-          column: 11
-        },
-        {
-          message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 5,
-          column: 11
-        }
+        errorMessage(
+          'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 3, column: 11}
+        ),
+        errorMessage(
+          'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+          + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 4, column: 11}
+        ),
+        errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+          + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 5, column: 11}
+        )
       ]
     },
     {
@@ -262,35 +258,23 @@ ruleTester.run('no-deprecated', rule, {
         }
       `,
       errors: [
-        {
-          message: errorMessage(
-            'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 4,
-          column: 13
-        },
-        {
-          message: errorMessage(
-            'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 5,
-          column: 13
-        },
-        {
-          message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 6,
-          column: 13
-        }
+        errorMessage(
+          'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 4, column: 13}
+        ),
+        errorMessage(
+          'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 5, column: 13}
+        ),
+        errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 6, column: 13}
+        )
       ]
     },
     {
@@ -302,35 +286,23 @@ ruleTester.run('no-deprecated', rule, {
         };
       `,
       errors: [
-        {
-          message: errorMessage(
-            'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 3,
-          column: 11
-        },
-        {
-          message: errorMessage(
-            'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 4,
-          column: 11
-        },
-        {
-          message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 5,
-          column: 11
-        }
+        errorMessage(
+          'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 3, column: 11}
+        ),
+        errorMessage(
+          'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 4, column: 11}
+        ),
+        errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 5, column: 11}
+        )
       ]
     },
     {
@@ -342,35 +314,23 @@ ruleTester.run('no-deprecated', rule, {
         }
       `,
       errors: [
-        {
-          message: errorMessage(
-            'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 3,
-          column: 11
-        },
-        {
-          message: errorMessage(
-            'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 4,
-          column: 11
-        },
-        {
-          message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 5,
-          column: 11
-        }
+        errorMessage(
+          'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 3, column: 11}
+        ),
+        errorMessage(
+          'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 4, column: 11}
+        ),
+        errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 5, column: 11}
+        )
       ]
     },
     {
@@ -382,35 +342,23 @@ ruleTester.run('no-deprecated', rule, {
         }
       `,
       errors: [
-        {
-          message: errorMessage(
-            'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 3,
-          column: 11
-        },
-        {
-          message: errorMessage(
-            'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 4,
-          column: 11
-        },
-        {
-          message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 5,
-          column: 11
-        }
+        errorMessage(
+          'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 3, column: 11}
+        ),
+        errorMessage(
+          'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 4, column: 11}
+        ),
+        errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 5, column: 11}
+        )
       ]
     },
     {
@@ -422,35 +370,23 @@ ruleTester.run('no-deprecated', rule, {
         })
       `,
       errors: [
-        {
-          message: errorMessage(
-            'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 3,
-          column: 11
-        },
-        {
-          message: errorMessage(
-            'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 4,
-          column: 11
-        },
-        {
-          message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 5,
-          column: 11
-        }
+        errorMessage(
+          'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 3, column: 11}
+        ),
+        errorMessage(
+          'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 4, column: 11}
+        ),
+        errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 5, column: 11}
+        )
       ]
     },
     {
@@ -463,35 +399,23 @@ ruleTester.run('no-deprecated', rule, {
         }
       `,
       errors: [
-        {
-          message: errorMessage(
-            'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 4,
-          column: 11
-        },
-        {
-          message: errorMessage(
-            'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 5,
-          column: 11
-        },
-        {
-          message: errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
-            'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
-            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
-          ),
-          type: 'Identifier',
-          line: 6,
-          column: 11
-        }
+        errorMessage(
+          'componentWillMount', '16.9.0', 'UNSAFE_componentWillMount',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillmount. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 4, column: 11}
+        ),
+        errorMessage(
+          'componentWillReceiveProps', '16.9.0', 'UNSAFE_componentWillReceiveProps',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 5, column: 11}
+        ),
+        errorMessage('componentWillUpdate', '16.9.0', 'UNSAFE_componentWillUpdate',
+          'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
+            + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.',
+          {type: 'Identifier', line: 6, column: 11}
+        )
       ]
     }
   ]

--- a/tests/lib/rules/no-did-mount-set-state.js
+++ b/tests/lib/rules/no-did-mount-set-state.js
@@ -91,7 +91,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
       });
     `,
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -105,7 +106,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -119,7 +121,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -133,7 +136,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     `,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -148,7 +152,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -164,7 +169,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     `,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -181,7 +187,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -196,7 +203,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
       });
     `,
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -212,7 +220,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -225,7 +234,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }, {
     code: `
@@ -238,7 +248,8 @@ ruleTester.run('no-did-mount-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidMount'
+      messageId: 'noSetState',
+      data: {name: 'componentDidMount'}
     }]
   }]
 });

--- a/tests/lib/rules/no-did-update-set-state.js
+++ b/tests/lib/rules/no-did-update-set-state.js
@@ -91,7 +91,8 @@ ruleTester.run('no-did-update-set-state', rule, {
       });
     `,
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -105,7 +106,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -119,7 +121,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -133,7 +136,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     `,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -148,7 +152,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -164,7 +169,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     `,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -181,7 +187,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -196,7 +203,8 @@ ruleTester.run('no-did-update-set-state', rule, {
       });
     `,
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -212,7 +220,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -225,7 +234,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }, {
     code: `
@@ -238,7 +248,8 @@ ruleTester.run('no-did-update-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentDidUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentDidUpdate'}
     }]
   }]
 });

--- a/tests/lib/rules/no-direct-mutation-state.js
+++ b/tests/lib/rules/no-direct-mutation-state.js
@@ -100,9 +100,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '});'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'var Hello = createReactClass({',
@@ -112,9 +110,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '});'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'var Hello = createReactClass({',
@@ -124,9 +120,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '});'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'var Hello = createReactClass({',
@@ -136,9 +130,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '});'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'var Hello = createReactClass({',
@@ -169,9 +161,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -183,9 +173,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -194,9 +182,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -205,9 +191,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -216,9 +200,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -227,9 +209,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -238,9 +218,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -249,9 +227,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }, {
     code: [
       'class Hello extends React.Component {',
@@ -260,9 +236,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '}'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   }
   /**
    * Would be nice to prevent this too
@@ -276,9 +250,7 @@ ruleTester.run('no-direct-mutation-state', rule, {
       '  }',
       '});'
     ].join('\n'),
-    errors: [{
-      message: 'Do not mutate state directly. Use setState().'
-    }]
+    errors: [{messageId: 'noDirectMutation'}]
   } */
   ]
 });

--- a/tests/lib/rules/no-find-dom-node.js
+++ b/tests/lib/rules/no-find-dom-node.js
@@ -75,9 +75,7 @@ ruleTester.run('no-find-dom-node', rule, {
         }
       });
     `,
-    errors: [{
-      message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
-    }]
+    errors: [{messageId: 'noFindDOMNode'}]
   }, {
     code: `
       var Hello = createReactClass({
@@ -89,9 +87,7 @@ ruleTester.run('no-find-dom-node', rule, {
         }
       });
     `,
-    errors: [{
-      message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
-    }]
+    errors: [{messageId: 'noFindDOMNode'}]
   }, {
     code: `
       class Hello extends Component {
@@ -103,9 +99,7 @@ ruleTester.run('no-find-dom-node', rule, {
         }
       };
     `,
-    errors: [{
-      message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
-    }]
+    errors: [{messageId: 'noFindDOMNode'}]
   }, {
     code: `
       class Hello extends Component {
@@ -117,8 +111,6 @@ ruleTester.run('no-find-dom-node', rule, {
         }
       };
     `,
-    errors: [{
-      message: 'Do not use findDOMNode. It doesn’t work with function components and is deprecated in StrictMode. See https://reactjs.org/docs/react-dom.html#finddomnode'
-    }]
+    errors: [{messageId: 'noFindDOMNode'}]
   }]
 });

--- a/tests/lib/rules/no-is-mounted.js
+++ b/tests/lib/rules/no-is-mounted.js
@@ -67,9 +67,7 @@ ruleTester.run('no-is-mounted', rule, {
         }
       });
     `,
-    errors: [{
-      message: 'Do not use isMounted'
-    }]
+    errors: [{messageId: 'noIsMounted'}]
   }, {
     code: `
       var Hello = createReactClass({
@@ -83,9 +81,7 @@ ruleTester.run('no-is-mounted', rule, {
         }
       });
     `,
-    errors: [{
-      message: 'Do not use isMounted'
-    }]
+    errors: [{messageId: 'noIsMounted'}]
   }, {
     code: `
       class Hello extends React.Component {
@@ -99,8 +95,6 @@ ruleTester.run('no-is-mounted', rule, {
         }
       };
     `,
-    errors: [{
-      message: 'Do not use isMounted'
-    }]
+    errors: [{messageId: 'noIsMounted'}]
   }]
 });

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -256,7 +256,7 @@ ruleTester.run('no-multi-comp', rule, {
       '});'
     ].join('\r'),
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -278,10 +278,10 @@ ruleTester.run('no-multi-comp', rule, {
       '}'
     ].join('\r'),
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }, {
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 11
     }]
   }, {
@@ -295,7 +295,7 @@ ruleTester.run('no-multi-comp', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 4
     }]
   }, {
@@ -310,7 +310,7 @@ ruleTester.run('no-multi-comp', rule, {
       '}'
     ].join('\r'),
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 4
     }]
   }, {
@@ -328,7 +328,7 @@ ruleTester.run('no-multi-comp', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   },
@@ -346,7 +346,7 @@ ruleTester.run('no-multi-comp', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 7
     }]
   },
@@ -362,7 +362,7 @@ ruleTester.run('no-multi-comp', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 5
     }]
   }, {
@@ -377,7 +377,7 @@ ruleTester.run('no-multi-comp', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 5
     }]
   }, {
@@ -392,7 +392,7 @@ ruleTester.run('no-multi-comp', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 5
     }]
   }, {
@@ -407,7 +407,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -422,7 +422,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -437,7 +437,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -452,7 +452,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -467,7 +467,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -482,7 +482,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -497,7 +497,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -512,7 +512,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -527,7 +527,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -542,7 +542,7 @@ ruleTester.run('no-multi-comp', rule, {
       ignoreStateless: false
     }],
     errors: [{
-      message: 'Declare only one React component per file',
+      messageId: 'onlyOneComponent',
       line: 6
     }]
   }, {
@@ -558,8 +558,6 @@ ruleTester.run('no-multi-comp', rule, {
         pragma: 'Foo'
       }
     },
-    errors: [{
-      message: 'Declare only one React component per file'
-    }]
+    errors: [{messageId: 'onlyOneComponent'}]
   }]
 });

--- a/tests/lib/rules/no-redundant-should-component-update.js
+++ b/tests/lib/rules/no-redundant-should-component-update.js
@@ -20,10 +20,6 @@ const parserOptions = {
   }
 };
 
-function errorMessage(node) {
-  return `${node} does not need shouldComponentUpdate when extending React.PureComponent.`;
-}
-
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -86,7 +82,10 @@ ruleTester.run('no-redundant-should-component-update', rule, {
           }
         }
       `,
-      errors: [{message: errorMessage('Foo')}],
+      errors: [{
+        messageId: 'noShouldCompUpdate',
+        data: {component: 'Foo'}
+      }],
       parserOptions
     },
     {
@@ -97,7 +96,10 @@ ruleTester.run('no-redundant-should-component-update', rule, {
           }
         }
       `,
-      errors: [{message: errorMessage('Foo')}],
+      errors: [{
+        messageId: 'noShouldCompUpdate',
+        data: {component: 'Foo'}
+      }],
       parserOptions
     },
     {
@@ -108,7 +110,10 @@ ruleTester.run('no-redundant-should-component-update', rule, {
           }
         }
       `,
-      errors: [{message: errorMessage('Foo')}],
+      errors: [{
+        messageId: 'noShouldCompUpdate',
+        data: {component: 'Foo'}
+      }],
       parser: parsers.BABEL_ESLINT,
       parserOptions
     },
@@ -122,7 +127,10 @@ ruleTester.run('no-redundant-should-component-update', rule, {
           };
         }
       `,
-      errors: [{message: errorMessage('Bar')}],
+      errors: [{
+        messageId: 'noShouldCompUpdate',
+        data: {component: 'Bar'}
+      }],
       parserOptions
     },
     {
@@ -135,7 +143,10 @@ ruleTester.run('no-redundant-should-component-update', rule, {
           };
         }
       `,
-      errors: [{message: errorMessage('Bar')}],
+      errors: [{
+        messageId: 'noShouldCompUpdate',
+        data: {component: 'Bar'}
+      }],
       parserOptions
     },
     {
@@ -146,7 +157,10 @@ ruleTester.run('no-redundant-should-component-update', rule, {
           }
         }
       `,
-      errors: [{message: errorMessage('Foo')}],
+      errors: [{
+        messageId: 'noShouldCompUpdate',
+        data: {component: 'Foo'}
+      }],
       parserOptions
     }
   ]

--- a/tests/lib/rules/no-render-return-value.js
+++ b/tests/lib/rules/no-render-return-value.js
@@ -71,7 +71,8 @@ ruleTester.run('no-render-return-value', rule, {
   invalid: [{
     code: 'var Hello = ReactDOM.render(<div />, document.body);',
     errors: [{
-      message: 'Do not depend on the return value from ReactDOM.render'
+      messageId: 'noReturnValue',
+      data: {node: 'ReactDOM'}
     }]
   }, {
     code: `
@@ -80,7 +81,8 @@ ruleTester.run('no-render-return-value', rule, {
       };
     `,
     errors: [{
-      message: 'Do not depend on the return value from ReactDOM.render'
+      messageId: 'noReturnValue',
+      data: {node: 'ReactDOM'}
     }]
   }, {
     code: `
@@ -89,22 +91,26 @@ ruleTester.run('no-render-return-value', rule, {
       }
     `,
     errors: [{
-      message: 'Do not depend on the return value from ReactDOM.render'
+      messageId: 'noReturnValue',
+      data: {node: 'ReactDOM'}
     }]
   }, {
     code: 'var render = (a, b) => ReactDOM.render(a, b)',
     errors: [{
-      message: 'Do not depend on the return value from ReactDOM.render'
+      messageId: 'noReturnValue',
+      data: {node: 'ReactDOM'}
     }]
   }, {
     code: 'this.o = ReactDOM.render(<div />, document.body);',
     errors: [{
-      message: 'Do not depend on the return value from ReactDOM.render'
+      messageId: 'noReturnValue',
+      data: {node: 'ReactDOM'}
     }]
   }, {
     code: 'var v; v = ReactDOM.render(<div />, document.body);',
     errors: [{
-      message: 'Do not depend on the return value from ReactDOM.render'
+      messageId: 'noReturnValue',
+      data: {node: 'ReactDOM'}
     }]
   }, {
     code: 'var inst = React.render(<div />, document.body);',
@@ -114,7 +120,8 @@ ruleTester.run('no-render-return-value', rule, {
       }
     },
     errors: [{
-      message: 'Do not depend on the return value from React.render'
+      messageId: 'noReturnValue',
+      data: {node: 'React'}
     }]
   }, {
     code: 'var inst = ReactDOM.render(<div />, document.body);',
@@ -124,7 +131,8 @@ ruleTester.run('no-render-return-value', rule, {
       }
     },
     errors: [{
-      message: 'Do not depend on the return value from ReactDOM.render'
+      messageId: 'noReturnValue',
+      data: {node: 'ReactDOM'}
     }]
   }, {
     code: 'var inst = React.render(<div />, document.body);',
@@ -134,7 +142,8 @@ ruleTester.run('no-render-return-value', rule, {
       }
     },
     errors: [{
-      message: 'Do not depend on the return value from React.render'
+      messageId: 'noReturnValue',
+      data: {node: 'React'}
     }]
   }]
 });

--- a/tests/lib/rules/no-set-state.js
+++ b/tests/lib/rules/no-set-state.js
@@ -70,9 +70,7 @@ ruleTester.run('no-set-state', rule, {
         }
       });
     `,
-    errors: [{
-      message: 'Do not use setState'
-    }]
+    errors: [{messageId: 'noSetState'}]
   }, {
     code: `
       var Hello = createReactClass({
@@ -86,9 +84,7 @@ ruleTester.run('no-set-state', rule, {
         }
       });
     `,
-    errors: [{
-      message: 'Do not use setState'
-    }]
+    errors: [{messageId: 'noSetState'}]
   }, {
     code: `
       class Hello extends React.Component {
@@ -102,9 +98,7 @@ ruleTester.run('no-set-state', rule, {
         }
       };
     `,
-    errors: [{
-      message: 'Do not use setState'
-    }]
+    errors: [{messageId: 'noSetState'}]
   }, {
     code: `
       class Hello extends React.Component {
@@ -119,9 +113,7 @@ ruleTester.run('no-set-state', rule, {
       };
     `,
     parser: parsers.BABEL_ESLINT,
-    errors: [{
-      message: 'Do not use setState'
-    }]
+    errors: [{messageId: 'noSetState'}]
   }, {
     code: `
       class Hello extends React.Component {
@@ -131,8 +123,6 @@ ruleTester.run('no-set-state', rule, {
       };
     `,
     parser: parsers.BABEL_ESLINT,
-    errors: [{
-      message: 'Do not use setState'
-    }]
+    errors: [{messageId: 'noSetState'}]
   }]
 });

--- a/tests/lib/rules/no-string-refs.js
+++ b/tests/lib/rules/no-string-refs.js
@@ -76,9 +76,7 @@ ruleTester.run('no-refs', rule, {
       });
     `,
     parser: parsers.BABEL_ESLINT,
-    errors: [{
-      message: 'Using this.refs is deprecated.'
-    }]
+    errors: [{messageId: 'thisRefsDeprecated'}]
   }, {
     code: `
       var Hello = createReactClass({
@@ -88,9 +86,7 @@ ruleTester.run('no-refs', rule, {
       });
     `,
     parser: parsers.BABEL_ESLINT,
-    errors: [{
-      message: 'Using string literals in ref attributes is deprecated.'
-    }]
+    errors: [{messageId: 'stringInRefDeprecated'}]
   }, {
     code: `
       var Hello = createReactClass({
@@ -100,9 +96,7 @@ ruleTester.run('no-refs', rule, {
       });
     `,
     parser: parsers.BABEL_ESLINT,
-    errors: [{
-      message: 'Using string literals in ref attributes is deprecated.'
-    }]
+    errors: [{messageId: 'stringInRefDeprecated'}]
   }, {
     code: `
       var Hello = createReactClass({
@@ -116,9 +110,9 @@ ruleTester.run('no-refs', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Using this.refs is deprecated.'
+      messageId: 'thisRefsDeprecated'
     }, {
-      message: 'Using string literals in ref attributes is deprecated.'
+      messageId: 'stringInRefDeprecated'
     }]
   },
   {
@@ -135,9 +129,9 @@ ruleTester.run('no-refs', rule, {
     parser: parsers.BABEL_ESLINT,
     options: [{noTemplateLiterals: true}],
     errors: [{
-      message: 'Using this.refs is deprecated.'
+      messageId: 'thisRefsDeprecated'
     }, {
-      message: 'Using string literals in ref attributes is deprecated.'
+      messageId: 'stringInRefDeprecated'
     }]
   },
   {
@@ -154,9 +148,9 @@ ruleTester.run('no-refs', rule, {
     parser: parsers.BABEL_ESLINT,
     options: [{noTemplateLiterals: true}],
     errors: [{
-      message: 'Using this.refs is deprecated.'
+      messageId: 'thisRefsDeprecated'
     }, {
-      message: 'Using string literals in ref attributes is deprecated.'
+      messageId: 'stringInRefDeprecated'
     }]
   }]
 });

--- a/tests/lib/rules/no-this-in-sfc.js
+++ b/tests/lib/rules/no-this-in-sfc.js
@@ -5,12 +5,6 @@
 'use strict';
 
 // ------------------------------------------------------------------------------
-// Constants
-// ------------------------------------------------------------------------------
-
-const ERROR_MESSAGE = 'Stateless functional components should not use `this`';
-
-// ------------------------------------------------------------------------------
 // Requirements
 // ------------------------------------------------------------------------------
 
@@ -154,32 +148,32 @@ ruleTester.run('no-this-in-sfc', rule, {
       const { foo } = this.props;
       return <div>{foo}</div>;
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     function Foo(props) {
       return <div>{this.props.foo}</div>;
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     function Foo(props) {
       return <div>{this.state.foo}</div>;
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     function Foo(props) {
       const { foo } = this.state;
       return <div>{foo}</div>;
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     function Foo(props) {
       return props.foo ? <div>{this.props.bar}</div> : null;
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     function Foo(props) {
@@ -188,7 +182,7 @@ ruleTester.run('no-this-in-sfc', rule, {
       }
       return null;
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     function Foo(props) {
@@ -197,13 +191,13 @@ ruleTester.run('no-this-in-sfc', rule, {
       }
       return null;
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: 'const Foo = (props) => <span>{this.props.foo}</span>',
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: 'const Foo = (props) => this.props.foo ? <span>{props.bar}</span> : null;',
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     function Foo(props) {
@@ -212,7 +206,7 @@ ruleTester.run('no-this-in-sfc', rule, {
       }
       return <div onClick={onClick}>{this.props.foo}</div>;
     }`,
-    errors: [{message: ERROR_MESSAGE}, {message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}, {messageId: 'noThisInSFC'}]
   }, {
     code: `
     class Foo {
@@ -223,7 +217,7 @@ ruleTester.run('no-this-in-sfc', rule, {
         }
       }
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     class Foo {
@@ -233,7 +227,7 @@ ruleTester.run('no-this-in-sfc', rule, {
       };
     }`,
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     class Foo {
@@ -246,7 +240,7 @@ ruleTester.run('no-this-in-sfc', rule, {
         }
       }
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }, {
     code: `
     class Foo {
@@ -257,6 +251,6 @@ ruleTester.run('no-this-in-sfc', rule, {
         };
       }
     }`,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'noThisInSFC'}]
   }]
 });

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -25,11 +25,6 @@ const parserOptions = {
 // Tests
 // -----------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Typo in static class property declaration';
-const ERROR_MESSAGE_ES5 = 'Typo in property declaration';
-const ERROR_MESSAGE_LIFECYCLE_METHOD = (actual, expected) => `Typo in component lifecycle method declaration: ${actual} should be ${expected}`;
-const ERROR_MESSAGE_STATIC = (method) => `Lifecycle method should be static: ${method}`;
-
 const ruleTester = new RuleTester();
 ruleTester.run('no-typos', rule, {
   valid: [].concat({
@@ -657,21 +652,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
+    errors: [{messageId: 'typoStaticClassProp', type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.PropTypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
+    errors: [{messageId: 'typoStaticClassProp', type: 'Identifier'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.PropTypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
+    errors: [{messageId: 'typoStaticClassProp', type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -680,21 +675,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.proptypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.proptypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -703,21 +698,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
+    errors: [{messageId: 'typoStaticClassProp', type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.ContextTypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.ContextTypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -726,21 +721,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.contexttypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.contexttypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -749,21 +744,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.ChildContextTypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.ChildContextTypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -772,21 +767,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.childcontexttypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.childcontexttypes = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -795,21 +790,21 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
+    errors: [{messageId: 'typoStaticClassProp', type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.DefaultProps = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
+    errors: [{messageId: 'typoStaticClassProp', type: 'Identifier'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.DefaultProps = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE, type: 'Identifier'}]
+    errors: [{messageId: 'typoStaticClassProp', type: 'Identifier'}]
   }, {
     code: `
       class Component extends React.Component {
@@ -818,28 +813,28 @@ ruleTester.run('no-typos', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Component extends React.Component {}
       Component.defaultprops = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       function MyComponent() { return (<div>{this.props.myProp}</div>) }
       MyComponent.defaultprops = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       Component.defaultprops = {}
       class Component extends React.Component {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       /** @extends React.Component */
@@ -847,7 +842,7 @@ ruleTester.run('no-typos', rule, {
       MyComponent.PROPTYPES = {}
     `,
     parserOptions,
-    errors: [{message: ERROR_MESSAGE}]
+    errors: [{messageId: 'typoStaticClassProp'}]
   }, {
     code: `
       class Hello extends React.Component {
@@ -871,43 +866,56 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('GetDerivedStateFromProps', 'getDerivedStateFromProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'GetDerivedStateFromProps', expected: 'getDerivedStateFromProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillMount', 'componentWillMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillMount', expected: 'componentWillMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('UNSAFE_ComponentWillMount', 'UNSAFE_componentWillMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'UNSAFE_ComponentWillMount', expected: 'UNSAFE_componentWillMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentDidMount', 'componentDidMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentDidMount', expected: 'componentDidMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillReceiveProps', 'componentWillReceiveProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillReceiveProps', expected: 'componentWillReceiveProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('UNSAFE_ComponentWillReceiveProps', 'UNSAFE_componentWillReceiveProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'UNSAFE_ComponentWillReceiveProps', expected: 'UNSAFE_componentWillReceiveProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ShouldComponentUpdate', 'shouldComponentUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ShouldComponentUpdate', expected: 'shouldComponentUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillUpdate', 'componentWillUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillUpdate', expected: 'componentWillUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('UNSAFE_ComponentWillUpdate', 'UNSAFE_componentWillUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'UNSAFE_ComponentWillUpdate', expected: 'UNSAFE_componentWillUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('GetSnapshotBeforeUpdate', 'getSnapshotBeforeUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'GetSnapshotBeforeUpdate', expected: 'getSnapshotBeforeUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentDidUpdate', 'componentDidUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentDidUpdate', expected: 'componentDidUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentDidCatch', 'componentDidCatch'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentDidCatch', expected: 'componentDidCatch'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillUnmount', 'componentWillUnmount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillUnmount', expected: 'componentWillUnmount'},
       type: 'MethodDefinition'
     }]
   }, {
@@ -933,46 +941,60 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Getderivedstatefromprops', 'getDerivedStateFromProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Getderivedstatefromprops', expected: 'getDerivedStateFromProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Componentwillmount', 'componentWillMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Componentwillmount', expected: 'componentWillMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('UNSAFE_Componentwillmount', 'UNSAFE_componentWillMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'UNSAFE_Componentwillmount', expected: 'UNSAFE_componentWillMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Componentdidmount', 'componentDidMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Componentdidmount', expected: 'componentDidMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Componentwillreceiveprops', 'componentWillReceiveProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Componentwillreceiveprops', expected: 'componentWillReceiveProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('UNSAFE_Componentwillreceiveprops', 'UNSAFE_componentWillReceiveProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'UNSAFE_Componentwillreceiveprops', expected: 'UNSAFE_componentWillReceiveProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Shouldcomponentupdate', 'shouldComponentUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Shouldcomponentupdate', expected: 'shouldComponentUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Componentwillupdate', 'componentWillUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Componentwillupdate', expected: 'componentWillUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('UNSAFE_Componentwillupdate', 'UNSAFE_componentWillUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'UNSAFE_Componentwillupdate', expected: 'UNSAFE_componentWillUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Getsnapshotbeforeupdate', 'getSnapshotBeforeUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Getsnapshotbeforeupdate', expected: 'getSnapshotBeforeUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Componentdidupdate', 'componentDidUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Componentdidupdate', expected: 'componentDidUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Componentdidcatch', 'componentDidCatch'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Componentdidcatch', expected: 'componentDidCatch'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Componentwillunmount', 'componentWillUnmount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Componentwillunmount', expected: 'componentWillUnmount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('Render', 'render'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'Render', expected: 'render'},
       type: 'MethodDefinition'
     }]
   }, {
@@ -998,43 +1020,56 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('getderivedstatefromprops', 'getDerivedStateFromProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'getderivedstatefromprops', expected: 'getDerivedStateFromProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('componentwillmount', 'componentWillMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'componentwillmount', expected: 'componentWillMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('unsafe_componentwillmount', 'UNSAFE_componentWillMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'unsafe_componentwillmount', expected: 'UNSAFE_componentWillMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('componentdidmount', 'componentDidMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'componentdidmount', expected: 'componentDidMount'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('componentwillreceiveprops', 'componentWillReceiveProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'componentwillreceiveprops', expected: 'componentWillReceiveProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('unsafe_componentwillreceiveprops', 'UNSAFE_componentWillReceiveProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'unsafe_componentwillreceiveprops', expected: 'UNSAFE_componentWillReceiveProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('shouldcomponentupdate', 'shouldComponentUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'shouldcomponentupdate', expected: 'shouldComponentUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('componentwillupdate', 'componentWillUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'componentwillupdate', expected: 'componentWillUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('unsafe_componentwillupdate', 'UNSAFE_componentWillUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'unsafe_componentwillupdate', expected: 'UNSAFE_componentWillUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('getsnapshotbeforeupdate', 'getSnapshotBeforeUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'getsnapshotbeforeupdate', expected: 'getSnapshotBeforeUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('componentdidupdate', 'componentDidUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'componentdidupdate', expected: 'componentDidUpdate'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('componentdidcatch', 'componentDidCatch'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'componentdidcatch', expected: 'componentDidCatch'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('componentwillunmount', 'componentWillUnmount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'componentwillunmount', expected: 'componentWillUnmount'},
       type: 'MethodDefinition'
     }]
   }, {
@@ -1047,7 +1082,8 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: Number'
+      messageId: 'typoPropType',
+      data: {name: 'Number'}
     }]
   }, {
     code: `
@@ -1059,7 +1095,8 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1073,7 +1110,8 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1087,7 +1125,8 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: Number'
+      messageId: 'typoPropType',
+      data: {name: 'Number'}
     }]
   }, {
     code: `
@@ -1100,7 +1139,8 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: Number'
+      messageId: 'typoPropType',
+      data: {name: 'Number'}
     }]
   }, {
     code: `
@@ -1116,7 +1156,8 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: String'
+      messageId: 'typoPropType',
+      data: {name: 'String'}
     }]
   }, {
     code: `
@@ -1132,7 +1173,8 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }]
   }, {
     code: `
@@ -1148,13 +1190,17 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1170,13 +1216,17 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1192,13 +1242,17 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1213,9 +1267,11 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1231,9 +1287,11 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1249,13 +1307,17 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1271,9 +1333,11 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1289,13 +1353,17 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1311,9 +1379,11 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1323,7 +1393,7 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: '`\'react\'` imported without a local `React` binding.'
+      messageId: 'noReactBinding'
     }]
   }, {
     code: `
@@ -1339,13 +1409,17 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1360,13 +1434,17 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1382,9 +1460,11 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1399,9 +1479,11 @@ ruleTester.run('no-typos', rule, {
    `,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1416,13 +1498,17 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1437,9 +1523,11 @@ ruleTester.run('no-typos', rule, {
    `,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1454,13 +1542,17 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1475,9 +1567,11 @@ ruleTester.run('no-typos', rule, {
    `,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1492,13 +1586,17 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1516,9 +1614,11 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1536,13 +1636,17 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1559,9 +1663,11 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }, {
-      message: 'Typo in prop type chain qualifier: isrequired'
+      messageId: 'typoPropTypeChain',
+      data: {name: 'isrequired'}
     }]
   }, {
     code: `
@@ -1578,13 +1684,17 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
+      messageId: 'typoPropType',
+      data: {name: 'bools'}
     }, {
-      message: 'Typo in declared prop type: Array'
+      messageId: 'typoPropType',
+      data: {name: 'Array'}
     }, {
-      message: 'Typo in declared prop type: function'
+      messageId: 'typoPropType',
+      data: {name: 'function'}
     }, {
-      message: 'Typo in declared prop type: objectof'
+      messageId: 'typoPropType',
+      data: {name: 'objectof'}
     }]
   }, {
     code: `
@@ -1607,34 +1717,41 @@ ruleTester.run('no-typos', rule, {
     `,
     parserOptions,
     errors: [{
-      message: ERROR_MESSAGE_ES5,
+      messageId: 'typoPropDeclaration',
       type: 'Identifier'
     }, {
-      message: ERROR_MESSAGE_ES5,
+      messageId: 'typoPropDeclaration',
       type: 'Identifier'
     }, {
-      message: ERROR_MESSAGE_ES5,
+      messageId: 'typoPropDeclaration',
       type: 'Identifier'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillMount', 'componentWillMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillMount', expected: 'componentWillMount'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentDidMount', 'componentDidMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentDidMount', expected: 'componentDidMount'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillReceiveProps', 'componentWillReceiveProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillReceiveProps', expected: 'componentWillReceiveProps'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ShouldComponentUpdate', 'shouldComponentUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ShouldComponentUpdate', expected: 'shouldComponentUpdate'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillUpdate', 'componentWillUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillUpdate', expected: 'componentWillUpdate'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentDidUpdate', 'componentDidUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentDidUpdate', expected: 'componentDidUpdate'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillUnmount', 'componentWillUnmount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillUnmount', expected: 'componentWillUnmount'},
       type: 'Property'
     }]
   }, {
@@ -1646,7 +1763,8 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: ERROR_MESSAGE_STATIC('getDerivedStateFromProps'),
+      messageId: 'staticLifecycleMethod',
+      data: {method: 'getDerivedStateFromProps'},
       type: 'MethodDefinition'
     }]
   }, {
@@ -1658,10 +1776,12 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: ERROR_MESSAGE_STATIC('GetDerivedStateFromProps'),
+      messageId: 'staticLifecycleMethod',
+      data: {method: 'GetDerivedStateFromProps'},
       type: 'MethodDefinition'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('GetDerivedStateFromProps', 'getDerivedStateFromProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'GetDerivedStateFromProps', expected: 'getDerivedStateFromProps'},
       type: 'MethodDefinition'
     }]
   }, {
@@ -1686,34 +1806,41 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.BABEL_ESLINT,
     parserOptions,
     errors: [{
-      message: ERROR_MESSAGE_ES5,
+      messageId: 'typoPropDeclaration',
       type: 'Identifier'
     }, {
-      message: ERROR_MESSAGE_ES5,
+      messageId: 'typoPropDeclaration',
       type: 'Identifier'
     }, {
-      message: ERROR_MESSAGE_ES5,
+      messageId: 'typoPropDeclaration',
       type: 'Identifier'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillMount', 'componentWillMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillMount', expected: 'componentWillMount'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentDidMount', 'componentDidMount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentDidMount', expected: 'componentDidMount'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillReceiveProps', 'componentWillReceiveProps'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillReceiveProps', expected: 'componentWillReceiveProps'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ShouldComponentUpdate', 'shouldComponentUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ShouldComponentUpdate', expected: 'shouldComponentUpdate'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillUpdate', 'componentWillUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillUpdate', expected: 'componentWillUpdate'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentDidUpdate', 'componentDidUpdate'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentDidUpdate', expected: 'componentDidUpdate'},
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE_LIFECYCLE_METHOD('ComponentWillUnmount', 'componentWillUnmount'),
+      messageId: 'typoLifecycleMethod',
+      data: {actual: 'ComponentWillUnmount', expected: 'componentWillUnmount'},
       type: 'Property'
     }]
     /*
@@ -1736,7 +1863,7 @@ ruleTester.run('no-typos', rule, {
     parser: parsers.TYPESCRIPT_ESLINT,
     parserOptions,
     errors: [{
-      message: '`\'prop-types\'` imported without a local `PropTypes` binding.'
+      messageId: 'noPropTypesBinding'
     }]
   }, {
     code: `
@@ -1745,7 +1872,7 @@ ruleTester.run('no-typos', rule, {
     parser: parsers['@TYPESCRIPT_ESLINT'],
     parserOptions,
     errors: [{
-      message: '`\'prop-types\'` imported without a local `PropTypes` binding.'
+      messageId: 'noPropTypesBinding'
     }]
   }))
 });

--- a/tests/lib/rules/no-unescaped-entities.js
+++ b/tests/lib/rules/no-unescaped-entities.js
@@ -125,7 +125,10 @@ ruleTester.run('no-unescaped-entities', rule, {
           }
         });
       `,
-      errors: [{message: '`>` can be escaped with `&gt;`.'}]
+      errors: [{
+        messageId: 'unescapedEntityAlts',
+        data: {entity: '>', alts: '`&gt;`'}
+      }]
     }), {
       code: `
         var Hello = createReactClass({
@@ -135,7 +138,10 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: '`>` can be escaped with `&gt;`.'}]
+      errors: [{
+        messageId: 'unescapedEntityAlts',
+        data: {entity: '>', alts: '`&gt;`'}
+      }]
     }, (allowsInvalidJSX && {
       code: `
         var Hello = createReactClass({
@@ -146,7 +152,10 @@ ruleTester.run('no-unescaped-entities', rule, {
           }
         });
       `,
-      errors: [{message: '`>` can be escaped with `&gt;`.'}]
+      errors: [{
+        messageId: 'unescapedEntityAlts',
+        data: {entity: '>', alts: '`&gt;`'}
+      }]
     }), {
       code: `
         var Hello = createReactClass({
@@ -158,7 +167,10 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: '`>` can be escaped with `&gt;`.'}]
+      errors: [{
+        messageId: 'unescapedEntityAlts',
+        data: {entity: '>', alts: '`&gt;`'}
+      }]
     }, {
       code: `
         var Hello = createReactClass({
@@ -167,7 +179,10 @@ ruleTester.run('no-unescaped-entities', rule, {
           }
         });
       `,
-      errors: [{message: '`\'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`.'}]
+      errors: [{
+        messageId: 'unescapedEntityAlts',
+        data: {entity: '\'', alts: '`&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`'}
+      }]
     }, (allowsInvalidJSX && {
       code: `
         var Hello = createReactClass({
@@ -177,9 +192,18 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       errors: [
-        {message: '`\'` can be escaped with `&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`.'},
-        {message: '`>` can be escaped with `&gt;`.'},
-        {message: '`>` can be escaped with `&gt;`.'}
+        {
+          messageId: 'unescapedEntityAlts',
+          data: {entity: '\'', alts: '`&apos;`, `&lsquo;`, `&#39;`, `&rsquo;`'}
+        },
+        {
+          messageId: 'unescapedEntityAlts',
+          data: {entity: '>', alts: '`&gt;`'}
+        },
+        {
+          messageId: 'unescapedEntityAlts',
+          data: {entity: '>', alts: '`&gt;`'}
+        }
       ]
     }), (allowsInvalidJSX && {
       code: `
@@ -189,7 +213,10 @@ ruleTester.run('no-unescaped-entities', rule, {
           }
         });
       `,
-      errors: [{message: '`}` can be escaped with `&#125;`.'}]
+      errors: [{
+        messageId: 'unescapedEntityAlts',
+        data: {entity: '}', alts: '`&#125;`'}
+      }]
     }), {
       code: `
         var Hello = createReactClass({
@@ -199,7 +226,10 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: '`}` can be escaped with `&#125;`.'}]
+      errors: [{
+        messageId: 'unescapedEntityAlts',
+        data: {entity: '}', alts: '`&#125;`'}
+      }]
     }, {
       code: `
         var Hello = createReactClass({
@@ -209,7 +239,10 @@ ruleTester.run('no-unescaped-entities', rule, {
         });
       `,
       parser: parsers.BABEL_ESLINT,
-      errors: [{message: 'HTML entity, `&` , must be escaped.'}],
+      errors: [{
+        messageId: 'unescapedEntity',
+        data: {entity: '&'}
+      }],
       options: [{
         forbid: ['&']
       }]
@@ -221,7 +254,10 @@ ruleTester.run('no-unescaped-entities', rule, {
           }
         });
       `,
-      errors: [{message: 'HTML entity, `&` , must be escaped.'}],
+      errors: [{
+        messageId: 'unescapedEntity',
+        data: {entity: '&'}
+      }],
       options: [{
         forbid: ['&']
       }]
@@ -233,7 +269,10 @@ ruleTester.run('no-unescaped-entities', rule, {
           }
         });
       `,
-      errors: [{message: '`&` can be escaped with `&amp;`.'}],
+      errors: [{
+        messageId: 'unescapedEntityAlts',
+        data: {entity: '&', alts: '`&amp;`'}
+      }],
       options: [{
         forbid: [{
           char: '&',

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -52,53 +52,92 @@ ruleTester.run('no-unknown-property', rule, {
   invalid: [{
     code: '<div class="bar"></div>;',
     output: '<div className="bar"></div>;',
-    errors: [{message: 'Unknown property \'class\' found, use \'className\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'class', standardName: 'className'}
+    }]
   }, {
     code: '<div for="bar"></div>;',
     output: '<div htmlFor="bar"></div>;',
-    errors: [{message: 'Unknown property \'for\' found, use \'htmlFor\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'for', standardName: 'htmlFor'}
+    }]
   }, {
     code: '<div accept-charset="bar"></div>;',
     output: '<div acceptCharset="bar"></div>;',
-    errors: [{message: 'Unknown property \'accept-charset\' found, use \'acceptCharset\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'accept-charset', standardName: 'acceptCharset'}
+    }]
   }, {
     code: '<div http-equiv="bar"></div>;',
     output: '<div httpEquiv="bar"></div>;',
-    errors: [{message: 'Unknown property \'http-equiv\' found, use \'httpEquiv\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'http-equiv', standardName: 'httpEquiv'}
+    }]
   }, {
     code: '<div accesskey="bar"></div>;',
     output: '<div accessKey="bar"></div>;',
-    errors: [{message: 'Unknown property \'accesskey\' found, use \'accessKey\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'accesskey', standardName: 'accessKey'}
+    }]
   }, {
     code: '<div onclick="bar"></div>;',
     output: '<div onClick="bar"></div>;',
-    errors: [{message: 'Unknown property \'onclick\' found, use \'onClick\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'onclick', standardName: 'onClick'}
+    }]
   }, {
     code: '<div onmousedown="bar"></div>;',
     output: '<div onMouseDown="bar"></div>;',
-    errors: [{message: 'Unknown property \'onmousedown\' found, use \'onMouseDown\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'onmousedown', standardName: 'onMouseDown'}
+    }]
   }, {
     code: '<div onMousedown="bar"></div>;',
     output: '<div onMouseDown="bar"></div>;',
-    errors: [{message: 'Unknown property \'onMousedown\' found, use \'onMouseDown\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'onMousedown', standardName: 'onMouseDown'}
+    }]
   }, {
     code: '<use xlink:href="bar" />;',
     output: '<use xlinkHref="bar" />;',
-    errors: [{message: 'Unknown property \'xlink:href\' found, use \'xlinkHref\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'xlink:href', standardName: 'xlinkHref'}
+    }]
   }, {
     code: '<rect clip-path="bar" />;',
     output: '<rect clipPath="bar" />;',
-    errors: [{message: 'Unknown property \'clip-path\' found, use \'clipPath\' instead'}]
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'clip-path', standardName: 'clipPath'}
+    }]
   }, {
     code: '<script crossorigin />',
-    errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}],
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'crossorigin', standardName: 'crossOrigin'}
+    }],
     output: '<script crossOrigin />'
   }, {
     code: '<div crossorigin />',
-    errors: [{message: 'Unknown property \'crossorigin\' found, use \'crossOrigin\' instead'}],
+    errors: [{
+      messageId: 'unknownProp',
+      data: {name: 'crossorigin', standardName: 'crossOrigin'}
+    }],
     output: '<div crossOrigin />'
   }, {
     code: '<div crossOrigin />',
-    errors: [{message: 'Invalid property \'crossOrigin\' found on tag \'div\', but it is only allowed on: script, img, video, audio, link'}]
+    errors: [{
+      messageId: 'invalidPropOnTag',
+      data: {name: 'crossOrigin', tagName: 'div', allowedTags: 'script, img, video, audio, link'}
+    }]
   }]
 });

--- a/tests/lib/rules/no-unsafe.js
+++ b/tests/lib/rules/no-unsafe.js
@@ -20,10 +20,6 @@ const parserOptions = {
   }
 };
 
-function errorMessage(method, newMethod, details) {
-  return `${method} is unsafe for use in async rendering. Update the component to use ${newMethod} instead. ${details}`;
-}
-
 // ------------------------------------------------------------------------------
 // Tests
 // ------------------------------------------------------------------------------
@@ -147,31 +143,34 @@ ruleTester.run('no-unsafe', rule, {
       settings: {react: {version: '16.4.0'}},
       errors: [
         {
-          message: errorMessage(
-            'componentWillMount',
-            'componentDidMount',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'componentWillMount',
+            newMethod: 'componentDidMount',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 9,
           type: 'ClassDeclaration'
         },
         {
-          message: errorMessage(
-            'componentWillReceiveProps',
-            'getDerivedStateFromProps',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'componentWillReceiveProps',
+            newMethod: 'getDerivedStateFromProps',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 9,
           type: 'ClassDeclaration'
         },
         {
-          message: errorMessage(
-            'componentWillUpdate',
-            'componentDidUpdate',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'componentWillUpdate',
+            newMethod: 'componentDidUpdate',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 9,
           type: 'ClassDeclaration'
@@ -189,31 +188,34 @@ ruleTester.run('no-unsafe', rule, {
       settings: {react: {version: '16.3.0'}},
       errors: [
         {
-          message: errorMessage(
-            'UNSAFE_componentWillMount',
-            'componentDidMount',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'UNSAFE_componentWillMount',
+            newMethod: 'componentDidMount',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 7,
           type: 'ClassDeclaration'
         },
         {
-          message: errorMessage(
-            'UNSAFE_componentWillReceiveProps',
-            'getDerivedStateFromProps',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'UNSAFE_componentWillReceiveProps',
+            newMethod: 'getDerivedStateFromProps',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 7,
           type: 'ClassDeclaration'
         },
         {
-          message: errorMessage(
-            'UNSAFE_componentWillUpdate',
-            'componentDidUpdate',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'UNSAFE_componentWillUpdate',
+            newMethod: 'componentDidUpdate',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 7,
           type: 'ClassDeclaration'
@@ -233,31 +235,34 @@ ruleTester.run('no-unsafe', rule, {
       settings: {react: {version: '16.3.0'}},
       errors: [
         {
-          message: errorMessage(
-            'componentWillMount',
-            'componentDidMount',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'componentWillMount',
+            newMethod: 'componentDidMount',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 40,
           type: 'ObjectExpression'
         },
         {
-          message: errorMessage(
-            'componentWillReceiveProps',
-            'getDerivedStateFromProps',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'componentWillReceiveProps',
+            newMethod: 'getDerivedStateFromProps',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 40,
           type: 'ObjectExpression'
         },
         {
-          message: errorMessage(
-            'componentWillUpdate',
-            'componentDidUpdate',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'componentWillUpdate',
+            newMethod: 'componentDidUpdate',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 40,
           type: 'ObjectExpression'
@@ -275,31 +280,34 @@ ruleTester.run('no-unsafe', rule, {
       settings: {react: {version: '16.3.0'}},
       errors: [
         {
-          message: errorMessage(
-            'UNSAFE_componentWillMount',
-            'componentDidMount',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'UNSAFE_componentWillMount',
+            newMethod: 'componentDidMount',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 38,
           type: 'ObjectExpression'
         },
         {
-          message: errorMessage(
-            'UNSAFE_componentWillReceiveProps',
-            'getDerivedStateFromProps',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'UNSAFE_componentWillReceiveProps',
+            newMethod: 'getDerivedStateFromProps',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 38,
           type: 'ObjectExpression'
         },
         {
-          message: errorMessage(
-            'UNSAFE_componentWillUpdate',
-            'componentDidUpdate',
-            'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
-          ),
+          messageId: 'unsafeMethod',
+          data: {
+            method: 'UNSAFE_componentWillUpdate',
+            newMethod: 'componentDidUpdate',
+            details: 'See https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html.'
+          },
           line: 2,
           column: 38,
           type: 'ObjectExpression'

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -3895,7 +3895,8 @@ ruleTester.run('no-unused-prop-types', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -3911,7 +3912,8 @@ ruleTester.run('no-unused-prop-types', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: '\'name\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'name'},
         line: 3,
         column: 5
       }]
@@ -3928,7 +3930,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'name'},
         line: 3,
         column: 5
       }]
@@ -4727,7 +4730,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4745,7 +4749,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4763,7 +4768,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4780,7 +4786,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4798,7 +4805,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4815,7 +4823,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4833,7 +4842,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4850,7 +4860,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4868,7 +4879,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4885,7 +4897,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'unused\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'unused'},
         line: 3,
         column: 5
       }]
@@ -4902,7 +4915,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'something\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'something'},
         line: 3,
         column: 5
       }]
@@ -4918,7 +4932,8 @@ ruleTester.run('no-unused-prop-types', rule, {
         '})'
       ].join('\n'),
       errors: [{
-        message: '\'something\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'something'},
         line: 3,
         column: 5
       }]
@@ -4939,7 +4954,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 4,
         column: 5
       }]
@@ -4960,7 +4976,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'baz\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'baz'},
         line: 5,
         column: 5
       }]
@@ -4979,7 +4996,8 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 10,
         column: 3
       }]
@@ -5000,7 +5018,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 4,
         column: 5
       }]
@@ -5041,7 +5060,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 4,
         column: 5
       }]
@@ -5060,7 +5080,8 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 10,
         column: 3
       }]
@@ -5081,7 +5102,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 4,
         column: 5
       }]
@@ -5103,7 +5125,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'baz\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'baz'},
         line: 5,
         column: 5
       }]
@@ -5126,7 +5149,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'baz\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'baz'},
         line: 5,
         column: 5
       }]
@@ -5145,7 +5169,8 @@ ruleTester.run('no-unused-prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 10,
         column: 3
       }]
@@ -5164,7 +5189,8 @@ ruleTester.run('no-unused-prop-types', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 10,
         column: 3
       }],
@@ -5187,7 +5213,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'bar\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'bar'},
         line: 4,
         column: 5
       }],
@@ -5213,7 +5240,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'foo\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'foo'},
         line: 3,
         column: 5
       }]
@@ -5237,7 +5265,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parserOptions: Object.assign({}, parserOptions, {ecmaVersion: 2017}),
       errors: [{
-        message: '\'baz\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'baz'},
         line: 13,
         column: 3
       }]
@@ -5261,7 +5290,8 @@ ruleTester.run('no-unused-prop-types', rule, {
       ].join('\n'),
       parserOptions: Object.assign({}, parserOptions, {ecmaVersion: 2017}),
       errors: [{
-        message: '\'foo\' PropType is defined but prop is never used',
+        messageId: 'unusedPropType',
+        data: {name: 'foo'},
         line: 11,
         column: 3
       }]

--- a/tests/lib/rules/no-unused-state.js
+++ b/tests/lib/rules/no-unused-state.js
@@ -20,7 +20,8 @@ const eslintTester = new RuleTester({parserOptions});
 
 function getErrorMessages(unusedFields) {
   return unusedFields.map((field) => ({
-    message: `Unused state field: '${field}'`
+    messageId: 'unusedStateField',
+    data: {name: field}
   }));
 }
 

--- a/tests/lib/rules/no-will-update-set-state.js
+++ b/tests/lib/rules/no-will-update-set-state.js
@@ -102,7 +102,8 @@ ruleTester.run('no-will-update-set-state', rule, {
       });
     `,
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -116,7 +117,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -130,7 +132,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     `,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -145,7 +148,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -161,7 +165,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     `,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -178,7 +183,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -193,7 +199,8 @@ ruleTester.run('no-will-update-set-state', rule, {
       });
     `,
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -209,7 +216,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -222,7 +230,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -235,7 +244,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     parser: parsers.BABEL_ESLINT,
     options: ['disallow-in-func'],
     errors: [{
-      message: 'Do not use setState in componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'componentWillUpdate'}
     }]
   }, {
     code: `
@@ -249,7 +259,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     `,
     settings: {react: {version: '16.3.0'}},
     errors: [{
-      message: 'Do not use setState in UNSAFE_componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'UNSAFE_componentWillUpdate'}
     }]
   }, {
     code: `
@@ -263,7 +274,8 @@ ruleTester.run('no-will-update-set-state', rule, {
     `,
     settings: {react: {version: '16.3.0'}},
     errors: [{
-      message: 'Do not use setState in UNSAFE_componentWillUpdate'
+      messageId: 'noSetState',
+      data: {name: 'UNSAFE_componentWillUpdate'}
     }]
   }]
 });

--- a/tests/lib/rules/prefer-es6-class.js
+++ b/tests/lib/rules/prefer-es6-class.js
@@ -80,7 +80,7 @@ ruleTester.run('prefer-es6-class', rule, {
       });
     `,
     errors: [{
-      message: 'Component should use es6 class instead of createClass'
+      messageId: 'shouldUseES6Class'
     }]
   }, {
     code: `
@@ -92,7 +92,7 @@ ruleTester.run('prefer-es6-class', rule, {
     `,
     options: ['always'],
     errors: [{
-      message: 'Component should use es6 class instead of createClass'
+      messageId: 'shouldUseES6Class'
     }]
   }, {
     code: `
@@ -104,7 +104,7 @@ ruleTester.run('prefer-es6-class', rule, {
     `,
     options: ['never'],
     errors: [{
-      message: 'Component should use createClass instead of es6 class'
+      messageId: 'shouldUseCreateClass'
     }]
   }]
 });

--- a/tests/lib/rules/prefer-read-only-props.js
+++ b/tests/lib/rules/prefer-read-only-props.js
@@ -181,7 +181,8 @@ ruleTester.run('prefer-read-only-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Prop \'name\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'name'}
       }],
       output: `
         type Props = {
@@ -210,7 +211,8 @@ ruleTester.run('prefer-read-only-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Prop \'name\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'name'}
       }],
       output: `
         type Props = {
@@ -238,7 +240,8 @@ ruleTester.run('prefer-read-only-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Prop \'name\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'name'}
       }],
       output: `
         class Hello extends React.Component {
@@ -260,7 +263,8 @@ ruleTester.run('prefer-read-only-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Prop \'name\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'name'}
       }],
       output: `
         function Hello(props: {+name: string}) {
@@ -276,7 +280,8 @@ ruleTester.run('prefer-read-only-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Prop \'name\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'name'}
       }],
       output: `
         function Hello(props: {|+name: string|}) {
@@ -292,7 +297,8 @@ ruleTester.run('prefer-read-only-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Prop \'name\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'name'}
       }],
       output: `
         function Hello({name}: {+name: string}) {
@@ -312,9 +318,11 @@ ruleTester.run('prefer-read-only-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Prop \'firstName\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'firstName'}
       }, {
-        message: 'Prop \'lastName\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'lastName'}
       }],
       output: `
         type PropsA = {+firstName: string};
@@ -334,7 +342,8 @@ ruleTester.run('prefer-read-only-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Prop \'name\' should be read-only.'
+        messageId: 'readOnlyProp',
+        data: {name: 'name'}
       }],
       output: `
         const Hello = (props: {+name: string}) => (

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -345,7 +345,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -356,7 +356,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -367,7 +367,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -378,7 +378,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -393,7 +393,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -406,7 +406,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -423,7 +423,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -438,7 +438,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -453,7 +453,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -468,7 +468,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -480,7 +480,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -495,7 +495,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -509,7 +509,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         });
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -520,7 +520,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -536,7 +536,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -553,7 +553,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -568,7 +568,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         };
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -584,7 +584,7 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -601,7 +601,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }, {
       code: `
@@ -616,7 +616,7 @@ ruleTester.run('prefer-stateless-function', rule, {
         };
       `,
       errors: [{
-        message: 'Component should be written as a pure function'
+        messageId: 'componentShouldBePure'
       }]
     }
   ]

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3155,7 +3155,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 7,
         column: 23,
         type: 'Identifier'
@@ -3170,7 +3171,8 @@ ruleTester.run('prop-types', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 3,
         column: 54,
         type: 'Identifier'
@@ -3184,7 +3186,8 @@ ruleTester.run('prop-types', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 3,
         column: 35,
         type: 'Identifier'
@@ -3198,7 +3201,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 3,
         column: 35,
         type: 'Identifier'
@@ -3349,7 +3353,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 3,
         column: 13,
         type: 'Property'
@@ -3367,7 +3372,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'title\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'title'},
         line: 3,
         column: 19,
         type: 'Property'
@@ -3386,7 +3392,8 @@ ruleTester.run('prop-types', rule, {
         'Hello.propTypes = {}'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 3,
         column: 13,
         type: 'Property'
@@ -3401,7 +3408,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 4,
         column: 35,
         type: 'Identifier'
@@ -3418,7 +3426,8 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: '\'lastname\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'lastname'}
       }]
     }, {
       code: [
@@ -3437,7 +3446,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3456,9 +3466,11 @@ ruleTester.run('prop-types', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: '\'propWithoutTypeDefinition\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'propWithoutTypeDefinition'}
       }, {
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3473,7 +3485,8 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: '\'lastname\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'lastname'}
       }]
     }, {
       code: [
@@ -3488,7 +3501,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'firstname\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'firstname'}
       }]
     }, {
       code: [
@@ -3504,7 +3518,8 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: '\'a.b\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'a.b'}
       }]
     }, {
       code: [
@@ -3522,7 +3537,8 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: '\'a.b.c\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'a.b.c'}
       }]
     }, {
       code: [
@@ -3538,7 +3554,8 @@ ruleTester.run('prop-types', rule, {
         'Hello.propTypes.a.b = PropTypes.shape({});'
       ].join('\n'),
       errors: [{
-        message: '\'a.b.c\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'a.b.c'}
       }]
     }, {
       code: [
@@ -3558,10 +3575,22 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: '\'a.b.c\' is missing in props validation'},
-        {message: '\'a.__.d\' is missing in props validation'},
-        {message: '\'a.__.d.length\' is missing in props validation'},
-        {message: '\'a.anything.e\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a.b.c'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a.__.d'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a.__.d.length'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a.anything.e'}
+        }
       ]
     }, {
       code: [
@@ -3583,10 +3612,22 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: '\'a[].c\' is missing in props validation'},
-        {message: '\'a[].d\' is missing in props validation'},
-        {message: '\'a[].d.length\' is missing in props validation'},
-        {message: '\'a[].e\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a[].c'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a[].d'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a[].d.length'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a[].e'}
+        }
       ]
     }, {
       code: [
@@ -3611,8 +3652,14 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: '\'a.length\' is missing in props validation'},
-        {message: '\'a.b\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a.length'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a.b'}
+        }
       ]
     }, {
       code: [
@@ -3631,7 +3678,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'propX\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'propX'}
+        }
       ]
     }, {
       code: [
@@ -3645,7 +3695,10 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: '\'some.value\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'some.value'}
+        }
       ]
     }, {
       code: [
@@ -3659,7 +3712,10 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: '\'arr\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'arr'}
+        }
       ]
     }, {
       code: [
@@ -3676,7 +3732,10 @@ ruleTester.run('prop-types', rule, {
         '};'
       ].join('\n'),
       errors: [
-        {message: '\'arr[].some.value\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'arr[].some.value'}
+        }
       ]
     }, {
       code: [
@@ -3691,7 +3750,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'firstname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'firstname'}
+        }
       ]
     }, {
       code: [
@@ -3704,7 +3766,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'firstname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'firstname'}
+        }
       ]
     }, {
       code: [
@@ -3723,7 +3788,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'firstname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'firstname'}
+        }
       ]
     }, {
       code: [
@@ -3733,7 +3801,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3743,7 +3812,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3753,7 +3823,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3764,7 +3835,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3774,7 +3846,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3784,7 +3857,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3794,7 +3868,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -3807,7 +3882,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'lastname'}
+        }
       ]
     }, {
       code: [
@@ -3820,7 +3898,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'source\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'source'}
+        }
       ]
     }, {
       code: [
@@ -3833,8 +3914,14 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'source\' is missing in props validation'},
-        {message: '\'source.uri\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'source'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'source.uri'}
+        }
       ]
     }, {
       code: [
@@ -3847,7 +3934,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'source\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'source'}
+        }
       ]
     }, {
       code: [
@@ -3860,8 +3950,14 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'source\' is missing in props validation'},
-        {message: '\'source.uri\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'source'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'source.uri'}
+        }
       ]
     }, {
       code: [
@@ -3877,7 +3973,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'name\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name'}
+        }
       ]
     }, {
       code: [
@@ -3893,7 +3992,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'name\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name'}
+        }
       ]
     }, {
       code: [
@@ -3913,8 +4015,14 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'firstname\' is missing in props validation'},
-        {message: '\'name\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'firstname'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name'}
+        }
       ]
     }, {
       code: [
@@ -3927,9 +4035,18 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'names\' is missing in props validation'},
-        {message: '\'names.map\' is missing in props validation'},
-        {message: '\'company\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'names'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'names.map'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'company'}
+        }
       ]
     }, {
       code: [
@@ -3941,7 +4058,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'text\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'text'}
+        }
       ]
     }, {
       code: [
@@ -3955,7 +4075,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'name\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name'}
+        }
       ]
     }, {
       code: [
@@ -3973,7 +4096,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'lastname'}
+        }
       ]
     }, {
       code: [
@@ -3991,7 +4117,10 @@ ruleTester.run('prop-types', rule, {
       parser: parsers.BABEL_ESLINT,
       settings,
       errors: [
-        {message: '\'lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'lastname'}
+        }
       ]
     }, {
       code: [
@@ -4011,7 +4140,10 @@ ruleTester.run('prop-types', rule, {
         propWrapperFunctions: ['forbidExtraProps']
       }),
       errors: [
-        {message: '\'lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'lastname'}
+        }
       ]
     }, {
       code: [
@@ -4031,7 +4163,10 @@ ruleTester.run('prop-types', rule, {
         propWrapperFunctions: ['Object.freeze']
       }),
       errors: [
-        {message: '\'lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'lastname'}
+        }
       ]
     }, {
       code: [
@@ -4049,7 +4184,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'lastname'}
+        }
       ]
     }, {
       code: [
@@ -4062,7 +4200,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'name\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name'}
+        }
       ]
     }, {
       code: [
@@ -4077,7 +4218,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'firstname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'firstname'}
+        }
       ]
     }, {
       code: [
@@ -4091,7 +4235,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'firstname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'firstname'}
+        }
       ]
     }, {
       code: [
@@ -4108,7 +4255,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'name.lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name.lastname'}
+        }
       ]
     }, {
       code: [
@@ -4122,7 +4272,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'name.lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name.lastname'}
+        }
       ]
     }, {
       code: [
@@ -4135,7 +4288,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'person.name.lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'person.name.lastname'}
+        }
       ]
     }, {
       code: [
@@ -4149,7 +4305,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'person.name.lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'person.name.lastname'}
+        }
       ]
     }, {
       code: [
@@ -4167,7 +4326,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'people[].name.lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'people[].name.lastname'}
+        }
       ]
     }, {
       code: [
@@ -4186,7 +4348,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'people[].name.lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'people[].name.lastname'}
+        }
       ]
     }, {
       code: [
@@ -4200,7 +4365,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'result.notok\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'result.notok'}
+        }
       ]
     }, {
       code: [
@@ -4212,7 +4380,8 @@ ruleTester.run('prop-types', rule, {
         'Greetings.propTypes = {};'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -4226,7 +4395,8 @@ ruleTester.run('prop-types', rule, {
         'Greetings.Hello.propTypes = {};'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -4239,7 +4409,8 @@ ruleTester.run('prop-types', rule, {
         'Greetings.Hello.propTypes = {};'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     }, {
       code: [
@@ -4249,9 +4420,11 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'names\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'names'}
       }, {
-        message: '\'names.map\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'names.map'}
       }]
     }, {
       code: [
@@ -4260,14 +4433,16 @@ ruleTester.run('prop-types', rule, {
         ')'
       ].join('\n'),
       errors: [{
-        message: '\'toggle\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'toggle'}
       }]
     }, {
       code: [
         'const MyComponent = props => props.test ? <div /> : <span />'
       ].join('\n'),
       errors: [{
-        message: '\'test\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'test'}
       }]
     }, {
       code: [
@@ -4278,7 +4453,8 @@ ruleTester.run('prop-types', rule, {
         '})'
       ].join('\n'),
       errors: [{
-        message: '\'test\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'test'}
       }]
     }, {
       code: [
@@ -4291,7 +4467,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'lastname\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'lastname'}
       }]
     }, {
       code: [
@@ -4309,8 +4486,14 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'firstname\' is missing in props validation'},
-        {message: '\'lastname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'firstname'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'lastname'}
+        }
       ]
     }, {
       code: [
@@ -4325,7 +4508,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'name.constructor.firstname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name.constructor.firstname'}
+        }
       ]
     },
     {
@@ -4335,7 +4521,10 @@ ruleTester.run('prop-types', rule, {
       }
     `,
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ],
       parser: parsers.BABEL_ESLINT
     },
@@ -4347,7 +4536,10 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [
-        {message: '\'bar\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'bar'}
+        }
       ]
     }, {
       code: [
@@ -4357,7 +4549,10 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [
-        {message: '\'bar\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'bar'}
+        }
       ]
     }, {
       code: [
@@ -4368,7 +4563,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 3,
         column: 35,
         type: 'Identifier'
@@ -4382,7 +4578,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'name\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name'},
         line: 3,
         column: 35,
         type: 'Identifier'
@@ -4398,7 +4595,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'b\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'b'},
         line: 4,
         column: 27,
         type: 'Property'
@@ -4414,7 +4612,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       options: [{skipUndeclared: true}],
       errors: [{
-        message: '\'firstname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'firstname'},
         line: 4,
         column: 29
       }]
@@ -4427,7 +4626,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       options: [{skipUndeclared: true}],
       errors: [{
-        message: '\'firstname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'firstname'},
         line: 2,
         column: 22
       }]
@@ -4444,7 +4644,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       options: [{skipUndeclared: true}],
       errors: [{
-        message: '\'firstname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'firstname'},
         line: 6,
         column: 29
       }]
@@ -4459,7 +4660,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       options: [{skipUndeclared: true}],
       errors: [{
-        message: '\'firstname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'firstname'},
         line: 3,
         column: 29
       }]
@@ -4473,7 +4675,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       options: [{skipUndeclared: false}],
       errors: [{
-        message: '\'firstname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'firstname'},
         line: 3,
         column: 29
       }]
@@ -4488,7 +4691,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'b\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'b'},
         line: 4,
         column: 27,
         type: 'Property'
@@ -4504,7 +4708,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'b\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'b'},
         line: 4,
         column: 27,
         type: 'Property'
@@ -4521,7 +4726,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'firstname\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'firstname'}
+        }
       ]
     }, {
       code: [
@@ -4536,7 +4744,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ]
     }, {
       code: [
@@ -4559,7 +4770,10 @@ ruleTester.run('prop-types', rule, {
         propWrapperFunctions: ['forbidExtraProps']
       }),
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ]
     }, {
       code: [
@@ -4579,7 +4793,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ]
     }, {
       code: [
@@ -4600,7 +4817,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ]
     }, {
       code: [
@@ -4620,7 +4840,10 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ]
     }, {
       code: [
@@ -4639,7 +4862,10 @@ ruleTester.run('prop-types', rule, {
         '  }'
       ].join('\n'),
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ]
     }, {
       code: [
@@ -4662,7 +4888,10 @@ ruleTester.run('prop-types', rule, {
         propWrapperFunctions: ['forbidExtraProps']
       }),
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ]
     }, {
       code: [
@@ -4681,7 +4910,10 @@ ruleTester.run('prop-types', rule, {
         '  }'
       ].join('\n'),
       errors: [
-        {message: '\'foo\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'foo'}
+        }
       ]
     }, {
       code: [
@@ -4697,7 +4929,10 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [
-        {message: '\'name\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'name'}
+        }
       ]
     }, {
       code: [
@@ -4711,7 +4946,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'lastname'},
         line: 6,
         column: 35,
         type: 'Identifier'
@@ -4730,7 +4966,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       settings: {react: {flowVersion: '0.52'}},
       errors: [{
-        message: '\'lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'lastname'},
         line: 6,
         column: 35,
         type: 'Identifier'
@@ -4751,7 +4988,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'lastname'},
         line: 7,
         column: 7,
         type: 'Property'
@@ -4773,7 +5011,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       settings: {react: {flowVersion: '0.52'}},
       errors: [{
-        message: '\'lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'lastname'},
         line: 7,
         column: 7,
         type: 'Property'
@@ -4789,7 +5028,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'name.lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name.lastname'},
         line: 4,
         column: 40,
         type: 'Identifier'
@@ -4806,7 +5046,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       settings: {react: {flowVersion: '0.52'}},
       errors: [{
-        message: '\'name.lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'name.lastname'},
         line: 4,
         column: 40,
         type: 'Identifier'
@@ -4822,7 +5063,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'result.notok\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'result.notok'},
         line: 4,
         column: 42,
         type: 'Identifier'
@@ -4839,7 +5081,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       settings: {react: {flowVersion: '0.52'}},
       errors: [{
-        message: '\'result.notok\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'result.notok'},
         line: 4,
         column: 42,
         type: 'Identifier'
@@ -4857,7 +5100,8 @@ ruleTester.run('prop-types', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: '\'person.lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'person.lastname'},
         line: 6,
         column: 42,
         type: 'Identifier'
@@ -4876,7 +5120,8 @@ ruleTester.run('prop-types', rule, {
       ].join('\n'),
       settings: {react: {flowVersion: '0.52'}},
       errors: [{
-        message: '\'person.lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'person.lastname'},
         line: 6,
         column: 42,
         type: 'Identifier'
@@ -4895,7 +5140,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'bar\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'bar'},
         line: 8,
         column: 37,
         type: 'Identifier'
@@ -4915,7 +5161,8 @@ ruleTester.run('prop-types', rule, {
       `,
       settings: {react: {flowVersion: '0.53'}},
       errors: [{
-        message: '\'bar\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'bar'},
         line: 8,
         column: 37,
         type: 'Identifier'
@@ -4934,7 +5181,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'bar\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'bar'},
         line: 8,
         column: 37,
         type: 'Identifier'
@@ -4954,7 +5202,8 @@ ruleTester.run('prop-types', rule, {
       `,
       settings: {react: {flowVersion: '0.53'}},
       errors: [{
-        message: '\'bar\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'bar'},
         line: 8,
         column: 37,
         type: 'Identifier'
@@ -4972,7 +5221,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'person.lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'person.lastname'},
         line: 7,
         column: 50,
         type: 'Identifier'
@@ -4991,7 +5241,8 @@ ruleTester.run('prop-types', rule, {
       `,
       settings: {react: {flowVersion: '0.53'}},
       errors: [{
-        message: '\'person.lastname\' is missing in props validation',
+        messageId: 'missingPropType',
+        data: {name: 'person.lastname'},
         line: 7,
         column: 50,
         type: 'Identifier'
@@ -5009,7 +5260,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'bar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'bar'}
       }],
       parser: parsers.BABEL_ESLINT
     }, {
@@ -5023,7 +5275,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'bar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'bar'}
       }],
       parser: parsers.BABEL_ESLINT
     }, {
@@ -5041,7 +5294,8 @@ ruleTester.run('prop-types', rule, {
         )
       `,
       errors: [{
-        message: '\'bar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'bar'}
       }],
       parser: parsers.BABEL_ESLINT
     }, {
@@ -5060,7 +5314,8 @@ ruleTester.run('prop-types', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'fooBar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'fooBar'}
       }]
     }, {
       code: `
@@ -5079,7 +5334,8 @@ ruleTester.run('prop-types', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'fooBar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'fooBar'}
       }]
     }, {
       code: `
@@ -5098,7 +5354,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'fooBar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'fooBar'}
       }],
       parser: parsers.BABEL_ESLINT
     }, {
@@ -5118,7 +5375,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'fooBar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'fooBar'}
       }],
       parser: parsers.BABEL_ESLINT
     },
@@ -5150,7 +5408,8 @@ ruleTester.run('prop-types', rule, {
       );
     `,
       errors: [{
-        message: '\'bad\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'bad'}
       }],
       parser: parsers.BABEL_ESLINT
     },
@@ -5170,7 +5429,8 @@ ruleTester.run('prop-types', rule, {
         };
       `,
       errors: [{
-        message: '\'foo.baz\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'foo.baz'}
       }]
     },
     {
@@ -5189,7 +5449,8 @@ ruleTester.run('prop-types', rule, {
         };
       `,
       errors: [{
-        message: '\'bar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'bar'}
       }]
     },
     {
@@ -5204,7 +5465,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'zoo\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'zoo'}
       }]
     },
     {
@@ -5229,7 +5491,8 @@ ruleTester.run('prop-types', rule, {
       `,
       settings: {react: {version: '16.3.0'}},
       errors: [{
-        message: '\'bar\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'bar'}
       }]
     },
     {
@@ -5244,7 +5507,8 @@ ruleTester.run('prop-types', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'page\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'page'}
       }]
     },
     {
@@ -5259,7 +5523,8 @@ ruleTester.run('prop-types', rule, {
         ));
       `,
       errors: [{
-        message: '\'cryptoCurrency\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'cryptoCurrency'}
       }]
     },
     {
@@ -5275,7 +5540,8 @@ ruleTester.run('prop-types', rule, {
         ));
       `,
       errors: [{
-        message: '\'cryptoCurrency\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'cryptoCurrency'}
       }]
     },
     {
@@ -5295,7 +5561,8 @@ ruleTester.run('prop-types', rule, {
         }
       },
       errors: [{
-        message: '\'cryptoCurrency\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'cryptoCurrency'}
       }]
     },
     {
@@ -5316,7 +5583,8 @@ ruleTester.run('prop-types', rule, {
         }
       },
       errors: [{
-        message: '\'cryptoCurrency\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'cryptoCurrency'}
       }]
     },
     {
@@ -5326,7 +5594,8 @@ ruleTester.run('prop-types', rule, {
         });
       `,
       errors: [{
-        message: '\'text\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'text'}
       }]
     },
     {
@@ -5337,7 +5606,8 @@ ruleTester.run('prop-types', rule, {
         });
       `,
       errors: [{
-        message: '\'text\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'text'}
       }]
     },
     {
@@ -5352,7 +5622,8 @@ ruleTester.run('prop-types', rule, {
         }
       },
       errors: [{
-        message: '\'text\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'text'}
       }]
     },
     {
@@ -5368,7 +5639,8 @@ ruleTester.run('prop-types', rule, {
         }
       },
       errors: [{
-        message: '\'text\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'text'}
       }]
     }, {
       code: `
@@ -5387,7 +5659,8 @@ ruleTester.run('prop-types', rule, {
         export default MyComponent;
       `,
       errors: [{
-        message: '\'usedProp\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'usedProp'}
       }]
     },
     {
@@ -5402,7 +5675,8 @@ ruleTester.run('prop-types', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     },
     {
@@ -5422,9 +5696,18 @@ ruleTester.run('prop-types', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [
-        {message: '\'a\' is missing in props validation'},
-        {message: '\'a.b\' is missing in props validation'},
-        {message: '\'a.b.c\' is missing in props validation'}
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a.b'}
+        },
+        {
+          messageId: 'missingPropType',
+          data: {name: 'a.b.c'}
+        }
       ]
     },
     {
@@ -5452,7 +5735,8 @@ ruleTester.run('prop-types', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'initialValues\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'initialValues'}
       }]
     },
     {
@@ -5492,7 +5776,8 @@ ruleTester.run('prop-types', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'lastname\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'lastname'}
       }]
     },
     {
@@ -5520,7 +5805,8 @@ ruleTester.run('prop-types', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: '\'user.age\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'user.age'}
       }]
     },
     {
@@ -5530,7 +5816,8 @@ ruleTester.run('prop-types', rule, {
         }));
       `,
       errors: [{
-        message: '\'text\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'text'}
       }]
     },
     {
@@ -5541,7 +5828,8 @@ ruleTester.run('prop-types', rule, {
         }));
       `,
       errors: [{
-        message: '\'text\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'text'}
       }]
     },
     {
@@ -5557,7 +5845,8 @@ ruleTester.run('prop-types', rule, {
         }
       },
       errors: [{
-        message: '\'text\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'text'}
       }]
     },
     {
@@ -5578,7 +5867,8 @@ ruleTester.run('prop-types', rule, {
         };
       `,
       errors: [{
-        message: '\'foo.baz\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'foo.baz'}
       }]
     },
     {
@@ -5590,10 +5880,12 @@ ruleTester.run('prop-types', rule, {
         );
       `,
       errors: [{
-        message: '\'length\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'length'}
       },
       {
-        message: '\'ordering\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'ordering'}
       }]
     },
     {
@@ -5683,7 +5975,8 @@ ruleTester.run('prop-types', rule, {
         };
       `,
       errors: [{
-        message: '\'foo.baz\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'foo.baz'}
       }]
     },
     {
@@ -5704,7 +5997,8 @@ ruleTester.run('prop-types', rule, {
         };
       `,
       errors: [{
-        message: '\'foo.baz\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'foo.baz'}
       }]
     },
     {
@@ -5725,7 +6019,8 @@ ruleTester.run('prop-types', rule, {
         };
       `,
       errors: [{
-        message: '\'foo.baz\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'foo.baz'}
       }]
     },
     {
@@ -5738,7 +6033,8 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       errors: [{
-        message: '\'name\' is missing in props validation'
+        messageId: 'missingPropType',
+        data: {name: 'name'}
       }]
     },
     parsers.TS([
@@ -5755,7 +6051,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers.TYPESCRIPT_ESLINT,
         errors: [{
-          message: '\'value\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'value'}
         }]
       },
       {
@@ -5771,7 +6068,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
-          message: '\'value\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'value'}
         }]
       },
       {
@@ -5795,7 +6093,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers.TYPESCRIPT_ESLINT,
         errors: [{
-          message: '\'userId\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'userId'}
         }]
       },
       {
@@ -5819,7 +6118,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
-          message: '\'userId\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'userId'}
         }]
       },
       {
@@ -5843,7 +6143,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers.TYPESCRIPT_ESLINT,
         errors: [{
-          message: '\'user\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'user'}
         }]
       },
       {
@@ -5867,7 +6168,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
-          message: '\'user\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'user'}
         }]
       },
       {
@@ -5892,7 +6194,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers.TYPESCRIPT_ESLINT,
         errors: [{
-          message: '\'userId\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'userId'}
         }]
       },
       {
@@ -5917,7 +6220,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
-          message: '\'userId\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'userId'}
         }]
       },
       {
@@ -5938,7 +6242,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers.TYPESCRIPT_ESLINT,
         errors: [{
-          message: '\'onClick\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'onClick'}
         }]
       },
       {
@@ -5959,7 +6264,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
-          message: '\'onClick\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'onClick'}
         }]
       },
       {
@@ -5978,7 +6284,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers.TYPESCRIPT_ESLINT,
         errors: [{
-          message: '\'books\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'books'}
         }]
       },
       {
@@ -5997,7 +6304,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
-          message: '\'books\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'books'}
         }]
       },
       {
@@ -6016,7 +6324,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers.TYPESCRIPT_ESLINT,
         errors: [{
-          message: '\'username\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'username'}
         }]
       },
       {
@@ -6035,7 +6344,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
-          message: '\'username\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'username'}
         }]
       },
       {
@@ -6057,7 +6367,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers.TYPESCRIPT_ESLINT,
         errors: [{
-          message: '\'dateCreated\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'dateCreated'}
         }]
       },
       {
@@ -6079,7 +6390,8 @@ ruleTester.run('prop-types', rule, {
         `,
         parser: parsers['@TYPESCRIPT_ESLINT'],
         errors: [{
-          message: '\'dateCreated\' is missing in props validation'
+          messageId: 'missingPropType',
+          data: {name: 'dateCreated'}
         }]
       },
       {
@@ -6199,7 +6511,10 @@ ruleTester.run('prop-types', rule, {
         }
       `,
         errors: [
-          {message: '\'bar\' is missing in props validation'}
+          {
+            messageId: 'missingPropType',
+            data: {name: 'bar'}
+          }
         ],
         parser: parsers['@TYPESCRIPT_ESLINT']
       },
@@ -6210,7 +6525,10 @@ ruleTester.run('prop-types', rule, {
         }
       `,
         errors: [
-          {message: '\'foo\' is missing in props validation'}
+          {
+            messageId: 'missingPropType',
+            data: {name: 'foo'}
+          }
         ],
         parser: parsers['@TYPESCRIPT_ESLINT']
       },
@@ -6221,7 +6539,10 @@ ruleTester.run('prop-types', rule, {
         }
       `,
         errors: [
-          {message: '\'bar\' is missing in props validation'}
+          {
+            messageId: 'missingPropType',
+            data: {name: 'bar'}
+          }
         ],
         parser: parsers['@TYPESCRIPT_ESLINT']
       },
@@ -6232,7 +6553,10 @@ ruleTester.run('prop-types', rule, {
         }
       `,
         errors: [
-          {message: '\'bar\' is missing in props validation'}
+          {
+            messageId: 'missingPropType',
+            data: {name: 'bar'}
+          }
         ],
         parser: parsers['@TYPESCRIPT_ESLINT']
       }

--- a/tests/lib/rules/react-in-jsx-scope.js
+++ b/tests/lib/rules/react-in-jsx-scope.js
@@ -64,26 +64,47 @@ ruleTester.run('react-in-jsx-scope', rule, {
   ],
   invalid: [{
     code: 'var App, a = <App />;',
-    errors: [{message: '\'React\' must be in scope when using JSX'}]
+    errors: [{
+      messageId: 'notInScope',
+      data: {name: 'React'}
+    }]
   }, {
     code: 'var a = <App />;',
-    errors: [{message: '\'React\' must be in scope when using JSX'}]
+    errors: [{
+      messageId: 'notInScope',
+      data: {name: 'React'}
+    }]
   }, {
     code: 'var a = <img />;',
-    errors: [{message: '\'React\' must be in scope when using JSX'}]
+    errors: [{
+      messageId: 'notInScope',
+      data: {name: 'React'}
+    }]
   }, {
     code: 'var a = <>fragment</>;',
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: '\'React\' must be in scope when using JSX'}]
+    errors: [{
+      messageId: 'notInScope',
+      data: {name: 'React'}
+    }]
   }, {
     code: '/** @jsx React.DOM */ var a = <img />;',
-    errors: [{message: '\'React\' must be in scope when using JSX'}]
+    errors: [{
+      messageId: 'notInScope',
+      data: {name: 'React'}
+    }]
   }, {
     code: '/** @jsx Foo.bar */ var React, a = <img />;',
-    errors: [{message: '\'Foo\' must be in scope when using JSX'}]
+    errors: [{
+      messageId: 'notInScope',
+      data: {name: 'Foo'}
+    }]
   }, {
     code: 'var React, a = <img />;',
-    errors: [{message: '\'Foo\' must be in scope when using JSX'}],
+    errors: [{
+      messageId: 'notInScope',
+      data: {name: 'Foo'}
+    }],
     settings
   }]
 });

--- a/tests/lib/rules/require-default-props.js
+++ b/tests/lib/rules/require-default-props.js
@@ -1106,7 +1106,8 @@ ruleTester.run('require-default-props', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 5,
         column: 3
       }]
@@ -1122,7 +1123,8 @@ ruleTester.run('require-default-props', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 5,
         column: 3
       }],
@@ -1142,7 +1144,8 @@ ruleTester.run('require-default-props', rule, {
         'MyStatelessComponent.propTypes = forbidExtraProps(propTypes);'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 5,
         column: 3
       }],
@@ -1163,12 +1166,14 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       errors: [
         {
-          message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'foo'},
           line: 5,
           column: 3
         },
         {
-          message: 'propType "baz" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'baz'},
           line: 8,
           column: 1
         }
@@ -1187,7 +1192,8 @@ ruleTester.run('require-default-props', rule, {
         'MyStatelessComponent.propTypes = types;'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 2,
         column: 3
       }]
@@ -1208,7 +1214,8 @@ ruleTester.run('require-default-props', rule, {
         'MyStatelessComponent.defaultProps = defaults;'
       ].join('\n'),
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 9,
         column: 3
       }]
@@ -1230,7 +1237,8 @@ ruleTester.run('require-default-props', rule, {
         'MyStatelessComponent.defaultProps = defaults;'
       ].join('\n'),
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 6,
         column: 3
       }]
@@ -1251,7 +1259,8 @@ ruleTester.run('require-default-props', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 6,
         column: 5
       }]
@@ -1270,7 +1279,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       options: [{ignoreFunctionalComponents: true}],
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 6,
         column: 5
       }]
@@ -1293,7 +1303,8 @@ ruleTester.run('require-default-props', rule, {
         '});'
       ].join('\n'),
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 7,
         column: 5
       }]
@@ -1316,7 +1327,8 @@ ruleTester.run('require-default-props', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 9,
         column: 3
       }]
@@ -1337,7 +1349,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       options: [{ignoreFunctionalComponents: true}],
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 9,
         column: 3
       }]
@@ -1360,7 +1373,8 @@ ruleTester.run('require-default-props', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 10,
         column: 3
       }]
@@ -1380,7 +1394,8 @@ ruleTester.run('require-default-props', rule, {
         'Greeting.propTypes.foo = PropTypes.string;'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 11,
         column: 1
       }]
@@ -1402,7 +1417,8 @@ ruleTester.run('require-default-props', rule, {
         'Greeting.defaultProps.foo = "foo";'
       ].join('\n'),
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 9,
         column: 3
       }]
@@ -1422,7 +1438,8 @@ ruleTester.run('require-default-props', rule, {
         'Greeting.defaultProps.bar = "bar";'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 9,
         column: 1
       }]
@@ -1443,7 +1460,8 @@ ruleTester.run('require-default-props', rule, {
         'Greeting.propTypes = props;'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 9,
         column: 3
       }]
@@ -1468,7 +1486,8 @@ ruleTester.run('require-default-props', rule, {
         'Greeting.defaultProps = defaults;'
       ].join('\n'),
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 10,
         column: 3
       }]
@@ -1490,7 +1509,8 @@ ruleTester.run('require-default-props', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'propType "name" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'name'},
         line: 4,
         column: 7
       }]
@@ -1510,7 +1530,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       options: [{ignoreFunctionalComponents: true}],
       errors: [{
-        message: 'propType "name" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'name'},
         line: 4,
         column: 7
       }]
@@ -1535,7 +1556,8 @@ ruleTester.run('require-default-props', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 4,
         column: 7
       }]
@@ -1556,7 +1578,8 @@ ruleTester.run('require-default-props', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 2,
         column: 3
       }]
@@ -1583,7 +1606,8 @@ ruleTester.run('require-default-props', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 7,
         column: 7
       }]
@@ -1607,7 +1631,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 8,
         column: 5
       }]
@@ -1629,7 +1654,8 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       options: [{ignoreFunctionalComponents: true}],
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 8,
         column: 5
       }]
@@ -1653,7 +1679,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 9,
         column: 5
       }]
@@ -1675,7 +1702,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 2,
         column: 3
       }]
@@ -1701,7 +1729,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 3,
         column: 3
       }]
@@ -1722,7 +1751,8 @@ ruleTester.run('require-default-props', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 8,
         column: 3
       }]
@@ -1737,7 +1767,8 @@ ruleTester.run('require-default-props', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 5,
         column: 3
       }]
@@ -1757,7 +1788,8 @@ ruleTester.run('require-default-props', rule, {
         '};'
       ].join('\n'),
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 8,
         column: 3
       }]
@@ -1783,7 +1815,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 4,
         column: 5
       }]
@@ -1805,7 +1838,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 3,
         column: 3
       }]
@@ -1828,7 +1862,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 2,
         column: 3
       }]
@@ -1848,7 +1883,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 4,
         column: 5
       }]
@@ -1869,12 +1905,14 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'foo'},
           line: 3,
           column: 5
         },
         {
-          message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'bar'},
           line: 4,
           column: 5
         }
@@ -1896,7 +1934,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 3,
         column: 5
       }]
@@ -1922,7 +1961,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 3,
         column: 3
       }]
@@ -1950,7 +1990,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 3,
         column: 3
       }]
@@ -1976,7 +2017,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 4,
         column: 5
       }]
@@ -1989,7 +2031,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 1,
         column: 25
       }]
@@ -2002,7 +2045,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 1,
         column: 35
       }]
@@ -2016,7 +2060,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 1,
         column: 39
       }]
@@ -2030,12 +2075,14 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'foo'},
           line: 1,
           column: 25
         },
         {
-          message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'bar'},
           line: 1,
           column: 39
         }
@@ -2053,7 +2100,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 2,
         column: 3
       }]
@@ -2066,7 +2114,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 1,
         column: 25
       }]
@@ -2080,7 +2129,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 1,
         column: 39
       }]
@@ -2093,7 +2143,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'},
         line: 1,
         column: 33
       }]
@@ -2107,7 +2158,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 1,
         column: 47
       }]
@@ -2126,7 +2178,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'},
         line: 3,
         column: 3
       }]
@@ -2142,12 +2195,14 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'propType "one" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'one'},
           line: 1,
           column: 25
         },
         {
-          message: 'propType "two" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'two'},
           line: 1,
           column: 44
         }
@@ -2172,12 +2227,14 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'bar'},
           line: 3,
           column: 3
         },
         {
-          message: 'propType "baz" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'baz'},
           line: 7,
           column: 3
         }
@@ -2206,7 +2263,8 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'propType "baz" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'baz'},
           line: 7,
           column: 3
         }
@@ -2225,12 +2283,14 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'propType "two" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'two'},
           line: 2,
           column: 3
         },
         {
-          message: 'propType "one" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'one'},
           line: 5,
           column: 25
         }
@@ -2249,7 +2309,8 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'propType "two" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'two'},
           line: 2,
           column: 3
         }
@@ -2269,7 +2330,8 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       errors: [
         {
-          message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.',
+          messageId: 'shouldHaveDefault',
+          data: {name: 'foo'},
           line: 3,
           column: 5
         }
@@ -2295,7 +2357,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "name" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'name'}
       }]
     },
     {
@@ -2313,7 +2376,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "first-name" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'first-name'}
       }]
     },
     {
@@ -2332,7 +2396,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       options: [{forbidDefaultForRequired: true}],
       errors: [{
-        message: 'propType "foo" is required and should not have a defaultProps declaration.'
+        messageId: 'noDefaultWithRequired',
+        data: {name: 'foo'}
       }]
     },
     {
@@ -2349,7 +2414,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       options: [{forbidDefaultForRequired: true}],
       errors: [{
-        message: 'propType "foo" is required and should not have a defaultProps declaration.'
+        messageId: 'noDefaultWithRequired',
+        data: {name: 'foo'}
       }]
     },
     {
@@ -2366,7 +2432,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       options: [{forbidDefaultForRequired: true}],
       errors: [{
-        message: 'propType "foo" is required and should not have a defaultProps declaration.'
+        messageId: 'noDefaultWithRequired',
+        data: {name: 'foo'}
       }]
     },
     {
@@ -2386,7 +2453,8 @@ ruleTester.run('require-default-props', rule, {
       parser: parsers.BABEL_ESLINT,
       options: [{forbidDefaultForRequired: true}],
       errors: [{
-        message: 'propType "foo" is required and should not have a defaultProps declaration.'
+        messageId: 'noDefaultWithRequired',
+        data: {name: 'foo'}
       }]
     },
     {
@@ -2409,7 +2477,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       options: [{forbidDefaultForRequired: true}],
       errors: [{
-        message: 'propType "foo" is required and should not have a defaultProps declaration.'
+        messageId: 'noDefaultWithRequired',
+        data: {name: 'foo'}
       }]
     },
     // test support for React PropTypes as Component's class generic
@@ -2429,7 +2498,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'}
       }]
     },
     {
@@ -2448,7 +2518,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'}
       }]
     },
     {
@@ -2471,7 +2542,8 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'}
       }]
     },
     {
@@ -2490,9 +2562,11 @@ ruleTester.run('require-default-props', rule, {
       ].join('\n'),
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "foo" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'foo'}
       }, {
-        message: 'propType "bar" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'bar'}
       }]
     },
     {
@@ -2506,7 +2580,8 @@ ruleTester.run('require-default-props', rule, {
       `,
       parser: parsers.BABEL_ESLINT,
       errors: [{
-        message: 'propType "name" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'name'}
       }]
     }, {
       code: `
@@ -2529,7 +2604,8 @@ ruleTester.run('require-default-props', rule, {
         export default MyComponent;
       `,
       errors: [{
-        message: 'propType "usedProp" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'usedProp'}
       }]
     },
     {
@@ -2543,7 +2619,8 @@ ruleTester.run('require-default-props', rule, {
         };
       `,
       errors: [{
-        message: 'propType "a" is not required, but has no corresponding defaultProps declaration.'
+        messageId: 'shouldHaveDefault',
+        data: {name: 'a'}
       }]
     }
   ]

--- a/tests/lib/rules/require-optimization.js
+++ b/tests/lib/rules/require-optimization.js
@@ -18,8 +18,6 @@ const parserOptions = {
   }
 };
 
-const MESSAGE = 'Component is not optimized. Please add a shouldComponentUpdate method.';
-
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('react-require-optimization', rule, {
   valid: [{
@@ -133,7 +131,7 @@ ruleTester.run('react-require-optimization', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }]
   }],
 
@@ -143,7 +141,7 @@ ruleTester.run('react-require-optimization', rule, {
       class YourComponent extends React.Component {}
     `,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }]
   }, {
     code: `
@@ -157,7 +155,7 @@ ruleTester.run('react-require-optimization', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }]
   }, {
     code: `
@@ -171,7 +169,7 @@ ruleTester.run('react-require-optimization', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }]
   }, {
     code: `
@@ -179,7 +177,7 @@ ruleTester.run('react-require-optimization', rule, {
       class YourComponent extends Component {}
     `,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }]
   }, {
     code: `
@@ -187,7 +185,7 @@ ruleTester.run('react-require-optimization', rule, {
       createReactClass({})
     `,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }]
   }, {
     code: `
@@ -197,7 +195,7 @@ ruleTester.run('react-require-optimization', rule, {
       })
     `,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }]
   }, {
     code: `
@@ -205,7 +203,7 @@ ruleTester.run('react-require-optimization', rule, {
       class DecoratedComponent extends Component {}
     `,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }],
     parser: parsers.BABEL_ESLINT
   }, {
@@ -216,7 +214,7 @@ ruleTester.run('react-require-optimization', rule, {
       class DecoratedComponent extends Component {}
     `,
     errors: [{
-      message: MESSAGE
+      messageId: 'noShouldComponentUpdate'
     }],
     parser: parsers.BABEL_ESLINT,
     options: [{allowDecorators: ['renderPure', 'pureRender']}]

--- a/tests/lib/rules/require-render-return.js
+++ b/tests/lib/rules/require-render-return.js
@@ -150,7 +150,7 @@ ruleTester.run('require-render-return', rule, {
       });
     `,
     errors: [{
-      message: 'Your render method should have a return statement',
+      messageId: 'noRenderReturn',
       line: 4
     }]
   }, {
@@ -161,7 +161,7 @@ ruleTester.run('require-render-return', rule, {
       }
     `,
     errors: [{
-      message: 'Your render method should have a return statement'
+      messageId: 'noRenderReturn'
     }]
   }, {
     // Missing return (but one is present in a sub-function)
@@ -175,7 +175,7 @@ ruleTester.run('require-render-return', rule, {
       }
     `,
     errors: [{
-      message: 'Your render method should have a return statement',
+      messageId: 'noRenderReturn',
       line: 3
     }]
   }, {
@@ -189,7 +189,7 @@ ruleTester.run('require-render-return', rule, {
     `,
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: 'Your render method should have a return statement',
+      messageId: 'noRenderReturn',
       type: 'ClassProperty'
     }]
   }]

--- a/tests/lib/rules/self-closing-comp.js
+++ b/tests/lib/rules/self-closing-comp.js
@@ -147,80 +147,80 @@ ruleTester.run('self-closing-comp', rule, {
       code: 'var contentContainer = <div className="content"></div>;',
       output: 'var contentContainer = <div className="content" />;',
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var contentContainer = <div className="content"></div>;',
       output: 'var contentContainer = <div className="content" />;',
       options: [],
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var HelloJohn = <Hello name="John"></Hello>;',
       output: 'var HelloJohn = <Hello name="John" />;',
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var CompoundHelloJohn = <Hello.Compound name="John"></Hello.Compound>;',
       output: 'var CompoundHelloJohn = <Hello.Compound name="John" />;',
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
       output: 'var HelloJohn = <Hello name="John" />;',
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var HelloJohn = <Hello.Compound name="John">\n</Hello.Compound>;',
       output: 'var HelloJohn = <Hello.Compound name="John" />;',
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var HelloJohn = <Hello name="John"></Hello>;',
       output: 'var HelloJohn = <Hello name="John" />;',
       options: [],
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var HelloJohn = <Hello.Compound name="John"></Hello.Compound>;',
       output: 'var HelloJohn = <Hello.Compound name="John" />;',
       options: [],
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var HelloJohn = <Hello name="John">\n</Hello>;',
       output: 'var HelloJohn = <Hello name="John" />;',
       options: [],
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var HelloJohn = <Hello.Compound name="John">\n</Hello.Compound>;',
       output: 'var HelloJohn = <Hello.Compound name="John" />;',
       options: [],
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var contentContainer = <div className="content"></div>;',
       output: 'var contentContainer = <div className="content" />;',
       options: [{html: true}],
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }, {
       code: 'var contentContainer = <div className="content">\n</div>;',
       output: 'var contentContainer = <div className="content" />;',
       options: [{html: true}],
       errors: [{
-        message: 'Empty components are self-closing'
+        messageId: 'notSelfClosing'
       }]
     }
   ]

--- a/tests/lib/rules/sort-comp.js
+++ b/tests/lib/rules/sort-comp.js
@@ -641,7 +641,10 @@ ruleTester.run('sort-comp', rule, {
       '  displayName : \'Hello\',',
       '});'
     ].join('\n'),
-    errors: [{message: 'render should be placed after displayName'}]
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'render', position: 'after', propB: 'displayName'}
+    }]
   }, {
     code: [
       '// Must run rule when render uses createElement instead of JSX',
@@ -652,7 +655,10 @@ ruleTester.run('sort-comp', rule, {
       '  displayName : \'Hello\',',
       '});'
     ].join('\n'),
-    errors: [{message: 'render should be placed after displayName'}]
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'render', position: 'after', propB: 'displayName'}
+    }]
   }, {
     code: [
       '// Must force a custom method to be placed before render',
@@ -663,7 +669,10 @@ ruleTester.run('sort-comp', rule, {
       '  onClick: function() {},',
       '});'
     ].join('\n'),
-    errors: [{message: 'render should be placed after onClick'}]
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'render', position: 'after', propB: 'onClick'}
+    }]
   }, {
     code: [
       '// Must force a custom method to be placed before render, even in function',
@@ -677,7 +686,10 @@ ruleTester.run('sort-comp', rule, {
       '};'
     ].join('\n'),
     parserOptions,
-    errors: [{message: 'render should be placed after onClick'}]
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'render', position: 'after', propB: 'onClick'}
+    }]
   }, {
     code: [
       '// Must force a custom method to be placed after render if no \'everything-else\' group is specified',
@@ -695,7 +707,10 @@ ruleTester.run('sort-comp', rule, {
         'render'
       ]
     }],
-    errors: [{message: 'onClick should be placed after render'}]
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'onClick', position: 'after', propB: 'render'}
+    }]
   }, {
     code: [
       '// Must validate static properties',
@@ -707,7 +722,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'render should be placed after displayName'}]
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'render', position: 'after', propB: 'displayName'}
+    }]
   }, {
     code: [
       '// Type Annotations should not be at the top by default',
@@ -721,7 +739,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'props should be placed after state'}]
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'props', position: 'after', propB: 'state'}
+    }]
   }, {
     code: [
       '// Type Annotations should be first',
@@ -734,7 +755,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'constructor should be placed after props'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'constructor', position: 'after', propB: 'props'}
+    }],
     options: [{
       order: [
         'type-annotations',
@@ -757,7 +781,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'state should be placed after constructor'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'state', position: 'after', propB: 'constructor'}
+    }],
     options: [{
       order: [
         'type-annotations',
@@ -779,7 +806,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'componentDidMountOk should be placed after getA'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'componentDidMountOk', position: 'after', propB: 'getA'}
+    }],
     options: [{
       order: [
         'static-methods',
@@ -803,7 +833,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'constructor should be placed after getter functions'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'constructor', position: 'after getter', propB: 'functions'}
+    }],
     options: [{
       order: [
         'getters',
@@ -825,7 +858,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'constructor should be placed after setter functions'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'constructor', position: 'after setter', propB: 'functions'}
+    }],
     options: [{
       order: [
         'setters',
@@ -849,7 +885,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'foo should be placed before constructor'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'foo', position: 'before', propB: 'constructor'}
+    }],
     options: [{
       order: [
         'instance-methods',
@@ -872,7 +911,10 @@ ruleTester.run('sort-comp', rule, {
       '}'
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'foo should be placed before constructor'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'foo', position: 'before', propB: 'constructor'}
+    }],
     options: [{
       order: [
         'instance-variables',
@@ -890,7 +932,10 @@ ruleTester.run('sort-comp', rule, {
       '  render() {}',
       '}'
     ].join('\n'),
-    errors: [{message: 'setters should be placed after render'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'setters', position: 'after', propB: 'render'}
+    }],
     options: [{
       order: [
         'setters',
@@ -906,7 +951,10 @@ ruleTester.run('sort-comp', rule, {
       '  foo() {}',
       '}'
     ].join('\n'),
-    errors: [{message: 'render should be placed after foo'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'render', position: 'after', propB: 'foo'}
+    }],
     options: [{
       order: [
         'foo',
@@ -924,7 +972,10 @@ ruleTester.run('sort-comp', rule, {
         }
       }
     `,
-    errors: [{message: 'getDerivedStateFromProps should be placed after foo'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'getDerivedStateFromProps', position: 'after', propB: 'foo'}
+    }],
     parser: parsers.BABEL_ESLINT,
     options: [{
       order: [
@@ -944,7 +995,10 @@ ruleTester.run('sort-comp', rule, {
         }
       }
     `,
-    errors: [{message: 'foo should be placed after bar'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'foo', position: 'after', propB: 'bar'}
+    }],
     parser: parsers.BABEL_ESLINT,
     options: [{
       order: [
@@ -965,7 +1019,10 @@ ruleTester.run('sort-comp', rule, {
       }
     `,
     parser: parsers.BABEL_ESLINT,
-    errors: [{message: 'bar should be placed after render'}],
+    errors: [{
+      messageId: 'unsortedProps',
+      data: {propA: 'bar', position: 'after', propB: 'render'}
+    }],
     options: [{
       order: [
         'static-methods',

--- a/tests/lib/rules/sort-prop-types.js
+++ b/tests/lib/rules/sort-prop-types.js
@@ -25,10 +25,6 @@ const parserOptions = {
 // Tests
 // -----------------------------------------------------------------------------
 
-const ERROR_MESSAGE = 'Prop types declarations should be sorted alphabetically';
-const REQUIRED_ERROR_MESSAGE = 'Required prop types must be listed before all other prop types';
-const CALLBACK_ERROR_MESSAGE = 'Callback prop types must be listed after all other prop types';
-
 const ruleTester = new RuleTester({parserOptions});
 ruleTester.run('sort-prop-types', rule, {
 
@@ -482,7 +478,7 @@ ruleTester.run('sort-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 5,
       type: 'Property'
@@ -513,7 +509,7 @@ ruleTester.run('sort-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 6,
       column: 5,
       type: 'Property'
@@ -545,7 +541,7 @@ ruleTester.run('sort-prop-types', rule, {
       '});'
     ].join('\n'),
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 5,
       type: 'Property'
@@ -577,7 +573,7 @@ ruleTester.run('sort-prop-types', rule, {
       ignoreCase: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 5,
       type: 'Property'
@@ -780,7 +776,7 @@ ruleTester.run('sort-prop-types', rule, {
       callbacksLast: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 6,
       column: 5,
       type: 'Property'
@@ -817,7 +813,7 @@ ruleTester.run('sort-prop-types', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 6,
       column: 5,
       type: 'Property'
@@ -853,7 +849,7 @@ ruleTester.run('sort-prop-types', rule, {
       callbacksLast: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 10,
       column: 5,
       type: 'Property'
@@ -892,7 +888,7 @@ ruleTester.run('sort-prop-types', rule, {
       propWrapperFunctions: ['forbidExtraProps']
     },
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 10,
       column: 5,
       type: 'Property'
@@ -923,7 +919,7 @@ ruleTester.run('sort-prop-types', rule, {
       propWrapperFunctions: ['forbidExtraProps']
     },
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 5,
       type: 'Property'
@@ -949,7 +945,7 @@ ruleTester.run('sort-prop-types', rule, {
       propWrapperFunctions: ['forbidExtraProps']
     },
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 5,
       type: 'Property'
@@ -980,7 +976,7 @@ ruleTester.run('sort-prop-types', rule, {
       callbacksLast: true
     }],
     errors: [{
-      message: CALLBACK_ERROR_MESSAGE,
+      messageId: 'callbackPropsLast',
       line: 5,
       column: 5,
       type: 'Property'
@@ -1015,7 +1011,7 @@ ruleTester.run('sort-prop-types', rule, {
       requiredFirst: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 5,
       type: 'Property'
@@ -1049,7 +1045,7 @@ ruleTester.run('sort-prop-types', rule, {
       requiredFirst: true
     }],
     errors: [{
-      message: REQUIRED_ERROR_MESSAGE,
+      messageId: 'requiredPropsFirst',
       line: 4,
       column: 5,
       type: 'Property'
@@ -1079,7 +1075,7 @@ ruleTester.run('sort-prop-types', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 6,
       column: 5,
       type: 'Property'
@@ -1109,7 +1105,7 @@ ruleTester.run('sort-prop-types', rule, {
     ].join('\n'),
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 6,
       column: 5,
       type: 'Property'
@@ -1138,7 +1134,7 @@ ruleTester.run('sort-prop-types', rule, {
       'TextFieldLabel.propTypes = propTypes;'
     ].join('\n'),
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 3,
       column: 3,
       type: 'Property'
@@ -1174,12 +1170,12 @@ ruleTester.run('sort-prop-types', rule, {
       sortShapeProp: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 12,
       column: 11,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 13,
       column: 11,
       type: 'Property'
@@ -1217,7 +1213,7 @@ ruleTester.run('sort-prop-types', rule, {
       sortShapeProp: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 10,
       column: 9,
       type: 'Property'
@@ -1251,7 +1247,7 @@ ruleTester.run('sort-prop-types', rule, {
       sortShapeProp: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 10,
       column: 9,
       type: 'Property'
@@ -1290,27 +1286,27 @@ ruleTester.run('sort-prop-types', rule, {
       sortShapeProp: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 9,
       column: 9,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 10,
       column: 9,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 12,
       column: 11,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 13,
       column: 11,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 14,
       column: 11,
       type: 'Property'
@@ -1355,12 +1351,12 @@ ruleTester.run('sort-prop-types', rule, {
       ignoreCase: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 13,
       column: 11,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 14,
       column: 11,
       type: 'Property'
@@ -1405,7 +1401,7 @@ ruleTester.run('sort-prop-types', rule, {
       requiredFirst: true
     }],
     errors: [{
-      message: REQUIRED_ERROR_MESSAGE,
+      messageId: 'requiredPropsFirst',
       line: 12,
       column: 11,
       type: 'Property'
@@ -1451,12 +1447,12 @@ ruleTester.run('sort-prop-types', rule, {
       callbacksLast: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 13,
       column: 11,
       type: 'Property'
     }, {
-      message: CALLBACK_ERROR_MESSAGE,
+      messageId: 'callbackPropsLast',
       line: 14,
       column: 11,
       type: 'Property'
@@ -1503,12 +1499,12 @@ ruleTester.run('sort-prop-types', rule, {
       sortShapeProp: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 13,
       column: 11,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 16,
       column: 11,
       type: 'Property'
@@ -1554,22 +1550,22 @@ ruleTester.run('sort-prop-types', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 5,
       column: 11,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 6,
       column: 11,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 8,
       column: 13,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 9,
       column: 13,
       type: 'Property'
@@ -1606,7 +1602,7 @@ ruleTester.run('sort-prop-types', rule, {
       noSortAlphabetically: false
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 5,
       type: 'Property'
@@ -1639,7 +1635,7 @@ ruleTester.run('sort-prop-types', rule, {
       noSortAlphabetically: false
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 5,
       type: 'Property'
@@ -1672,7 +1668,7 @@ ruleTester.run('sort-prop-types', rule, {
       ignoreCase: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 9,
       column: 9,
       type: 'Property'
@@ -1710,12 +1706,12 @@ ruleTester.run('sort-prop-types', rule, {
     }],
     parser: parsers.BABEL_ESLINT,
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 9,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 5,
       column: 9,
       type: 'Property'
@@ -1756,12 +1752,12 @@ ruleTester.run('sort-prop-types', rule, {
       sortShapeProp: true
     }],
     errors: [{
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 4,
       column: 9,
       type: 'Property'
     }, {
-      message: ERROR_MESSAGE,
+      messageId: 'propsNotSorted',
       line: 5,
       column: 9,
       type: 'Property'

--- a/tests/lib/rules/state-in-constructor.js
+++ b/tests/lib/rules/state-in-constructor.js
@@ -242,7 +242,7 @@ ruleTester.run('state-in-constructor', rule, {
     `,
     options: ['never'],
     errors: [{
-      message: 'State initialization should be in a class property'
+      messageId: 'stateInitClassProp'
     }]
   }, {
     code: `
@@ -259,7 +259,7 @@ ruleTester.run('state-in-constructor', rule, {
     `,
     options: ['never'],
     errors: [{
-      message: 'State initialization should be in a class property'
+      messageId: 'stateInitClassProp'
     }]
   }, {
     code: `
@@ -271,7 +271,7 @@ ruleTester.run('state-in-constructor', rule, {
       }
     `,
     errors: [{
-      message: 'State initialization should be in a constructor'
+      messageId: 'stateInitConstructor'
     }]
   }, {
     code: `
@@ -284,7 +284,7 @@ ruleTester.run('state-in-constructor', rule, {
       }
     `,
     errors: [{
-      message: 'State initialization should be in a constructor'
+      messageId: 'stateInitConstructor'
     }]
   }, {
     code: `
@@ -300,7 +300,7 @@ ruleTester.run('state-in-constructor', rule, {
       }
     `,
     errors: [{
-      message: 'State initialization should be in a constructor'
+      messageId: 'stateInitConstructor'
     }]
   }, {
     code: `
@@ -316,7 +316,7 @@ ruleTester.run('state-in-constructor', rule, {
       }
     `,
     errors: [{
-      message: 'State initialization should be in a constructor'
+      messageId: 'stateInitConstructor'
     }]
   }, {
     code: `
@@ -333,7 +333,7 @@ ruleTester.run('state-in-constructor', rule, {
     `,
     options: ['never'],
     errors: [{
-      message: 'State initialization should be in a class property'
+      messageId: 'stateInitClassProp'
     }]
   }, {
     code: `
@@ -351,7 +351,7 @@ ruleTester.run('state-in-constructor', rule, {
     `,
     options: ['never'],
     errors: [{
-      message: 'State initialization should be in a class property'
+      messageId: 'stateInitClassProp'
     }]
   }]
 });

--- a/tests/lib/rules/static-property-placement.js
+++ b/tests/lib/rules/static-property-placement.js
@@ -1159,12 +1159,30 @@ ruleTester.run('static-property-placement', rule, {
         }
       `].join('\n'),
       errors: [
-        {message: '\'childContextTypes\' should be declared as a static class property.'},
-        {message: '\'contextTypes\' should be declared as a static class property.'},
-        {message: '\'contextType\' should be declared as a static class property.'},
-        {message: '\'displayName\' should be declared as a static class property.'},
-        {message: '\'defaultProps\' should be declared as a static class property.'},
-        {message: '\'propTypes\' should be declared as a static class property.'}
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     {
@@ -1205,12 +1223,30 @@ ruleTester.run('static-property-placement', rule, {
         propTypes: STATIC_PUBLIC_FIELD
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared as a static class property.'},
-        {message: '\'contextTypes\' should be declared as a static class property.'},
-        {message: '\'contextType\' should be declared as a static class property.'},
-        {message: '\'displayName\' should be declared as a static class property.'},
-        {message: '\'defaultProps\' should be declared as a static class property.'},
-        {message: '\'propTypes\' should be declared as a static class property.'}
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     // ------------------------------------------------------------------------------
@@ -1254,12 +1290,30 @@ ruleTester.run('static-property-placement', rule, {
         }
       `].join('\n'),
       errors: [
-        {message: '\'childContextTypes\' should be declared as a static class property.'},
-        {message: '\'contextTypes\' should be declared as a static class property.'},
-        {message: '\'contextType\' should be declared as a static class property.'},
-        {message: '\'displayName\' should be declared as a static class property.'},
-        {message: '\'defaultProps\' should be declared as a static class property.'},
-        {message: '\'propTypes\' should be declared as a static class property.'}
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     {
@@ -1308,12 +1362,30 @@ ruleTester.run('static-property-placement', rule, {
         propTypes: STATIC_PUBLIC_FIELD
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared as a static class property.'},
-        {message: '\'contextTypes\' should be declared as a static class property.'},
-        {message: '\'contextType\' should be declared as a static class property.'},
-        {message: '\'displayName\' should be declared as a static class property.'},
-        {message: '\'defaultProps\' should be declared as a static class property.'},
-        {message: '\'propTypes\' should be declared as a static class property.'}
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     // ------------------------------------------------------------------------------
@@ -1346,12 +1418,30 @@ ruleTester.run('static-property-placement', rule, {
       `].join('\n'),
       options: [PROPERTY_ASSIGNMENT],
       errors: [
-        {message: '\'childContextTypes\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'contextType\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared outside the class body.'},
-        {message: '\'defaultProps\' should be declared outside the class body.'},
-        {message: '\'propTypes\' should be declared outside the class body.'}
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     {
@@ -1388,12 +1478,30 @@ ruleTester.run('static-property-placement', rule, {
         propTypes: PROPERTY_ASSIGNMENT
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'contextType\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared outside the class body.'},
-        {message: '\'defaultProps\' should be declared outside the class body.'},
-        {message: '\'propTypes\' should be declared outside the class body.'}
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     // ------------------------------------------------------------------------------
@@ -1438,12 +1546,30 @@ ruleTester.run('static-property-placement', rule, {
       `].join('\n'),
       options: [PROPERTY_ASSIGNMENT],
       errors: [
-        {message: '\'childContextTypes\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'contextType\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared outside the class body.'},
-        {message: '\'defaultProps\' should be declared outside the class body.'},
-        {message: '\'propTypes\' should be declared outside the class body.'}
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     {
@@ -1492,12 +1618,30 @@ ruleTester.run('static-property-placement', rule, {
         propTypes: PROPERTY_ASSIGNMENT
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'contextType\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared outside the class body.'},
-        {message: '\'defaultProps\' should be declared outside the class body.'},
-        {message: '\'propTypes\' should be declared outside the class body.'}
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     // ------------------------------------------------------------------------------
@@ -1530,12 +1674,30 @@ ruleTester.run('static-property-placement', rule, {
       `].join('\n'),
       options: [STATIC_GETTER],
       errors: [
-        {message: '\'childContextTypes\' should be declared as a static getter class function.'},
-        {message: '\'contextTypes\' should be declared as a static getter class function.'},
-        {message: '\'contextType\' should be declared as a static getter class function.'},
-        {message: '\'displayName\' should be declared as a static getter class function.'},
-        {message: '\'defaultProps\' should be declared as a static getter class function.'},
-        {message: '\'propTypes\' should be declared as a static getter class function.'}
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     {
@@ -1572,12 +1734,30 @@ ruleTester.run('static-property-placement', rule, {
         propTypes: STATIC_GETTER
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared as a static getter class function.'},
-        {message: '\'contextTypes\' should be declared as a static getter class function.'},
-        {message: '\'contextType\' should be declared as a static getter class function.'},
-        {message: '\'displayName\' should be declared as a static getter class function.'},
-        {message: '\'defaultProps\' should be declared as a static getter class function.'},
-        {message: '\'propTypes\' should be declared as a static getter class function.'}
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     // ------------------------------------------------------------------------------
@@ -1614,12 +1794,30 @@ ruleTester.run('static-property-placement', rule, {
       `].join('\n'),
       options: [STATIC_GETTER],
       errors: [
-        {message: '\'childContextTypes\' should be declared as a static getter class function.'},
-        {message: '\'contextTypes\' should be declared as a static getter class function.'},
-        {message: '\'contextType\' should be declared as a static getter class function.'},
-        {message: '\'displayName\' should be declared as a static getter class function.'},
-        {message: '\'defaultProps\' should be declared as a static getter class function.'},
-        {message: '\'propTypes\' should be declared as a static getter class function.'}
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     {
@@ -1660,12 +1858,30 @@ ruleTester.run('static-property-placement', rule, {
         propTypes: STATIC_GETTER
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared as a static getter class function.'},
-        {message: '\'contextTypes\' should be declared as a static getter class function.'},
-        {message: '\'contextType\' should be declared as a static getter class function.'},
-        {message: '\'displayName\' should be declared as a static getter class function.'},
-        {message: '\'defaultProps\' should be declared as a static getter class function.'},
-        {message: '\'propTypes\' should be declared as a static getter class function.'}
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     // ------------------------------------------------------------------------------
@@ -1704,12 +1920,30 @@ ruleTester.run('static-property-placement', rule, {
         displayName: STATIC_PUBLIC_FIELD
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'contextType\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared as a static class property.'},
-        {message: '\'defaultProps\' should be declared as a static getter class function.'},
-        {message: '\'propTypes\' should be declared as a static class property.'}
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notStaticClassProp',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     {
@@ -1746,12 +1980,30 @@ ruleTester.run('static-property-placement', rule, {
         displayName: PROPERTY_ASSIGNMENT
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'contextType\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared outside the class body.'},
-        {message: '\'defaultProps\' should be declared as a static getter class function.'},
-        {message: '\'propTypes\' should be declared as a static getter class function.'}
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'notGetterClassFunc',
+          data: {name: 'propTypes'}
+        }
       ]
     },
     // ------------------------------------------------------------------------------
@@ -1791,10 +2043,22 @@ ruleTester.run('static-property-placement', rule, {
         propTypes: STATIC_GETTER
       }],
       errors: [
-        {message: '\'childContextTypes\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'contextType\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared outside the class body.'}
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'displayName'}
+        }
       ]
     },
     {
@@ -1834,14 +2098,38 @@ ruleTester.run('static-property-placement', rule, {
       `].join('\n'),
       options: [PROPERTY_ASSIGNMENT],
       errors: [
-        {message: '\'childContextTypes\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'contextType\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared outside the class body.'},
-        {message: '\'contextTypes\' should be declared outside the class body.'},
-        {message: '\'defaultProps\' should be declared outside the class body.'},
-        {message: '\'propTypes\' should be declared outside the class body.'},
-        {message: '\'displayName\' should be declared outside the class body.'}
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'childContextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextType'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'displayName'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'contextTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'defaultProps'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'propTypes'}
+        },
+        {
+          messageId: 'declareOutsideClass',
+          data: {name: 'displayName'}
+        }
       ]
 
     }

--- a/tests/lib/rules/style-prop-object.js
+++ b/tests/lib/rules/style-prop-object.js
@@ -214,7 +214,7 @@ ruleTester.run('style-prop-object', rule, {
     {
       code: '<div style="color: \'red\'" />',
       errors: [{
-        message: 'Style prop value must be an object',
+        messageId: 'stylePropNotObject',
         line: 1,
         column: 6,
         type: 'JSXAttribute'
@@ -223,7 +223,7 @@ ruleTester.run('style-prop-object', rule, {
     {
       code: '<Hello style="color: \'red\'" />',
       errors: [{
-        message: 'Style prop value must be an object',
+        messageId: 'stylePropNotObject',
         line: 1,
         column: 8,
         type: 'JSXAttribute'
@@ -232,7 +232,7 @@ ruleTester.run('style-prop-object', rule, {
     {
       code: '<div style={true} />',
       errors: [{
-        message: 'Style prop value must be an object',
+        messageId: 'stylePropNotObject',
         line: 1,
         column: 6,
         type: 'JSXAttribute'
@@ -246,7 +246,7 @@ ruleTester.run('style-prop-object', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'Style prop value must be an object',
+        messageId: 'stylePropNotObject',
         line: 3,
         column: 22,
         type: 'Identifier'
@@ -260,7 +260,7 @@ ruleTester.run('style-prop-object', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'Style prop value must be an object',
+        messageId: 'stylePropNotObject',
         line: 3,
         column: 24,
         type: 'Identifier'
@@ -274,7 +274,7 @@ ruleTester.run('style-prop-object', rule, {
         '}'
       ].join('\n'),
       errors: [{
-        message: 'Style prop value must be an object',
+        messageId: 'stylePropNotObject',
         line: 3,
         column: 22,
         type: 'Identifier'
@@ -288,7 +288,7 @@ ruleTester.run('style-prop-object', rule, {
         }
       ],
       errors: [{
-        message: 'Style prop value must be an object',
+        messageId: 'stylePropNotObject',
         line: 1,
         column: 14,
         type: 'JSXAttribute'
@@ -302,7 +302,7 @@ ruleTester.run('style-prop-object', rule, {
         }
       ],
       errors: [{
-        message: 'Style prop value must be an object',
+        messageId: 'stylePropNotObject',
         line: 1,
         column: 43,
         type: 'Literal'

--- a/tests/lib/rules/void-dom-elements-no-children.js
+++ b/tests/lib/rules/void-dom-elements-no-children.js
@@ -22,10 +22,6 @@ const parserOptions = {
   }
 };
 
-function errorMessage(elementName) {
-  return `Void DOM element <${elementName} /> cannot receive children.`;
-}
-
 // -----------------------------------------------------------------------------
 // Tests
 // -----------------------------------------------------------------------------
@@ -92,38 +88,62 @@ ruleTester.run('void-dom-elements-no-children', rule, {
   invalid: [
     {
       code: '<br>Foo</br>;',
-      errors: [{message: errorMessage('br')}]
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'br'}
+      }]
     },
     {
       code: '<br children="Foo" />;',
-      errors: [{message: errorMessage('br')}]
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'br'}
+      }]
     },
     {
       code: '<img {...props} children="Foo" />;',
-      errors: [{message: errorMessage('img')}]
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'img'}
+      }]
     },
     {
       code: '<br dangerouslySetInnerHTML={{ __html: "Foo" }} />;',
-      errors: [{message: errorMessage('br')}]
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'br'}
+      }]
     },
     {
       code: 'React.createElement("br", {}, "Foo");',
-      errors: [{message: errorMessage('br')}]
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'br'}
+      }]
     },
     {
       code: 'React.createElement("br", { children: "Foo" });',
-      errors: [{message: errorMessage('br')}]
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'br'}
+      }]
     },
     {
       code: 'React.createElement("br", { dangerouslySetInnerHTML: { __html: "Foo" } });',
-      errors: [{message: errorMessage('br')}]
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'br'}
+      }]
     },
     {
       code: `
         import React, {createElement} from "react";
         createElement("img", {}, "Foo");
       `,
-      errors: [{message: errorMessage('img')}],
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'img'}
+      }],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -131,7 +151,10 @@ ruleTester.run('void-dom-elements-no-children', rule, {
         import React, {createElement} from "react";
         createElement("img", { children: "Foo" });
       `,
-      errors: [{message: errorMessage('img')}],
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'img'}
+      }],
       parser: parsers.BABEL_ESLINT
     },
     {
@@ -139,7 +162,10 @@ ruleTester.run('void-dom-elements-no-children', rule, {
         import React, {createElement} from "react";
         createElement("img", { dangerouslySetInnerHTML: { __html: "Foo" } });
       `,
-      errors: [{message: errorMessage('img')}],
+      errors: [{
+        messageId: 'noChildrenInVoidEl',
+        data: {element: 'img'}
+      }],
       parser: parsers.BABEL_ESLINT
     }
   ]


### PR DESCRIPTION
This moves all error messages for every rule to the built-in `meta.messages` property to support easier rule writing in the future.

Resolves #2915 