### PR TITLE
[Tests]: add weekly scheduled smoke tests

### DIFF
--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -62,7 +62,7 @@ jobs:
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:
           node-version: ${{ matrix.node-version }}
-          after_install: npm install --no-save "eslint@${{ matrix.eslint }}"
+          after_install: npm install --no-save "eslint@${{ matrix.eslint }}" "@typescript-eslint/parser@${{ matrix.node-version >= 10 && '3' || '2' }}"
           skip-ls-check: true
         env:
           NPM_CONFIG_LEGACY_PEER_DEPS: true

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,28 @@
+name: Smoke test
+
+on:
+  schedule:
+    - cron: '0 0 * * SUN'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    if: ${{ github.repository == 'yannickcr/eslint-plugin-react' || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - uses: ljharb/actions/node/install@main
+        name: 'nvm install lts/* && npm install'
+        with:
+          node-version: 'lts/*'
+          skip-ls-check: true
+      - run: |
+          npm link
+          npm link eslint-plugin-react
+      - uses: AriPerkkio/eslint-remote-tester-run-action@v1
+        with:
+          issue-title: 'Results of weekly scheduled smoke test'
+          eslint-remote-tester-config: test/eslint-remote-tester.config.js

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ node_modules
 !tests/**/node_modules
 npm-debug.log
 sftp-config.json
+eslint-remote-tester-results
 
 # Only apps should have lockfiles
 yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [Refactor] `utils/Components`: correct spelling and delete unused code ([#3026][] @ohhoney1)
 * [Docs] [`jsx-uses-react`], [`react-in-jsx-scope`]: document [`react/jsx-runtime`] config ([#3018][] @pkuczynski @ljharb)
 * [Docs] [`require-default-props`]: fix small typo ([#2994][] @evsasse)
+* [Tests] add weekly scheduled smoke tests ([#2963][] @AriPerkkio)
 
 [#3038]: https://github.com/yannickcr/eslint-plugin-react/pull/3038
 [#3036]: https://github.com/yannickcr/eslint-plugin-react/issues/3036
@@ -35,6 +36,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 [#2998]: https://github.com/yannickcr/eslint-plugin-react/pull/2998
 [#2994]: https://github.com/yannickcr/eslint-plugin-react/pull/2994
 [#2992]: https://github.com/yannickcr/eslint-plugin-react/pull/2992
+[#2963]: https://github.com/yannickcr/eslint-plugin-react/pull/2963
 [#1617]: https://github.com/yannickcr/eslint-plugin-react/pull/1617
 [#1547]: https://github.com/yannickcr/eslint-plugin-react/pull/1547
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@types/eslint": "=7.2.10",
     "@types/estree": "^0.0.47",
     "@types/node": "^14.14.37",
-    "@typescript-eslint/parser": "^2.34.0",
+    "@typescript-eslint/parser": "^2.34.0 || ^3.10.1",
     "aud": "^1.1.5",
     "babel-eslint": "^8.2.6",
     "eslint": "^3 || ^4 || ^5 || ^6 || ^7",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-eslint-plugin": "^2.3.0 || ^3.3.1",
     "eslint-plugin-import": "^2.23.4",
+    "eslint-remote-tester": "^1.3.0",
+    "eslint-remote-tester-repositories": "^0.0.2",
     "espree": "^3.5.4",
     "istanbul": "^0.4.5",
     "markdown-magic": "^2.0.0",

--- a/test/eslint-remote-tester.config.js
+++ b/test/eslint-remote-tester.config.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const eslintRemoteTesterRepositories = require('eslint-remote-tester-repositories');
+
+module.exports = {
+  repositories: eslintRemoteTesterRepositories.getRepositories({randomize: true}),
+
+  pathIgnorePattern: eslintRemoteTesterRepositories.getPathIgnorePattern(),
+
+  extensions: ['js', 'jsx', 'ts', 'tsx'],
+
+  concurrentTasks: 3,
+
+  logLevel: 'info',
+
+  /** Optional boolean flag used to enable caching of cloned repositories. For CIs it's ideal to disable caching. Defauls to true. */
+  cache: false,
+
+  eslintrc: {
+    root: true,
+    env: {
+      es6: true
+    },
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+      ecmaVersion: 2020,
+      sourceType: 'module',
+      ecmaFeatures: {
+        jsx: true
+      }
+    },
+    settings: {
+      react: {
+        version: '16.13.1'
+      }
+    },
+    extends: ['plugin:react/all']
+  }
+};

--- a/tests/fixtures/version/detect-version-missing/node_modules/react/index.js
+++ b/tests/fixtures/version/detect-version-missing/node_modules/react/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const error = new Error();
+error.code = 'MODULE_NOT_FOUND';
+throw error;

--- a/tests/fixtures/version/detect-version-missing/node_modules/react/package.json
+++ b/tests/fixtures/version/detect-version-missing/node_modules/react/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "react",
+    "main": "index.js"
+  }

--- a/tests/util/version.js
+++ b/tests/util/version.js
@@ -56,6 +56,8 @@ describe('Version', () => {
     });
 
     it('assumes latest version if react is not installed', () => {
+      sinon.stub(context, 'getFilename').callsFake(() => path.resolve(base, 'detect-version-missing', 'test.js'));
+
       assert.equal(versionUtil.testReactVersion(context, '999.999.999'), true);
 
       expectedErrorArgs = [
@@ -64,6 +66,8 @@ describe('Version', () => {
     });
 
     it('warns only once for failure to detect react ', () => {
+      sinon.stub(context, 'getFilename').callsFake(() => path.resolve(base, 'detect-version-missing', 'test.js'));
+
       assert.equal(versionUtil.testReactVersion(context, '999.999.999'), true);
       assert.equal(versionUtil.testReactVersion(context, '999.999.999'), true);
 


### PR DESCRIPTION
Context: https://github.com/AriPerkkio/eslint-remote-tester/issues/29

### What

Adds weekly scheduled smoke tests to be run on every Sunday at 00:00. Tests can also be trigger manually (`workflow_dispatch`). These tests will be looking for rule crashes.

Previously these tests have been run in `eslint-remote-tester`'s repository. So far bugs below have been found by automated CI runs:

1. `jsx-no-constructed-context-values: Cannot read property 'set' of undefined` yannickcr/eslint-plugin-react#2894
2. `jsx-no-constructed-context-values: Cannot read property 'type' of null` yannickcr/eslint-plugin-react#2895
3. `no-unknown-property: allowedTags.indexOf is not a function` yannickcr/eslint-plugin-react#2879
4. `jsx-max-depth: Maximum call stack size exceeded` yannickcr/eslint-plugin-react#2880
5. `jsx-wrap-multilines: RangeError: Invalid count value` yannickcr/eslint-plugin-react#2875
6. `jsx-no-script-url: Cannot read property 'type' of null` yannickcr/eslint-plugin-react#2871
7. `no-typos: Cannot read property 'toLowerCase' of undefined` yannickcr/eslint-plugin-react#2870
8. `jsx-max-depth: Cannot read property 'length' of undefined` yannickcr/eslint-plugin-react#2869
9. Unreleased: `Add new rule "react/no-referential-type-default-prop"` yannickcr/eslint-plugin-react#2848
10. `forbid-dom-props` https://github.com/yannickcr/eslint-plugin-react/pull/2961#issuecomment-814917710

### How

[Plugin maintainer making sure all existing rules do not crash](https://github.com/AriPerkkio/eslint-remote-tester#plugin-maintainer-making-sure-all-existing-rules-do-not-crash)

Utilizes https://github.com/marketplace/actions/eslint-remote-tester-runner. Each test run will check as many repositories as it can in **5 hours 30 minutes** (default value of `timeLimit`). 
There are 10K repositories in `test/smoke-test-repositories.json`. The first ~3300 are specifically picked for this plugin as they have `/react/` in the repository name. These were collected from [libraries.io](https://github.com/librariesio/libraries.io).

At first the rules will be `extends: ['plugin:react/all']` but it is absolutely OK to include `rules: {}` with settings for specific rules if wanted. 

Available configuration options:
- `eslint-remote-tester-run-action`: https://github.com/marketplace/actions/eslint-remote-tester-runner#action-parameters
- `eslint-remote-tester`: https://github.com/AriPerkkio/eslint-remote-tester#configuration-options

When test fails the @github-actions bot will open new issue with title `Results of weekly scheduled smoke test`. It will reuse the existing issue if previous one hasn't yet been closed. It's recommended to close the issues once their findings are fixed.

🎉 