### PR TITLE
forbid-dom-props: support `JSXNamespacedName`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 * [`jsx-max-depth`]: Prevent getting stuck in circular references ([#2957][] @AriPerkkio)
 * [`jsx-no-target-blank`]: fix handling of `warnOnSpreadAttributes` being false ([#2953][] @Nokel81)
+* [`forbid-dom-props`]: support `JSXNamespacedName` [#2961][] @mrtnzlml)
 
 ### Changed
 * Fix CHANGELOG.md ([#2950][] @JounQin)
 
+[#2961]: https://github.com/yannickcr/eslint-plugin-react/pull/2961
 [#2953]: https://github.com/yannickcr/eslint-plugin-react/pull/2953
 [#2957]: https://github.com/yannickcr/eslint-plugin-react/pull/2957
 [#2950]: https://github.com/yannickcr/eslint-plugin-react/pull/2950

--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -75,8 +75,8 @@ module.exports = {
     return {
       JSXAttribute(node) {
         const tag = node.parent.name.name;
-        if (!(tag && tag[0] !== tag[0].toUpperCase())) {
-          // This is a Component, not  a DOM node, so exit.
+        if (!(tag && typeof tag === 'string' && tag[0] !== tag[0].toUpperCase())) {
+          // This is a Component, not a DOM node, so exit.
           return;
         }
 

--- a/tests/lib/rules/forbid-dom-props.js
+++ b/tests/lib/rules/forbid-dom-props.js
@@ -74,6 +74,13 @@ ruleTester.run('forbid-element-props', rule, {
   }, {
     code: [
       'const First = (props) => (',
+      '  <fbt:param name="name">{props.name}</fbt:param>',
+      ');'
+    ].join('\n'),
+    options: [{forbid: ['id']}]
+  }, {
+    code: [
+      'const First = (props) => (',
       '  <div name="foo" />',
       ');'
     ].join('\n'),


### PR DESCRIPTION
This rather strange pattern is common in [FBT](https://facebook.github.io/fbt/docs/params) and valid according to [JSX](http://facebook.github.io/jsx/) (see `JSXNamespacedName`). Without this change the rule fails on the following error:

```
TypeError: Cannot read property 'toUpperCase' of undefined
```

See: https://github.com/adeira/universe/issues/2005