### PR TITLE
[Fix] `jsx-max-depth`: Prevent getting stuck in circular references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Fixed
+* [`jsx-max-depth`]: Prevent getting stuck in circular references ([#2957][] @AriPerkkio)
+
 ### Changed
 * Fix CHANGELOG.md ([#2950][] @JounQin)
 
+[#2957]: https://github.com/yannickcr/eslint-plugin-react/pull/2957
 [#2950]: https://github.com/yannickcr/eslint-plugin-react/pull/2950
 
 ## [7.23.1] - 2021.03.23

--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const has = require('has');
+const includes = require('array-includes');
 const variableUtil = require('../util/variable');
 const jsxUtil = require('../util/jsx');
 const docsUrl = require('../util/docsUrl');
@@ -83,8 +84,8 @@ module.exports = {
       });
     }
 
-    function findJSXElementOrFragment(variables, name) {
-      function find(refs) {
+    function findJSXElementOrFragment(variables, name, previousReferences) {
+      function find(refs, prevRefs) {
         let i = refs.length;
 
         while (--i >= 0) {
@@ -94,7 +95,7 @@ module.exports = {
             return (jsxUtil.isJSX(writeExpr)
               && writeExpr)
               || ((writeExpr && writeExpr.type === 'Identifier')
-              && findJSXElementOrFragment(variables, writeExpr.name));
+              && findJSXElementOrFragment(variables, writeExpr.name, prevRefs));
           }
         }
 
@@ -102,7 +103,18 @@ module.exports = {
       }
 
       const variable = variableUtil.getVariable(variables, name);
-      return variable && variable.references && find(variable.references);
+      if (variable && variable.references) {
+        const containDuplicates = previousReferences.some((ref) => includes(variable.references, ref));
+
+        // Prevent getting stuck in circular references
+        if (containDuplicates) {
+          return false;
+        }
+
+        return find(variable.references, previousReferences.concat(variable.references));
+      }
+
+      return false;
     }
 
     function checkDescendant(baseDepth, children) {
@@ -141,7 +153,7 @@ module.exports = {
         }
 
         const variables = variableUtil.variablesInScope(context);
-        const element = findJSXElementOrFragment(variables, node.expression.name);
+        const element = findJSXElementOrFragment(variables, node.expression.name, []);
 
         if (element) {
           const baseDepth = getDepth(node);

--- a/tests/lib/rules/jsx-max-depth.js
+++ b/tests/lib/rules/jsx-max-depth.js
@@ -114,6 +114,33 @@ ruleTester.run('jsx-max-depth', rule, {
       '  return <div>{A}</div>;',
       '}'
     ].join('\n')
+  }, {
+    // Validates circular references don't get rule stuck
+    code: `
+      function Component() {
+        let first = "";
+        const second = first;
+        first = second;
+        return <div id={first} />;
+      };
+    `
+  },
+  {
+    // Validates circular references are checked at multiple levels
+    code: `
+      function Component() {
+        let first = "";
+        let second = "";
+        let third = "";
+        let fourth = "";
+        const fifth = first;
+        first = second;
+        second = third;
+        third = fourth;
+        fourth = fifth;
+        return <div id={first} />;
+      };
+    `
   }],
 
   invalid: [{


### PR DESCRIPTION
Fixes #2880.

### What:

`findJSXElementOrFragment` is getting stuck if given variable A references variable B, while variable B also references variable A (directly or via another references).

### How:

Before calling method recursively, check whether we have already checked references of the variable.

### Test plan:

#### Unit tests:
1. Simple circular reference check for a single level
2. Complex circular reference check for multiple levels. Makes sure `previousReferences` is passed through the whole call chain, instead of just a single call.

#### Regression:
Ran `eslint-remote-tester` in comparison mode against 500 repositories. First run caught ~86K ESLint reports. Second call (with the fix) was identical except the old crash being missing. Results: https://github.com/AriPerkkio/eslint-plugin-react/pull/1#issuecomment-810785700

I had to do couple of iterations of refactoring due to node4 job failing (function default props, spread syntax, `Array.includes`). 
Ready to change any part of the changes if required.