### PR TITLE
[Fix] `jsx-no-target-blank`: Allow rel="noreferrer" when `allowReferrer` is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`no-typos`]: avoid a crash on bindingless `prop-types` import; add warning ([#2899][] @ljharb)
 * [`jsx-curly-brace-presence`]: ignore containers with comments ([#2900][] @golopot)
 * [`destructuring-assignment`]: fix a false positive for local prop named `context` in SFC ([#2929][] @SyMind)
+* [`jsx-no-target-blank`]: Allow rel="noreferrer" when `allowReferrer` is true ([#2925][] @edemaine)
 
 ### Changed
 * [Docs] [`jsx-no-constructed-context-values`][]: fix invalid example syntax ([#2910][] @kud)
@@ -24,6 +25,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [Docs] added missing curly braces ([#2923][] @Muditxofficial)
 
 [#2929]: https://github.com/yannickcr/eslint-plugin-react/pull/2929
+[#2925]: https://github.com/yannickcr/eslint-plugin-react/pull/2925
 [#2923]: https://github.com/yannickcr/eslint-plugin-react/pull/2923
 [#2910]: https://github.com/yannickcr/eslint-plugin-react/pull/2910
 [#2908]: https://github.com/yannickcr/eslint-plugin-react/pull/2908

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -88,7 +88,11 @@ function hasSecureRel(node, allowReferrer, warnOnSpreadAttributes, spreadAttribu
   const relAttribute = node.attributes[relIndex];
   const value = getStringFromValue(relAttribute.value);
   const tags = value && typeof value === 'string' && value.toLowerCase().split(' ');
-  return tags && (allowReferrer ? tags.indexOf('noopener') >= 0 : tags.indexOf('noreferrer') >= 0);
+  const noreferrer = tags && tags.indexOf('noreferrer') >= 0;
+  if (noreferrer) {
+    return true;
+  }
+  return allowReferrer && tags && tags.indexOf('noopener') >= 0;
 }
 
 module.exports = {

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -104,6 +104,10 @@ ruleTester.run('jsx-no-target-blank', rule, {
       options: [{allowReferrer: true}]
     },
     {
+      code: '<a href="foobar" target="_blank" rel="noreferrer"></a>',
+      options: [{allowReferrer: true}]
+    },
+    {
       code: '<a target={3} />'
     }
   ],
@@ -210,6 +214,12 @@ ruleTester.run('jsx-no-target-blank', rule, {
     {
       code: '<a target={"_blank"} href="//example.com/19"></a>',
       output: '<a target={"_blank"} href="//example.com/19" rel="noreferrer"></a>',
+      errors: defaultErrors
+    },
+    {
+      code: '<a href="http://example.com/20" target="_blank"></a>',
+      output: '<a href="http://example.com/20" target="_blank" rel="noreferrer"></a>',
+      options: [{allowReferrer: true}],
       errors: defaultErrors
     },
     {


### PR DESCRIPTION
Fix #2924 by allowing either `rel="noreferrer"` or `rel="noopener"` when `allowReferrer` is true.

Also add a missing negative test with `allowReferrer` set to true.