### PR TITLE
[Fix] `jsx-handler-names`: properly substitute value into message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Added
 * component detection: add componentWrapperFunctions setting ([#2713][] @@jzabala @LandonSchropp)
 
+### Fixed
+* [`jsx-handler-names`]: properly substitute value into message ([#2975][] @G-Rath)
+
+[#2975]: https://github.com/yannickcr/eslint-plugin-react/pull/2975
 [#2713]: https://github.com/yannickcr/eslint-plugin-react/pull/2713
 
 ## [7.23.2] - 2021.04.08

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -22,7 +22,7 @@ module.exports = {
 
     messages: {
       badHandlerName: 'Handler function for {{propKey}} prop key must be a camelCase name beginning with \'{{handlerPrefix}}\' only',
-      badPropKey: 'Prop key for {{propValue}} must begin with \'{{handlerPropPrefix}\''
+      badPropKey: 'Prop key for {{propValue}} must begin with \'{{handlerPropPrefix}}\''
     },
 
     schema: [{

--- a/tests/lib/rules/jsx-handler-names.js
+++ b/tests/lib/rules/jsx-handler-names.js
@@ -213,6 +213,11 @@ ruleTester.run('jsx-handler-names', rule, {
   }, {
     code: '<TestComponent only={this.handleChange} />',
     errors: [{
+      message: 'Prop key for handleChange must begin with \'on\''
+    }]
+  }, {
+    code: '<TestComponent only={this.handleChange} />',
+    errors: [{
       messageId: 'badPropKey',
       data: {propValue: 'handleChange', handlerPropPrefix: 'on'}
     }]


### PR DESCRIPTION
Currently the output is `ESLint: Prop key for handleChange must begin with '{{handlerPropPrefix}'(react/jsx-handler-names)`