### PR TITLE
[Fix] `jsx-curly-newline`: Update error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`jsx-no-target-blank`]: Allow rel="noreferrer" when `allowReferrer` is true ([#2925][] @edemaine)
 * [`boolean-prop-naming`]: add check for typescript "boolean" type ([#2930][] @vedadeepta)
 * version detection: Add tests that verify versioning works for sibling and child projects ([#2943][] @jcrosetto)
+* [`jsx-curly-newline`]: Update error messages ([#2933][] @jbrower2)
 
 ### Changed
 * [Docs] [`jsx-no-constructed-context-values`][]: fix invalid example syntax ([#2910][] @kud)
@@ -30,6 +31,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 [#2943]: https://github.com/yannickcr/eslint-plugin-react/pull/2943
 [#2935]: https://github.com/yannickcr/eslint-plugin-react/pull/2935
+[#2933]: https://github.com/yannickcr/eslint-plugin-react/pull/2933
 [#2930]: https://github.com/yannickcr/eslint-plugin-react/pull/2930
 [#2929]: https://github.com/yannickcr/eslint-plugin-react/pull/2929
 [#2925]: https://github.com/yannickcr/eslint-plugin-react/pull/2925

--- a/lib/rules/jsx-curly-newline.js
+++ b/lib/rules/jsx-curly-newline.js
@@ -67,8 +67,8 @@ module.exports = {
     messages: {
       expectedBefore: 'Expected newline before \'}\'.',
       expectedAfter: 'Expected newline after \'{\'.',
-      unexpectedBefore: 'Unexpected newline before \'{\'.',
-      unexpectedAfter: 'Unexpected newline after \'}\'.'
+      unexpectedBefore: 'Unexpected newline before \'}\'.',
+      unexpectedAfter: 'Unexpected newline after \'{\'.'
     }
   },
 


### PR DESCRIPTION
The error messages for 'unexpected' curlys use the opposite curly.