### PR TITLE
[New] `jsx-no-useless-fragment`: add `ignoreUnsafeChildren` flag

### DIFF
--- a/docs/rules/jsx-no-useless-fragment.md
+++ b/docs/rules/jsx-no-useless-fragment.md
@@ -57,14 +57,14 @@ const cat = <>meow</>
 
 ```js
 ...
-"react/jsx-no-useless-fragments": [<enabled>, { "ignoreNeedsMoreChildren": <boolean> }]
+"react/jsx-no-useless-fragments": [<enabled>, { "ignoreUnsafeChildren": <boolean> }]
 ...
 ```
 
-### `ignoreNeedsMoreChildren` (default: `false`)
+### `ignoreUnsafeChildren` (default: `false`)
 
 When `true` the rule will ignore errors related to fragments having enough
-children.
+children when removing the fragment could result in a runtime error.
 
 Examples of **correct** code for this rule:
 

--- a/docs/rules/jsx-no-useless-fragment.md
+++ b/docs/rules/jsx-no-useless-fragment.md
@@ -52,3 +52,28 @@ const cat = <>meow</>
 
 <Fragment key={item.id}>{item.value}</Fragment>
 ```
+
+## Rule Options
+
+```js
+...
+"react/jsx-no-useless-fragments": [<enabled>, { "ignoreNeedsMoreChildren": <boolean> }]
+...
+```
+
+### `ignoreNeedsMoreChildren` (default: `false`)
+
+When `true` the rule will ignore errors related to fragments having enough
+children.
+
+Examples of **correct** code for this rule:
+
+```jsx
+<></>
+
+<>{children}</>
+
+<>{foo && <Foo/>}</>
+
+<>{foo?.map(x => <Bar x={x}/>)}</>
+```

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -97,7 +97,7 @@ module.exports = {
     const reactPragma = pragmaUtil.getFromContext(context);
     const fragmentPragma = pragmaUtil.getFragmentFromContext(context);
     const config = context.options[0] || {};
-    const ignoreNeedsMoreChildren = !!config.ignoreNeedsMoreChildren;
+    const ignoreUnsafeChildren = !!config.ignoreUnsafeChildren;
 
     /**
      * Test whether a node is an padding spaces trimmed by react runtime.
@@ -200,7 +200,7 @@ module.exports = {
      * @returns {boolean}
      */
     function hasSafeInnerExpr(node) {
-      if (!ignoreNeedsMoreChildren) {
+      if (!ignoreUnsafeChildren) {
         return true;
       }
 

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -96,6 +96,8 @@ module.exports = {
   create(context) {
     const reactPragma = pragmaUtil.getFromContext(context);
     const fragmentPragma = pragmaUtil.getFragmentFromContext(context);
+    const config = context.options[0] || {};
+    const ignoreNeedsMoreChildren = !!config.ignoreNeedsMoreChildren;
 
     /**
      * Test whether a node is an padding spaces trimmed by react runtime.
@@ -198,7 +200,7 @@ module.exports = {
         return;
       }
 
-      if (hasLessThanTwoChildren(node) && !isFragmentWithOnlyTextAndIsNotChild(node)) {
+      if (hasLessThanTwoChildren(node) && !isFragmentWithOnlyTextAndIsNotChild(node) && !ignoreNeedsMoreChildren) {
         context.report({
           node,
           messageId: 'NeedsMoreChidren',

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -195,12 +195,35 @@ module.exports = {
       };
     }
 
+    /**
+     * @param {ASTNode} node
+     * @returns {boolean}
+     */
+    function hasSafeInnerExpr(node) {
+      if (!ignoreNeedsMoreChildren) {
+        return true;
+      }
+
+      if (node.children.length === 0) {
+        return false;
+      }
+      if (node.children.length === 1 && node.children[0].type === 'JSXExpressionContainer' && !isChildOfHtmlElement(node)) {
+        return false;
+      }
+
+      return true;
+    }
+
+    /**
+     * @param {ASTNode} node
+     * @returns {void}
+     */
     function checkNode(node) {
       if (isKeyedElement(node)) {
         return;
       }
 
-      if (hasLessThanTwoChildren(node) && !isFragmentWithOnlyTextAndIsNotChild(node) && !ignoreNeedsMoreChildren) {
+      if (hasLessThanTwoChildren(node) && !isFragmentWithOnlyTextAndIsNotChild(node) && hasSafeInnerExpr(node)) {
         context.report({
           node,
           messageId: 'NeedsMoreChidren',

--- a/tests/lib/rules/jsx-no-useless-fragment.js
+++ b/tests/lib/rules/jsx-no-useless-fragment.js
@@ -164,6 +164,21 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       parser: parsers.BABEL_ESLINT
     },
     {
+      code: `
+        <>
+          <div/>
+        </>
+      `,
+      output: `
+        <div/>
+      `,
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
+      errors: [{messageId: 'NeedsMoreChidren'}],
+      parser: parsers.BABEL_ESLINT
+    },
+    {
       code: '<Fragment />',
       errors: [{messageId: 'NeedsMoreChidren'}]
     },
@@ -176,6 +191,20 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       output: `
         <Foo />
       `,
+      errors: [{messageId: 'NeedsMoreChidren'}]
+    },
+    {
+      code: `
+        <React.Fragment>
+          <Foo />
+        </React.Fragment>
+      `,
+      output: `
+        <Foo />
+      `,
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
       errors: [{messageId: 'NeedsMoreChidren'}]
     },
     {

--- a/tests/lib/rules/jsx-no-useless-fragment.js
+++ b/tests/lib/rules/jsx-no-useless-fragment.js
@@ -67,6 +67,51 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
     {
       code: '<>{foos.map(foo => foo)}</>',
       parser: parsers.BABEL_ESLINT
+    },
+    {
+      // component could require a ReactNode
+      code: '<></>',
+      output: null,
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
+      parser: parsers.BABEL_ESLINT
+    },
+    {
+      // children could be undefined
+      code: '<>{children}</>',
+      output: null,
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
+      parser: parsers.BABEL_ESLINT
+    },
+    {
+      // props.children could be undefined
+      code: '<>{props.children}</>',
+      output: null,
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
+      parser: parsers.BABEL_ESLINT
+    },
+    {
+      // foo could be undefined
+      code: '<>{foo && <Foo/>}</>',
+      output: null,
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
+      parser: parsers.BABEL_ESLINT
+    },
+    {
+      // foo could be undefined
+      code: '<>{foo?.map(x => <Bar id={x.id}/>)}</>',
+      output: null,
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
+      parser: parsers.BABEL_ESLINT
     }
   ],
   invalid: [

--- a/tests/lib/rules/jsx-no-useless-fragment.js
+++ b/tests/lib/rules/jsx-no-useless-fragment.js
@@ -146,8 +146,26 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       parser: parsers.BABEL_ESLINT
     },
     {
+      code: '<p><>{meow}</></p>',
+      output: '<p>{meow}</p>',
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
+      errors: [{messageId: 'NeedsMoreChidren'}, {messageId: 'ChildOfHtmlElement'}],
+      parser: parsers.BABEL_ESLINT
+    },
+    {
       code: '<><div/></>',
       output: '<div/>',
+      errors: [{messageId: 'NeedsMoreChidren'}],
+      parser: parsers.BABEL_ESLINT
+    },
+    {
+      code: '<><div/></>',
+      output: '<div/>',
+      options: [{
+        ignoreNeedsMoreChildren: true
+      }],
       errors: [{messageId: 'NeedsMoreChidren'}],
       parser: parsers.BABEL_ESLINT
     },

--- a/tests/lib/rules/jsx-no-useless-fragment.js
+++ b/tests/lib/rules/jsx-no-useless-fragment.js
@@ -73,7 +73,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       code: '<></>',
       output: null,
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       parser: parsers.BABEL_ESLINT
     },
@@ -82,7 +82,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       code: '<>{children}</>',
       output: null,
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       parser: parsers.BABEL_ESLINT
     },
@@ -91,7 +91,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       code: '<>{props.children}</>',
       output: null,
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       parser: parsers.BABEL_ESLINT
     },
@@ -100,7 +100,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       code: '<>{foo && <Foo/>}</>',
       output: null,
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       parser: parsers.BABEL_ESLINT
     },
@@ -109,7 +109,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       code: '<>{foo?.map(x => <Bar id={x.id}/>)}</>',
       output: null,
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       parser: parsers.BABEL_ESLINT
     }
@@ -149,7 +149,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       code: '<p><>{meow}</></p>',
       output: '<p>{meow}</p>',
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       errors: [{messageId: 'NeedsMoreChidren'}, {messageId: 'ChildOfHtmlElement'}],
       parser: parsers.BABEL_ESLINT
@@ -164,7 +164,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       code: '<><div/></>',
       output: '<div/>',
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       errors: [{messageId: 'NeedsMoreChidren'}],
       parser: parsers.BABEL_ESLINT
@@ -191,7 +191,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
         <div/>
       `,
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       errors: [{messageId: 'NeedsMoreChidren'}],
       parser: parsers.BABEL_ESLINT
@@ -221,7 +221,7 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
         <Foo />
       `,
       options: [{
-        ignoreNeedsMoreChildren: true
+        ignoreUnsafeChildren: true
       }],
       errors: [{messageId: 'NeedsMoreChidren'}]
     },


### PR DESCRIPTION
With `ignoreUnsafeChildren` enabled, this rule will only warn about
useless fragments that removing would guarantee no change in behavior.

addresses some of: https://github.com/yannickcr/eslint-plugin-react/issues/2584