### PR TITLE
Reduce memory allocation in rules and utils

### DIFF
--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -227,7 +227,9 @@ module.exports = {
       if (!node || !Array.isArray(args)) {
         return;
       }
-      args.filter((arg) => arg.type === 'ObjectExpression').forEach((object) => validatePropNaming(node, object.properties));
+      args.forEach((object) => object.type === 'ObjectExpression'
+        && validatePropNaming(node, object.properties)
+      );
     }
 
     // --------------------------------------------------------------------------

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const propsUtil = require('../util/props');
 const docsUrl = require('../util/docsUrl');
@@ -312,18 +313,18 @@ module.exports = {
         }
 
         const list = components.list();
-        Object.keys(list).forEach((component) => {
+        values(list).forEach((component) => {
           // If this is a functional component that uses a global type, check it
           if (
             (
-              list[component].node.type === 'FunctionDeclaration'
-              || list[component].node.type === 'ArrowFunctionExpression'
+              component.node.type === 'FunctionDeclaration'
+              || component.node.type === 'ArrowFunctionExpression'
             )
-            && list[component].node.params
-            && list[component].node.params.length
-            && list[component].node.params[0].typeAnnotation
+            && component.node.params
+            && component.node.params.length
+            && component.node.params[0].typeAnnotation
           ) {
-            const typeNode = list[component].node.params[0].typeAnnotation;
+            const typeNode = component.node.params[0].typeAnnotation;
             const annotation = typeNode.typeAnnotation;
             let propType;
             if (annotation.type === 'GenericTypeAnnotation') {
@@ -336,14 +337,14 @@ module.exports = {
 
             if (propType) {
               validatePropNaming(
-                list[component].node,
+                component.node,
                 propType.properties || propType.members
               );
             }
           }
 
-          if (list[component].invalidProps && list[component].invalidProps.length > 0) {
-            reportInvalidNaming(list[component]);
+          if (component.invalidProps && component.invalidProps.length > 0) {
+            reportInvalidNaming(component);
           }
         });
 

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -174,17 +174,17 @@ module.exports = {
      * @param {Function} addInvalidProp callback to run for each error
      */
     function runCheck(proptypes, addInvalidProp) {
-      proptypes = proptypes || [];
-
-      proptypes.forEach((prop) => {
-        if (config.validateNested && nestedPropTypes(prop)) {
-          runCheck(prop.value.arguments[0].properties, addInvalidProp);
-          return;
-        }
-        if (flowCheck(prop) || regularCheck(prop) || tsCheck(prop)) {
-          addInvalidProp(prop);
-        }
-      });
+      if (proptypes && proptypes.length > 0) {
+        proptypes.forEach((prop) => {
+          if (config.validateNested && nestedPropTypes(prop)) {
+            runCheck(prop.value.arguments[0].properties, addInvalidProp);
+            return;
+          }
+          if (flowCheck(prop) || regularCheck(prop) || tsCheck(prop)) {
+            addInvalidProp(prop);
+          }
+        });
+      }
     }
 
     /**

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -94,11 +94,13 @@ module.exports = {
         const list = components.list();
 
         // If no defaultProps could be found, we don't report anything.
-        values(list).filter((component) => component.defaultProps).forEach((component) => {
-          reportInvalidDefaultProps(
-            component.declaredPropTypes,
-            component.defaultProps || {}
-          );
+        values(list).forEach((component) => {
+          if (component.defaultProps) {
+            reportInvalidDefaultProps(
+              component.declaredPropTypes,
+              component.defaultProps || {}
+            );
+          }
         });
       }
     };

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -93,10 +94,10 @@ module.exports = {
         const list = components.list();
 
         // If no defaultProps could be found, we don't report anything.
-        Object.keys(list).filter((component) => list[component].defaultProps).forEach((component) => {
+        values(list).filter((component) => component.defaultProps).forEach((component) => {
           reportInvalidDefaultProps(
-            list[component].declaredPropTypes,
-            list[component].defaultProps || {}
+            component.declaredPropTypes,
+            component.defaultProps || {}
           );
         });
       }

--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -13,6 +13,16 @@ const DEFAULT_OPTION = 'always';
 function createSFCParams() {
   const queue = [];
 
+  const identifyProps = (params) => {
+    const props = params[0];
+    return props && !props.destructuring && props.name;
+  };
+
+  const identifyContext = (params) => {
+    const context = params[1];
+    return context && !context.destructuring && context.name;
+  };
+
   return {
     push(params) {
       queue.unshift(params);
@@ -21,17 +31,11 @@ function createSFCParams() {
       queue.shift();
     },
     propsName() {
-      const found = queue.find((params) => {
-        const props = params[0];
-        return props && !props.destructuring && props.name;
-      });
+      const found = queue.find(identifyProps);
       return found && found[0] && found[0].name;
     },
     contextName() {
-      const found = queue.find((params) => {
-        const context = params[1];
-        return context && !context.destructuring && context.name;
-      });
+      const found = queue.find(identifyContext);
       return found && found[1] && found.name;
     }
   };
@@ -87,24 +91,26 @@ module.exports = {
      *   FunctionDeclaration, or FunctionExpression
      */
     function handleStatelessComponent(node) {
-      const params = evalParams(node.params);
-
       const SFCComponent = components.get(context.getScope(node).block);
       if (!SFCComponent) {
         return;
       }
+      const params = evalParams(node.params);
+
       sfcParams.push(params);
 
-      if (params[0] && params[0].destructuring && components.get(node) && configuration === 'never') {
-        context.report({
-          node,
-          messageId: 'noDestructPropsInSFCArg'
-        });
-      } else if (params[1] && params[1].destructuring && components.get(node) && configuration === 'never') {
-        context.report({
-          node,
-          messageId: 'noDestructContextInSFCArg'
-        });
+      if (configuration === 'never') {
+        if (params[0] && params[0].destructuring && components.get(node)) {
+          context.report({
+            node,
+            messageId: 'noDestructPropsInSFCArg'
+          });
+        } else if (params[1] && params[1].destructuring && components.get(node)) {
+          context.report({
+            node,
+            messageId: 'noDestructContextInSFCArg'
+          });
+        }
       }
     }
 
@@ -116,15 +122,11 @@ module.exports = {
     }
 
     function handleSFCUsage(node) {
-      const propsName = sfcParams.propsName();
-      const contextName = sfcParams.contextName();
       // props.aProp || context.aProp
-      const isPropUsed = (
-        (propsName && node.object.name === propsName)
-          || (contextName && node.object.name === contextName)
-      )
-        && !isAssignmentLHS(node);
-      if (isPropUsed && configuration === 'always') {
+      const isPropUsed = node.object.name && (
+        node.object.name === sfcParams.propsName() || node.object.name === sfcParams.contextName()
+      ) && !isAssignmentLHS(node);
+      if (isPropUsed) {
         context.report({
           node,
           messageId: 'useDestructAssignment',
@@ -155,8 +157,7 @@ module.exports = {
       );
 
       if (
-        isPropUsed && configuration === 'always'
-        && !(ignoreClassFields && isInClassProperty(node))
+        isPropUsed && !(ignoreClassFields && isInClassProperty(node))
       ) {
         context.report({
           node,
@@ -183,49 +184,51 @@ module.exports = {
       'FunctionExpression:exit': handleStatelessComponentExit,
 
       MemberExpression(node) {
-        const SFCComponent = components.get(context.getScope(node).block);
-        const classComponent = utils.getParentComponent(node);
-        if (SFCComponent) {
-          handleSFCUsage(node);
-        }
-        if (classComponent) {
-          handleClassUsage(node);
+        if (configuration === 'always') {
+          const SFCComponent = components.get(context.getScope(node).block);
+          const classComponent = utils.getParentComponent(node);
+          if (SFCComponent) {
+            handleSFCUsage(node);
+          }
+          if (classComponent) {
+            handleClassUsage(node);
+          }
         }
       },
 
       VariableDeclarator(node) {
-        const classComponent = utils.getParentComponent(node);
-        const SFCComponent = components.get(context.getScope(node).block);
+        if (configuration === 'never') {
+          const destructuring = (node.init && node.id && node.id.type === 'ObjectPattern');
+          // let {foo} = props;
+          const destructuringSFC = destructuring && (node.init.name === 'props' || node.init.name === 'context');
+          // let {foo} = this.props;
+          const destructuringClass = destructuring && node.init.object && node.init.object.type === 'ThisExpression' && (
+            node.init.property.name === 'props' || node.init.property.name === 'context' || node.init.property.name === 'state'
+          );
 
-        const destructuring = (node.init && node.id && node.id.type === 'ObjectPattern');
-        // let {foo} = props;
-        const destructuringSFC = destructuring && (node.init.name === 'props' || node.init.name === 'context');
-        // let {foo} = this.props;
-        const destructuringClass = destructuring && node.init.object && node.init.object.type === 'ThisExpression' && (
-          node.init.property.name === 'props' || node.init.property.name === 'context' || node.init.property.name === 'state'
-        );
+          if (destructuringSFC && components.get(context.getScope(node).block)) {
+            context.report({
+              node,
+              messageId: 'noDestructAssignment',
+              data: {
+                type: node.init.name
+              }
+            });
+          }
 
-        if (SFCComponent && destructuringSFC && configuration === 'never') {
-          context.report({
-            node,
-            messageId: 'noDestructAssignment',
-            data: {
-              type: node.init.name
-            }
-          });
-        }
-
-        if (
-          classComponent && destructuringClass && configuration === 'never'
-          && !(ignoreClassFields && node.parent.type === 'ClassProperty')
-        ) {
-          context.report({
-            node,
-            messageId: 'noDestructAssignment',
-            data: {
-              type: node.init.property.name
-            }
-          });
+          if (
+            destructuringClass
+            && !(ignoreClassFields && node.parent.type === 'ClassProperty')
+            && utils.getParentComponent(node)
+          ) {
+            context.report({
+              node,
+              messageId: 'noDestructAssignment',
+              data: {
+                type: node.init.property.name
+              }
+            });
+          }
         }
       }
     };

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
@@ -229,9 +230,10 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
         // Report missing display name for all components
-        Object.keys(list).filter((component) => !list[component].hasDisplayName).forEach((component) => {
-          reportMissingDisplayName(list[component]);
-        });
+        values(list).filter((component) => !component.hasDisplayName)
+          .forEach((component) => {
+            reportMissingDisplayName(component);
+          });
       }
     };
   })

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -43,14 +43,16 @@ module.exports = {
     const config = context.options[0] || {};
     const ignoreTranspilerName = config.ignoreTranspilerName || false;
 
+    const markFlag = {
+      hasDisplayName: true
+    };
+
     /**
      * Mark a prop type as declared
      * @param {ASTNode} node The AST node being checked.
      */
     function markDisplayNameAsDeclared(node) {
-      components.set(node, {
-        hasDisplayName: true
-      });
+      components.set(node, markFlag);
     }
 
     /**
@@ -230,9 +232,11 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
         // Report missing display name for all components
-        values(list).filter((component) => !component.hasDisplayName)
+        values(list)
           .forEach((component) => {
-            reportMissingDisplayName(component);
+            if (!component.hasDisplayName) {
+              reportMissingDisplayName(component);
+            }
           });
       }
     };

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -83,8 +83,6 @@ module.exports = {
     return {
       JSXAttribute(node) {
         const parentName = node.parent.name;
-        // Extract a component name when using a "namespace", e.g. `<AntdLayout.Content />`.
-        const tag = parentName.name || `${parentName.object.name}.${parentName.property.name}`;
         const componentName = parentName.name || parentName.property.name;
         if (componentName && typeof componentName[0] === 'string' && componentName[0] !== componentName[0].toUpperCase()) {
           // This is a DOM node, not a Component, so exit.
@@ -92,6 +90,9 @@ module.exports = {
         }
 
         const prop = node.name.name;
+
+        // Extract a component name when using a "namespace", e.g. `<AntdLayout.Content />`.
+        const tag = parentName.name || `${parentName.object.name}.${parentName.property.name}`;
 
         if (!isForbidden(prop, tag)) {
           return;

--- a/lib/rules/function-component-definition.js
+++ b/lib/rules/function-component-definition.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const entries = require('object.entries');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -13,8 +14,8 @@ const docsUrl = require('../util/docsUrl');
 // ------------------------------------------------------------------------------
 
 function buildFunction(template, parts) {
-  return Object.keys(parts)
-    .reduce((acc, key) => acc.replace(`{${key}}`, parts[key] || ''), template);
+  return entries(parts)
+    .reduce((acc, entry) => acc.replace(`{${entry[0]}}`, entry[1] || ''), template);
 }
 
 const NAMED_FUNCTION_TEMPLATES = {

--- a/lib/rules/jsx-fragments.js
+++ b/lib/rules/jsx-fragments.js
@@ -50,17 +50,15 @@ module.exports = {
     const openFragLong = `<${reactPragma}.${fragmentPragma}>`;
     const closeFragLong = `</${reactPragma}.${fragmentPragma}>`;
 
-    function reportOnReactVersion(node) {
-      if (!versionUtil.testReactVersion(context, '16.2.0')) {
-        context.report({
-          node,
-          messageId: 'fragmentsNotSupported'
-        });
-        return true;
-      }
+    const reactVersionCheck = !versionUtil.testReactVersion(context, '16.2.0');
 
-      return false;
-    }
+    const reportOnReactVersion = reactVersionCheck ? (node) => {
+      context.report({
+        node,
+        messageId: 'fragmentsNotSupported'
+      });
+      return true;
+    } : () => false;
 
     function getFixerToLong(jsxFragment) {
       const sourceCode = context.getSourceCode();

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -138,8 +138,8 @@ module.exports = {
      */
     function getNodeIndent(node) {
       let src = context.getSourceCode().getText(node, node.loc.start.column + extraColumnStart);
-      const lines = src.split('\n');
-      src = lines[0];
+      const matches = src.match(/^(.*)\n/);
+      src = matches ? matches[1] : src;
 
       let regExp;
       if (indentType === 'space') {
@@ -150,14 +150,16 @@ module.exports = {
 
       const indent = regExp.exec(src);
       const useOperator = /^([ ]|[\t])*[:]/.test(src) || /^([ ]|[\t])*[?]/.test(src);
-      const useBracket = /^([ ]|[\t])*[<]/.test(src);
 
       line.currentOperator = false;
       if (useOperator) {
         line.isUsingOperator = true;
         line.currentOperator = true;
-      } else if (useBracket) {
-        line.isUsingOperator = false;
+      } else {
+        const useBracket = /^([ ]|[\t])*[<]/.test(src);
+        if (useBracket) {
+          line.isUsingOperator = false;
+        }
       }
 
       return indent ? indent[0].length : 0;

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -277,13 +277,11 @@ module.exports = {
      */
     function checkNodesIndent(node, indent, excludeCommas) {
       const nodeIndent = getNodeIndent(node, false, excludeCommas);
-      const isCorrectRightInLogicalExp = isRightInLogicalExp(node) && (nodeIndent - indent) === indentSize;
-      const isCorrectAlternateInCondExp = isAlternateInConditionalExp(node) && (nodeIndent - indent) === 0;
       if (
         nodeIndent !== indent
         && astUtil.isNodeFirstInLine(context, node)
-        && !isCorrectRightInLogicalExp
-        && !isCorrectAlternateInCondExp
+        && !(isRightInLogicalExp(node) && (nodeIndent - indent) === indentSize)
+        && !(isAlternateInConditionalExp(node) && (nodeIndent - indent) === 0)
       ) {
         report(node, indent, nodeIndent);
       }

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -149,20 +149,19 @@ module.exports = {
       excludeCommas = excludeCommas || false;
 
       let src = context.getSourceCode().getText(node, node.loc.start.column + extraColumnStart);
-      const lines = src.split('\n');
+      let matches;
       if (byLastLine) {
-        src = lines[lines.length - 1];
+        matches = src.match(/.*\n(.*)$/);
       } else {
-        src = lines[0];
+        matches = src.match(/^(.*)\n/);
       }
-
-      const skip = excludeCommas ? ',' : '';
+      src = matches ? matches[1] : src;
 
       let regExp;
       if (indentType === 'space') {
-        regExp = new RegExp(`^[ ${skip}]+`);
+        regExp = excludeCommas ? /^[ ,]+/ : /^[ ]+/;
       } else {
-        regExp = new RegExp(`^[\t${skip}]+`);
+        regExp = excludeCommas ? /^[\t,]+/ : /^[\t]+/;
       }
 
       const indent = regExp.exec(src);

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -19,6 +19,8 @@ const defaultOptions = {
   checkKeyMustBeforeSpread: false
 };
 
+const hasReturnStatementType = (item) => item.type === 'ReturnStatement';
+
 module.exports = {
   meta: {
     docs: {
@@ -78,7 +80,7 @@ module.exports = {
     }
 
     function getReturnStatement(body) {
-      return body.filter((item) => item.type === 'ReturnStatement')[0];
+      return body.find(hasReturnStatementType);
     }
 
     function isKeyAfterSpread(attributes) {

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+const entries = require('object.entries');
 const propName = require('jsx-ast-utils/propName');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
@@ -110,27 +111,34 @@ module.exports = {
       blockVariableNameSets[blockStart][violationType].add(variableName);
     }
 
+    function onlyBlockStatements(ancestor) {
+      return ancestor.type === 'BlockStatement';
+    }
+
     function getBlockStatementAncestors(node) {
-      return context.getAncestors(node).reverse().filter(
-        (ancestor) => ancestor.type === 'BlockStatement'
-      );
+      return context.getAncestors(node).filter(onlyBlockStatements).reverse();
     }
 
     function reportVariableViolation(node, name, blockStart) {
       const blockSets = blockVariableNameSets[blockStart];
-      const violationTypes = Object.keys(blockSets);
+      const violationTypes = entries(blockSets);
 
-      return violationTypes.find((type) => {
-        if (blockSets[type].has(name)) {
-          context.report({
-            node,
-            messageId: type
-          });
+      const foundTypeEntry = violationTypes.find((typeEntry) => {
+        if (typeEntry[1].has(name)) {
           return true;
         }
 
         return false;
       });
+
+      if (foundTypeEntry) {
+        context.report({
+          node,
+          messageId: foundTypeEntry[0]
+        });
+      }
+
+      return foundTypeEntry;
     }
 
     function findVariableViolation(node, name) {
@@ -148,40 +156,43 @@ module.exports = {
         if (!node.init) {
           return;
         }
-        const blockAncestors = getBlockStatementAncestors(node);
-        const variableViolationType = getNodeViolationType(node.init);
 
-        if (
-          blockAncestors.length > 0
-          && variableViolationType
-          && node.parent.kind === 'const' // only support const right now
-        ) {
-          addVariableNameToSet(
-            variableViolationType, node.id.name, blockAncestors[0].range[0]
-          );
+        // only support const right now
+        if (node.parent.kind === 'const') {
+          const blockAncestors = getBlockStatementAncestors(node);
+          const variableViolationType = getNodeViolationType(node.init);
+
+          if (
+            blockAncestors.length > 0
+            && variableViolationType
+          ) {
+            addVariableNameToSet(
+              variableViolationType, node.id.name, blockAncestors[0].range[0]
+            );
+          }
         }
       },
 
       JSXAttribute(node) {
-        const isRef = configuration.ignoreRefs && propName(node) === 'ref';
-        if (isRef || !node.value || !node.value.expression) {
+        if (!node.value || !node.value.expression || (configuration.ignoreRefs && propName(node) === 'ref')) {
           return;
         }
-        const isDOMComponent = jsxUtil.isDOMComponent(node.parent);
-        if (configuration.ignoreDOMComponents && isDOMComponent) {
+        if (configuration.ignoreDOMComponents && jsxUtil.isDOMComponent(node.parent)) {
           return;
         }
         const valueNode = node.value.expression;
         const valueNodeType = valueNode.type;
-        const nodeViolationType = getNodeViolationType(valueNode);
 
         if (valueNodeType === 'Identifier') {
           findVariableViolation(node, valueNode.name);
-        } else if (nodeViolationType) {
-          context.report({
-            node,
-            messageId: nodeViolationType
-          });
+        } else {
+          const nodeViolationType = getNodeViolationType(valueNode);
+          if (nodeViolationType) {
+            context.report({
+              node,
+              messageId: nodeViolationType
+            });
+          }
         }
       }
     };

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -19,7 +19,7 @@ function isJSXText(node) {
  * @returns {boolean}
  */
 function isOnlyWhitespace(text) {
-  return text.trim().length === 0;
+  return !/\S/.test(text);
 }
 
 /**

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -27,7 +27,7 @@ function isOnlyWhitespace(text) {
  * @returns {boolean}
  */
 function isNonspaceJSXTextOrJSXCurly(node) {
-  return (isJSXText(node) && !isOnlyWhitespace(node.raw)) || node.type === 'JSXExpressionContainer';
+  return node.type === 'JSXExpressionContainer' || (isJSXText(node) && !isOnlyWhitespace(node.raw));
 }
 
 /**

--- a/lib/rules/jsx-one-expression-per-line.js
+++ b/lib/rules/jsx-one-expression-per-line.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const entries = require('object.entries');
+const values = require('object.values');
 const docsUrl = require('../util/docsUrl');
 const jsxUtil = require('../util/jsx');
 
@@ -123,12 +125,14 @@ module.exports = {
         }
       });
 
-      Object.keys(childrenGroupedByLine).forEach((_line) => {
-        const line = parseInt(_line, 10);
+      entries(childrenGroupedByLine).forEach((lineEntry) => {
+        const lineKey = lineEntry[0];
+        const lineValue = lineEntry[1];
+        const line = parseInt(lineKey, 10);
         const firstIndex = 0;
-        const lastIndex = childrenGroupedByLine[line].length - 1;
+        const lastIndex = lineValue.length - 1;
 
-        childrenGroupedByLine[line].forEach((child, i) => {
+        lineValue.forEach((child, i) => {
           let prevChild;
           let nextChild;
 
@@ -137,7 +141,7 @@ module.exports = {
               prevChild = openingElement;
             }
           } else {
-            prevChild = childrenGroupedByLine[line][i - 1];
+            prevChild = lineValue[i - 1];
           }
 
           if (i === lastIndex) {
@@ -196,9 +200,7 @@ module.exports = {
         });
       });
 
-      Object.keys(fixDetailsByNode).forEach((key) => {
-        const details = fixDetailsByNode[key];
-
+      values(fixDetailsByNode).forEach((details) => {
         const nodeToReport = details.node;
         const descriptor = details.descriptor;
         const source = details.source.replace(/(^ +| +(?=\n)*$)/g, '');

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -25,20 +25,23 @@ function testLowerCase(char) {
   return char === lowerCase && lowerCase !== char.toUpperCase();
 }
 
+const isCharNonAlphanumeric = (char) => !testDigit(char) && char.toLowerCase() === char.toUpperCase();
+const isCharLowerCaseOrDigit = (char) => testLowerCase(char) || testDigit(char);
+
 function testPascalCase(name) {
   if (!testUpperCase(name.charAt(0))) {
     return false;
   }
   const anyNonAlphaNumeric = Array.prototype.some.call(
     name.slice(1),
-    (char) => char.toLowerCase() === char.toUpperCase() && !testDigit(char)
+    isCharNonAlphanumeric
   );
   if (anyNonAlphaNumeric) {
     return false;
   }
   return Array.prototype.some.call(
     name.slice(1),
-    (char) => testLowerCase(char) || testDigit(char)
+    isCharLowerCaseOrDigit
   );
 }
 
@@ -120,23 +123,25 @@ module.exports = {
         if (isCompatTag) return undefined;
 
         const name = elementType(node);
-        let checkNames = [name];
+        let checkNames;
         let index = 0;
 
         if (name.lastIndexOf(':') > -1) {
           checkNames = name.split(':');
         } else if (name.lastIndexOf('.') > -1) {
           checkNames = name.split('.');
+        } else {
+          checkNames = [name];
         }
 
         do {
           const splitName = checkNames[index];
           if (splitName.length === 1) return undefined;
-          const isPascalCase = testPascalCase(splitName);
-          const isAllowedAllCaps = allowAllCaps && testAllCaps(splitName);
-          const isIgnored = ignoreCheck(ignore, splitName);
 
-          if (!isPascalCase && !isAllowedAllCaps && !isIgnored) {
+          if (!testPascalCase(splitName)
+            && !(allowAllCaps && testAllCaps(splitName))
+            && !ignoreCheck(ignore, splitName)
+          ) {
             context.report({
               node,
               messageId: allowAllCaps ? 'usePascalOrSnakeCase' : 'usePascalCase',

--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -157,12 +157,13 @@ module.exports = {
           while (current.type !== 'Program') {
             if (isFirstArgumentInSetStateCall(current, node)) {
               vars
-                .filter((v) => v.scope === context.getScope() && v.variableName === node.name)
                 .forEach((v) => {
-                  context.report({
-                    node: v.node,
-                    messageId: 'useCallback'
-                  });
+                  if (v.scope === context.getScope() && v.variableName === node.name) {
+                    context.report({
+                      node: v.node,
+                      messageId: 'useCallback'
+                    });
+                  }
                 });
             }
             current = current.parent;

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -47,6 +47,8 @@ module.exports = {
       some: 1
     };
 
+    const pragmaFromContext = pragma.getFromContext(context);
+
     const reactChildMethods = ['map', 'forEach'];
 
     function isArrayIndex(node) {
@@ -73,7 +75,7 @@ module.exports = {
       if (obj && obj.name === 'Children') {
         return true;
       }
-      if (obj && obj.object && obj.object.name === pragma.getFromContext(context)) {
+      if (obj && obj.object && obj.object.name === pragmaFromContext) {
         return true;
       }
 
@@ -141,8 +143,10 @@ module.exports = {
 
       if (node.type === 'TemplateLiteral') {
         // key={`foo-${bar}`}
-        node.expressions.filter(isArrayIndex).forEach(() => {
-          context.report({node, messageId: 'noArrayIndex'});
+        node.expressions.forEach((expressionNode) => {
+          if (isArrayIndex(expressionNode)) {
+            context.report({node, messageId: 'noArrayIndex'});
+          }
         });
 
         return;
@@ -152,8 +156,10 @@ module.exports = {
         // key={'foo' + bar}
         const identifiers = getIdentifiersFromBinaryExpression(node);
 
-        identifiers.filter(isArrayIndex).forEach(() => {
-          context.report({node, messageId: 'noArrayIndex'});
+        identifiers.forEach((identifierNode) => {
+          if (isArrayIndex(identifierNode)) {
+            context.report({node, messageId: 'noArrayIndex'});
+          }
         });
       }
     }

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -47,6 +47,8 @@ module.exports = {
       some: 1
     };
 
+    const reactChildMethods = ['map', 'forEach'];
+
     function isArrayIndex(node) {
       return node.type === 'Identifier'
         && indexParamNames.indexOf(node.name) !== -1;
@@ -62,7 +64,7 @@ module.exports = {
         return null;
       }
 
-      const isReactChildMethod = ['map', 'forEach'].indexOf(callee.property.name) > -1;
+      const isReactChildMethod = reactChildMethods.indexOf(callee.property.name) > -1;
       if (!isReactChildMethod) {
         return null;
       }

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -24,6 +24,16 @@ const MODULES = {
   'react-addons-perf': ['ReactPerf', 'Perf']
 };
 
+const VERSION_MAP = {
+  '0.12.0': [0, 12, 0],
+  '0.13.0': [0, 13, 0],
+  '0.14.0': [0, 14, 0],
+  '15.0.0': [15, 0, 0],
+  '15.5.0': [15, 5, 0],
+  '15.6.0': [15, 6, 0],
+  '16.9.0': [16, 9, 0]
+};
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -47,7 +57,13 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     const pragma = pragmaUtil.getFromContext(context);
 
+    const reactVersion = versionUtil.getReactVersionFromContext(context);
+
+    let deprecatedCache;
     function getDeprecated() {
+      if (deprecatedCache !== undefined) {
+        return deprecatedCache;
+      }
       const deprecated = {};
       // 0.12.0
       deprecated[`${pragma}.renderComponent`] = ['0.12.0', `${pragma}.render`];
@@ -101,6 +117,7 @@ module.exports = {
         'https://reactjs.org/docs/react-component.html#unsafe_componentwillupdate. '
         + 'Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components.'
       ];
+      deprecatedCache = deprecated;
       return deprecated;
     }
 
@@ -108,10 +125,9 @@ module.exports = {
       const deprecated = getDeprecated();
 
       return (
-        deprecated
-        && deprecated[method]
-        && deprecated[method][0]
-        && versionUtil.testReactVersion(context, deprecated[method][0])
+        // eslint-disable-next-line no-prototype-builtins
+        deprecated.hasOwnProperty(method) // necessary to avoid 'constructor'
+        && versionUtil.isLessThan(VERSION_MAP[deprecated[method][0]], reactVersion)
       );
     }
 
@@ -141,8 +157,10 @@ module.exports = {
         return moduleName;
       }
 
+      const matchName = (name) => name === node.init.name;
+
       values(MODULES).some((moduleNames) => {
-        moduleName = moduleNames.find((name) => name === node.init.name);
+        moduleName = moduleNames.find(matchName);
         return moduleName;
       });
 

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -6,6 +6,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -140,9 +141,9 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
 
-        Object.keys(list).forEach((key) => {
-          if (!isValid(list[key])) {
-            reportMutations(list[key]);
+        values(list).forEach((val) => {
+          if (!isValid(val)) {
+            reportMutations(val);
           }
         });
       }

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -67,10 +68,10 @@ module.exports = {
 
         const list = components.list();
 
-        Object.keys(list).filter((component) => !isIgnored(list[component])).forEach((component, i) => {
+        values(list).filter((component) => !isIgnored(component)).forEach((component, i) => {
           if (i >= 1) {
             context.report({
-              node: list[component].node,
+              node: component.node,
               messageId: 'onlyOneComponent'
             });
           }

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -80,8 +80,10 @@ module.exports = {
 
       'Program:exit'() {
         const list = components.list();
-        values(list).filter((component) => !isValid(component)).forEach((component) => {
-          reportSetStateUsages(component);
+        values(list).forEach((component) => {
+          if (!isValid(component)) {
+            reportSetStateUsages(component);
+          }
         });
       }
     };

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -79,8 +80,8 @@ module.exports = {
 
       'Program:exit'() {
         const list = components.list();
-        Object.keys(list).filter((component) => !isValid(list[component])).forEach((component) => {
-          reportSetStateUsages(list[component]);
+        values(list).filter((component) => !isValid(component)).forEach((component) => {
+          reportSetStateUsages(component);
         });
       }
     };

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -46,12 +46,12 @@ module.exports = {
      */
     function isRefsUsage(node) {
       return Boolean(
-        (
+        node.object.type === 'ThisExpression'
+        && node.property.name === 'refs'
+        && (
           utils.getParentES6Component()
           || utils.getParentES5Component()
         )
-        && node.object.type === 'ThisExpression'
-        && node.property.name === 'refs'
       );
     }
 

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -4,7 +4,8 @@
 
 'use strict';
 
-const PROP_TYPES = Object.keys(require('prop-types'));
+const PROP_TYPES = require('prop-types');
+const fromEntries = require('object.fromentries');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -13,7 +14,17 @@ const docsUrl = require('../util/docsUrl');
 // ------------------------------------------------------------------------------
 
 const STATIC_CLASS_PROPERTIES = ['propTypes', 'contextTypes', 'childContextTypes', 'defaultProps'];
+const STATIC_CLASS_PROPERTIES_LOWER_CASE = fromEntries(STATIC_CLASS_PROPERTIES.map((name) => ([
+  name.toLowerCase(),
+  name
+])));
+const STATIC_CLASS_PROPERTIES_LOCALE_LOWER_CASE = fromEntries(
+  STATIC_CLASS_PROPERTIES.map((name) => [name.toLocaleLowerCase(), name])
+);
 const STATIC_LIFECYCLE_METHODS = ['getDerivedStateFromProps'];
+const INVALID_STATIC_LIFECYCLE_METHODS = fromEntries(STATIC_LIFECYCLE_METHODS
+  .map((name) => [name.toLowerCase(), name])
+);
 const LIFECYCLE_METHODS = [
   'getDerivedStateFromProps',
   'componentWillMount',
@@ -30,6 +41,9 @@ const LIFECYCLE_METHODS = [
   'componentWillUnmount',
   'render'
 ];
+const INVALID_LIFECYCLE_METHODS = fromEntries(LIFECYCLE_METHODS
+  .map((name) => [name.toLowerCase(), name])
+);
 
 module.exports = {
   meta: {
@@ -69,7 +83,7 @@ module.exports = {
     }
 
     function checkValidPropType(node) {
-      if (node.name && !PROP_TYPES.some((propTypeName) => propTypeName === node.name)) {
+      if (node.name && !(node.name in PROP_TYPES)) {
         context.report({
           node,
           messageId: 'typoPropType',
@@ -144,8 +158,10 @@ module.exports = {
       if (propertyName === 'propTypes' || propertyName === 'contextTypes' || propertyName === 'childContextTypes') {
         checkValidPropObject(propertyValue);
       }
-      STATIC_CLASS_PROPERTIES.forEach((CLASS_PROP) => {
-        if (propertyName && CLASS_PROP.toLowerCase() === propertyName.toLowerCase() && CLASS_PROP !== propertyName) {
+      if (propertyName) {
+        const propertyNameLowerCase = propertyName.toLowerCase();
+        if (propertyNameLowerCase in STATIC_CLASS_PROPERTIES_LOWER_CASE
+          && STATIC_CLASS_PROPERTIES_LOWER_CASE[propertyNameLowerCase] !== propertyName) {
           context.report({
             node: propertyKey,
             messageId: isClassProperty
@@ -153,7 +169,7 @@ module.exports = {
               : 'typoPropDeclaration'
           });
         }
-      });
+      }
     }
 
     function reportErrorIfLifecycleMethodCasingTypo(node) {
@@ -165,8 +181,10 @@ module.exports = {
         return;
       }
 
-      STATIC_LIFECYCLE_METHODS.forEach((method) => {
-        if (!node.static && nodeKeyName.toLowerCase() === method.toLowerCase()) {
+      const nodeKeyNameLowerCase = nodeKeyName.toLowerCase();
+
+      if (!node.static) {
+        if (nodeKeyNameLowerCase in INVALID_STATIC_LIFECYCLE_METHODS) {
           context.report({
             node,
             messageId: 'staticLifecycleMethod',
@@ -175,17 +193,16 @@ module.exports = {
             }
           });
         }
-      });
+      }
 
-      LIFECYCLE_METHODS.forEach((method) => {
-        if (method.toLowerCase() === nodeKeyName.toLowerCase() && method !== nodeKeyName) {
-          context.report({
-            node,
-            messageId: 'typoLifecycleMethod',
-            data: {actual: nodeKeyName, expected: method}
-          });
-        }
-      });
+      if (nodeKeyNameLowerCase in INVALID_LIFECYCLE_METHODS
+        && INVALID_LIFECYCLE_METHODS[nodeKeyNameLowerCase] !== nodeKeyName) {
+        context.report({
+          node,
+          messageId: 'typoLifecycleMethod',
+          data: {actual: nodeKeyName, expected: INVALID_LIFECYCLE_METHODS[nodeKeyNameLowerCase]}
+        });
+      }
     }
 
     return {
@@ -232,19 +249,21 @@ module.exports = {
 
         if (
           !propertyName
-          || STATIC_CLASS_PROPERTIES.map((prop) => prop.toLocaleLowerCase()).indexOf(propertyName.toLowerCase()) === -1
+          || !(propertyName.toLowerCase() in STATIC_CLASS_PROPERTIES_LOCALE_LOWER_CASE)
         ) {
           return;
         }
 
-        const relatedComponent = utils.getRelatedComponent(node);
+        if (node.parent && node.parent.type === 'AssignmentExpression' && node.parent.right) {
+          const relatedComponent = utils.getRelatedComponent(node);
 
-        if (
-          relatedComponent
-          && (utils.isES6Component(relatedComponent.node) || utils.isReturningJSX(relatedComponent.node))
-          && (node.parent && node.parent.type === 'AssignmentExpression' && node.parent.right)
-        ) {
-          reportErrorIfPropertyCasingTypo(node.parent.right, node.property, true);
+          if (
+            relatedComponent
+            && (utils.isES6Component(relatedComponent.node) || utils.isReturningJSX(relatedComponent.node))
+            && (node.parent && node.parent.type === 'AssignmentExpression' && node.parent.right)
+          ) {
+            reportErrorIfPropertyCasingTypo(node.parent.right, node.property, true);
+          }
         }
       },
 

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -132,13 +132,6 @@ const DOM_PROPERTY_NAMES = [
   'autoSave',
   'itemProp', 'itemScope', 'itemType', 'itemRef', 'itemID'
 ];
-function getDOMPropertyNames(context) {
-  // this was removed in React v16.1+, see https://github.com/facebook/react/pull/10823
-  if (!versionUtil.testReactVersion(context, '16.1.0')) {
-    return ['allowTransparency'].concat(DOM_PROPERTY_NAMES);
-  }
-  return DOM_PROPERTY_NAMES;
-}
 
 // ------------------------------------------------------------------------------
 // Helpers
@@ -189,24 +182,6 @@ function tagNameHasDot(node) {
   );
 }
 
-/**
- * Get the standard name of the attribute.
- * @param {String} name - Name of the attribute.
- * @param {String} context - eslint context
- * @returns {String | undefined} The standard name of the attribute, or undefined if no standard name was found.
- */
-function getStandardName(name, context) {
-  if (has(DOM_ATTRIBUTE_NAMES, name)) {
-    return DOM_ATTRIBUTE_NAMES[name];
-  }
-  if (has(SVGDOM_ATTRIBUTE_NAMES, name)) {
-    return SVGDOM_ATTRIBUTE_NAMES[name];
-  }
-  const names = getDOMPropertyNames(context);
-  // Let's find a possible attribute match with a case-insensitive search.
-  return names.find((element) => element.toLowerCase() === name.toLowerCase());
-}
-
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -241,6 +216,28 @@ module.exports = {
   },
 
   create(context) {
+    // this was removed in React v16.1+, see https://github.com/facebook/react/pull/10823
+    const derivedDOMPropertyNames = (!versionUtil.testReactVersion(context, '16.1.0'))
+      ? ['allowTransparency'].concat(DOM_PROPERTY_NAMES)
+      : DOM_PROPERTY_NAMES;
+
+    /**
+     * Get the standard name of the attribute.
+     * @param {String} name - Name of the attribute.
+     * @returns {String | undefined} The standard name of the attribute, or undefined if no standard name was found.
+     */
+    function getStandardName(name) {
+      if (has(DOM_ATTRIBUTE_NAMES, name)) {
+        return DOM_ATTRIBUTE_NAMES[name];
+      }
+      if (has(SVGDOM_ATTRIBUTE_NAMES, name)) {
+        return SVGDOM_ATTRIBUTE_NAMES[name];
+      }
+      // Let's find a possible attribute match with a case-insensitive search.
+      const lowerCaseName = name.toLowerCase();
+      return derivedDOMPropertyNames.find((element) => element.toLowerCase() === lowerCaseName);
+    }
+
     function getIgnoreConfig() {
       return (context.options[0] && context.options[0].ignore) || DEFAULTS.ignore;
     }
@@ -278,7 +275,7 @@ module.exports = {
         // of what we should normally have with React. If yes, we'll report an
         // error. We don't want to report if the input attribute name is the
         // standard name though!
-        const standardName = getStandardName(name, context);
+        const standardName = getStandardName(name);
         if (!isTagName(node) || !standardName || standardName === name) {
           return;
         }

--- a/lib/rules/no-unsafe.js
+++ b/lib/rules/no-unsafe.js
@@ -74,21 +74,12 @@ module.exports = {
     }
 
     /**
-     * Returns a list of unsafe methods
-     * @returns {Array} A list of unsafe methods
-     */
-    function getUnsafeMethods() {
-      return Object.keys(unsafe);
-    }
-
-    /**
      * Checks if a passed method is unsafe
      * @param {string} method Life cycle method
      * @returns {boolean} Returns true for unsafe methods, otherwise returns false
      */
     function isUnsafe(method) {
-      const unsafeMethods = getUnsafeMethods();
-      return unsafeMethods.indexOf(method) !== -1;
+      return (method in unsafe);
     }
 
     /**

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -35,7 +35,7 @@ function generateErrorMessageWithParentName(parentName) {
  * @returns {Boolean}
  */
 function startsWithRender(text) {
-  return (text || '').startsWith('render');
+  return text !== undefined && text.startsWith('render');
 }
 
 /**

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -8,6 +8,7 @@
 // As for exceptions for props.children or props.className (and alike) look at
 // https://github.com/yannickcr/eslint-plugin-react/issues/7
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -111,8 +112,7 @@ module.exports = {
         return;
       }
 
-      Object.keys(props || {}).forEach((key) => {
-        const prop = props[key];
+      values(props || {}).forEach((prop) => {
         // Skip props that check instances
         if (prop === true) {
           return;
@@ -159,11 +159,11 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
         // Report undeclared proptypes for all classes
-        Object.keys(list).filter((component) => mustBeValidated(list[component])).forEach((component) => {
-          if (!mustBeValidated(list[component])) {
+        values(list).filter((component) => mustBeValidated(component)).forEach((component) => {
+          if (!mustBeValidated(component)) {
             return;
           }
-          reportUnusedPropTypes(list[component]);
+          reportUnusedPropTypes(component);
         });
       }
     };

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -112,35 +112,37 @@ module.exports = {
         return;
       }
 
-      values(props || {}).forEach((prop) => {
-        // Skip props that check instances
-        if (prop === true) {
-          return;
-        }
+      if (props) {
+        values(props).forEach((prop) => {
+          // Skip props that check instances
+          if (prop === true) {
+            return;
+          }
 
-        if ((prop.type === 'shape' || prop.type === 'exact') && configuration.skipShapeProps) {
-          return;
-        }
+          if ((prop.type === 'shape' || prop.type === 'exact') && configuration.skipShapeProps) {
+            return;
+          }
 
-        if (prop.node && prop.node.typeAnnotation && prop.node.typeAnnotation.typeAnnotation
-          && prop.node.typeAnnotation.typeAnnotation.type === 'TSNeverKeyword') {
-          return;
-        }
+          if (prop.node && prop.node.typeAnnotation && prop.node.typeAnnotation.typeAnnotation
+            && prop.node.typeAnnotation.typeAnnotation.type === 'TSNeverKeyword') {
+            return;
+          }
 
-        if (prop.node && !isIgnored(prop.fullName) && !isPropUsed(component, prop)) {
-          context.report({
-            node: prop.node.key || prop.node,
-            messageId: 'unusedPropType',
-            data: {
-              name: prop.fullName
-            }
-          });
-        }
+          if (prop.node && !isIgnored(prop.fullName) && !isPropUsed(component, prop)) {
+            context.report({
+              node: prop.node.key || prop.node,
+              messageId: 'unusedPropType',
+              data: {
+                name: prop.fullName
+              }
+            });
+          }
 
-        if (prop.children) {
-          reportUnusedPropType(component, prop.children);
-        }
-      });
+          if (prop.children) {
+            reportUnusedPropType(component, prop.children);
+          }
+        });
+      }
     }
 
     /**
@@ -159,11 +161,10 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
         // Report undeclared proptypes for all classes
-        values(list).filter((component) => mustBeValidated(component)).forEach((component) => {
-          if (!mustBeValidated(component)) {
-            return;
+        values(list).forEach((component) => {
+          if (mustBeValidated(component)) {
+            reportUnusedPropTypes(component);
           }
-          reportUnusedPropTypes(component);
         });
       }
     };

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -144,14 +144,16 @@ module.exports = {
     // Takes an ObjectExpression node and adds all named Property nodes to the
     // current set of state fields.
     function addStateFields(node) {
-      node.properties.filter((prop) => (
-        prop.type === 'Property'
-          && (prop.key.type === 'Literal'
-          || (prop.key.type === 'TemplateLiteral' && prop.key.expressions.length === 0)
-          || (prop.computed === false && prop.key.type === 'Identifier'))
-          && getName(prop.key) !== null
-      )).forEach((prop) => {
-        classInfo.stateFields.add(prop);
+      node.properties.forEach((prop) => {
+        if (
+          prop.type === 'Property'
+            && (prop.key.type === 'Literal'
+            || (prop.key.type === 'TemplateLiteral' && prop.key.expressions.length === 0)
+            || (prop.computed === false && prop.key.type === 'Identifier'))
+            && getName(prop.key) !== null
+        ) {
+          classInfo.stateFields.add(prop);
+        }
       });
     }
 

--- a/lib/rules/prefer-read-only-props.js
+++ b/lib/rules/prefer-read-only-props.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const entries = require('object.entries');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -15,6 +16,33 @@ function isFlowPropertyType(node) {
 function isCovariant(node) {
   return (node.variance && (node.variance.kind === 'plus')) || (node.parent.parent.parent.id && (node.parent.parent.parent.id.name === '$ReadOnly'));
 }
+
+const reportPropTypeWithContext = (context) => (propEntry) => {
+  const propName = propEntry[0];
+  const prop = propEntry[1];
+  if (!isFlowPropertyType(prop.node)) {
+    return;
+  }
+
+  if (!isCovariant(prop.node)) {
+    context.report({
+      node: prop.node,
+      messageId: 'readOnlyProp',
+      data: {
+        name: propName
+      },
+      fix: (fixer) => {
+        if (!prop.node.variance) {
+          // Insert covariance
+          return fixer.insertTextBefore(prop.node, '+');
+        }
+
+        // Replace contravariance with covariance
+        return fixer.replaceText(prop.node.variance, '+');
+      }
+    });
+  }
+};
 
 // ------------------------------------------------------------------------------
 // Rule Definition
@@ -41,39 +69,15 @@ module.exports = {
     'Program:exit'() {
       const list = components.list();
 
+      const reportPropType = reportPropTypeWithContext(context);
+
       Object.keys(list).forEach((key) => {
         const component = list[key];
-
         if (!component.declaredPropTypes) {
           return;
         }
 
-        Object.keys(component.declaredPropTypes).forEach((propName) => {
-          const prop = component.declaredPropTypes[propName];
-
-          if (!isFlowPropertyType(prop.node)) {
-            return;
-          }
-
-          if (!isCovariant(prop.node)) {
-            context.report({
-              node: prop.node,
-              messageId: 'readOnlyProp',
-              data: {
-                name: propName
-              },
-              fix: (fixer) => {
-                if (!prop.node.variance) {
-                  // Insert covariance
-                  return fixer.insertTextBefore(prop.node, '+');
-                }
-
-                // Replace contravariance with covariance
-                return fixer.replaceText(prop.node.variance, '+');
-              }
-            });
-          }
-        });
+        entries(component.declaredPropTypes).forEach(reportPropType);
       });
     }
   }))

--- a/lib/rules/prefer-read-only-props.js
+++ b/lib/rules/prefer-read-only-props.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const entries = require('object.entries');
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -71,8 +72,7 @@ module.exports = {
 
       const reportPropType = reportPropTypeWithContext(context);
 
-      Object.keys(list).forEach((key) => {
-        const component = list[key];
+      values(list).forEach((component) => {
         if (!component.declaredPropTypes) {
           return;
         }

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -46,6 +46,8 @@ module.exports = {
     const configuration = context.options[0] || {};
     const ignorePureComponents = configuration.ignorePureComponents || false;
 
+    const allowNullInReturnStatement = versionUtil.testReactVersion(context, '15.0.0'); // Stateless components can return null since React 15
+
     // --------------------------------------------------------------------------
     // Public
     // --------------------------------------------------------------------------
@@ -345,7 +347,7 @@ module.exports = {
           scope = scope.upper;
         }
         const isRender = blockNode && blockNode.key && blockNode.key.name === 'render';
-        const allowNull = versionUtil.testReactVersion(context, '15.0.0'); // Stateless components can return null since React 15
+        const allowNull = allowNullInReturnStatement;
         const isReturningJSX = utils.isReturningJSX(node, !allowNull);
         const isReturningNull = node.argument && (node.argument.value === null || node.argument.value === false);
         if (

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -7,6 +7,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const versionUtil = require('../util/version');
 const astUtil = require('../util/ast');
@@ -359,24 +360,24 @@ module.exports = {
 
       'Program:exit'() {
         const list = components.list();
-        Object.keys(list).forEach((component) => {
+        values(list).forEach((component) => {
           if (
-            hasOtherProperties(list[component].node)
-            || list[component].useThis
-            || list[component].useRef
-            || list[component].invalidReturn
-            || list[component].hasChildContextTypes
-            || list[component].useDecorators
-            || (!utils.isES5Component(list[component].node) && !utils.isES6Component(list[component].node))
+            component.useThis
+            || component.useRef
+            || component.invalidReturn
+            || component.hasChildContextTypes
+            || component.useDecorators
+            || hasOtherProperties(component.node)
+            || (!utils.isES5Component(component.node) && !utils.isES6Component(component.node))
           ) {
             return;
           }
 
-          if (list[component].hasSCU) {
+          if (component.hasSCU) {
             return;
           }
           context.report({
-            node: list[component].node,
+            node: component.node,
             messageId: 'componentShouldBePure'
           });
         });

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -8,6 +8,7 @@
 // As for exceptions for props.children or props.className (and alike) look at
 // https://github.com/yannickcr/eslint-plugin-react/issues/7
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -190,8 +191,8 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
         // Report undeclared proptypes for all classes
-        Object.keys(list).filter((component) => mustBeValidated(list[component])).forEach((component) => {
-          reportUndeclaredPropTypes(list[component]);
+        values(list).filter((component) => mustBeValidated(component)).forEach((component) => {
+          reportUndeclaredPropTypes(component);
         });
       }
     };

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -167,19 +167,19 @@ module.exports = {
      * @param {Object} component The component to process
      */
     function reportUndeclaredPropTypes(component) {
-      const undeclareds = component.usedPropTypes.filter((propType) => (
-        propType.node
-        && !isIgnored(propType.allNames[0])
-        && !isDeclaredInComponent(component.node, propType.allNames)
-      ));
-      undeclareds.forEach((propType) => {
-        context.report({
-          node: propType.node,
-          messageId: 'missingPropType',
-          data: {
-            name: propType.allNames.join('.').replace(/\.__COMPUTED_PROP__/g, '[]')
-          }
-        });
+      component.usedPropTypes.forEach((propType) => {
+        if (propType.node
+          && !isIgnored(propType.allNames[0])
+          && !isDeclaredInComponent(component.node, propType.allNames)
+        ) {
+          context.report({
+            node: propType.node,
+            messageId: 'missingPropType',
+            data: {
+              name: propType.allNames.join('.').replace(/\.__COMPUTED_PROP__/g, '[]')
+            }
+          });
+        }
       });
     }
 
@@ -191,8 +191,10 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
         // Report undeclared proptypes for all classes
-        values(list).filter((component) => mustBeValidated(component)).forEach((component) => {
-          reportUndeclaredPropTypes(component);
+        values(list).forEach((component) => {
+          if (mustBeValidated(component)) {
+            reportUndeclaredPropTypes(component);
+          }
         });
       }
     };

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -94,17 +94,17 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
 
-        values(list).filter((component) => {
+        values(list).forEach((component) => {
           if (ignoreFunctionalComponents
             && (astUtil.isFunction(component.node) || astUtil.isFunctionLikeExpression(component.node))) {
-            return false;
+            return;
           }
-          return component.declaredPropTypes;
-        }).forEach((component) => {
-          reportPropTypesWithoutDefault(
-            component.declaredPropTypes,
-            component.defaultProps || {}
-          );
+          if (component.declaredPropTypes) {
+            reportPropTypesWithoutDefault(
+              component.declaredPropTypes,
+              component.defaultProps || {}
+            );
+          }
         });
       }
     };

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const entries = require('object.entries');
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 const astUtil = require('../util/ast');
@@ -58,8 +60,9 @@ module.exports = {
         return;
       }
 
-      Object.keys(propTypes).forEach((propName) => {
-        const prop = propTypes[propName];
+      entries(propTypes).forEach((propEntry) => {
+        const propName = propEntry[0];
+        const prop = propEntry[1];
         if (prop.isRequired) {
           if (forbidDefaultForRequired && defaultProps[propName]) {
             context.report({
@@ -91,16 +94,16 @@ module.exports = {
       'Program:exit'() {
         const list = components.list();
 
-        Object.keys(list).filter((component) => {
+        values(list).filter((component) => {
           if (ignoreFunctionalComponents
-            && (astUtil.isFunction(list[component].node) || astUtil.isFunctionLikeExpression(list[component].node))) {
+            && (astUtil.isFunction(component.node) || astUtil.isFunctionLikeExpression(component.node))) {
             return false;
           }
-          return list[component].declaredPropTypes;
+          return component.declaredPropTypes;
         }).forEach((component) => {
           reportPropTypesWithoutDefault(
-            list[component].declaredPropTypes,
-            list[component].defaultProps || {}
+            component.declaredPropTypes,
+            component.defaultProps || {}
           );
         });
       }

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const docsUrl = require('../util/docsUrl');
 
@@ -221,8 +222,8 @@ module.exports = {
         const list = components.list();
 
         // Report missing shouldComponentUpdate for all components
-        Object.keys(list).filter((component) => !list[component].hasSCU).forEach((component) => {
-          reportMissingOptimization(list[component]);
+        values(list).filter((component) => !component.hasSCU).forEach((component) => {
+          reportMissingOptimization(component);
         });
       }
     };

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -222,8 +222,10 @@ module.exports = {
         const list = components.list();
 
         // Report missing shouldComponentUpdate for all components
-        values(list).filter((component) => !component.hasSCU).forEach((component) => {
-          reportMissingOptimization(component);
+        values(list).forEach((component) => {
+          if (!component.hasSCU) {
+            reportMissingOptimization(component);
+          }
         });
       }
     };

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -49,8 +49,9 @@ module.exports = {
     function findRenderMethod(node) {
       const properties = astUtil.getComponentProperties(node);
       return properties
-        .filter((property) => astUtil.getPropertyName(property) === 'render' && property.value)
-        .find((property) => astUtil.isFunctionLikeExpression(property.value));
+        .find((property) => astUtil.getPropertyName(property) === 'render'
+          && property.value && astUtil.isFunctionLikeExpression(property.value)
+        );
     }
 
     return {

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const Components = require('../util/Components');
 const astUtil = require('../util/ast');
 const docsUrl = require('../util/docsUrl');
@@ -79,16 +80,16 @@ module.exports = {
 
       'Program:exit'() {
         const list = components.list();
-        Object.keys(list).forEach((component) => {
+        values(list).forEach((component) => {
           if (
-            !findRenderMethod(list[component].node)
-            || list[component].hasReturnStatement
-            || (!utils.isES5Component(list[component].node) && !utils.isES6Component(list[component].node))
+            component.hasReturnStatement
+            || !findRenderMethod(component.node)
+            || (!utils.isES5Component(component.node) && !utils.isES6Component(component.node))
           ) {
             return;
           }
           context.report({
-            node: findRenderMethod(list[component].node),
+            node: findRenderMethod(component.node),
             messageId: 'noRenderReturn'
           });
         });

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -7,6 +7,7 @@
 
 const has = require('has');
 const entries = require('object.entries');
+const values = require('object.values');
 const arrayIncludes = require('array-includes');
 
 const Components = require('../util/Components');
@@ -430,8 +431,8 @@ module.exports = {
     return {
       'Program:exit'() {
         const list = components.list();
-        Object.keys(list).forEach((component) => {
-          const properties = astUtil.getComponentProperties(list[component].node);
+        values(list).forEach((component) => {
+          const properties = astUtil.getComponentProperties(component.node);
           checkPropsOrder(properties);
         });
 

--- a/lib/rules/static-property-placement.js
+++ b/lib/rules/static-property-placement.js
@@ -168,7 +168,7 @@ module.exports = {
 
       MethodDefinition: (node) => {
         // If the function is inside a class and is static getter then check if correctly positioned
-        if (utils.getParentES6Component() && node.static && node.kind === 'get') {
+        if (node.static && node.kind === 'get' && utils.getParentES6Component()) {
           // Report error if needed
           reportNodeIncorrectlyPositioned(node, STATIC_GETTER);
         }

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -40,6 +40,22 @@ function isVoidDOMElement(elementName) {
   return has(VOID_DOM_ELEMENTS, elementName);
 }
 
+function isChildrenOrDangerProp(prop) {
+  if (!prop.key) {
+    return false;
+  }
+
+  return prop.key.name === 'children' || prop.key.name === 'dangerouslySetInnerHTML';
+}
+
+function isChildrenOrDangerAttribute(attribute) {
+  if (!attribute.name) {
+    return false;
+  }
+
+  return attribute.name.name === 'children' || attribute.name.name === 'dangerouslySetInnerHTML';
+}
+
 // ------------------------------------------------------------------------------
 // Rule Definition
 // ------------------------------------------------------------------------------
@@ -82,13 +98,7 @@ module.exports = {
 
       const attributes = node.openingElement.attributes;
 
-      const hasChildrenAttributeOrDanger = attributes.some((attribute) => {
-        if (!attribute.name) {
-          return false;
-        }
-
-        return attribute.name.name === 'children' || attribute.name.name === 'dangerouslySetInnerHTML';
-      });
+      const hasChildrenAttributeOrDanger = attributes.some(isChildrenOrDangerAttribute);
 
       if (hasChildrenAttributeOrDanger) {
         // e.g. <br children="Foo" />
@@ -143,13 +153,7 @@ module.exports = {
 
       const props = args[1].properties;
 
-      const hasChildrenPropOrDanger = props.some((prop) => {
-        if (!prop.key) {
-          return false;
-        }
-
-        return prop.key.name === 'children' || prop.key.name === 'dangerouslySetInnerHTML';
-      });
+      const hasChildrenPropOrDanger = props.some(isChildrenOrDangerProp);
 
       if (hasChildrenPropOrDanger) {
         // e.g. React.createElement('br', { children: 'Foo' })

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -41,15 +41,18 @@ function usedPropTypesAreEquivalent(propA, propB) {
 }
 
 function mergeUsedPropTypes(propsList, newPropsList) {
-  const propsToAdd = [];
-  newPropsList.forEach((newProp) => {
-    const newPropisAlreadyInTheList = propsList.some((prop) => usedPropTypesAreEquivalent(prop, newProp));
-    if (!newPropisAlreadyInTheList) {
-      propsToAdd.push(newProp);
+  if (propsList === undefined || propsList.length === 0) {
+    return newPropsList;
+  }
+  if (newPropsList !== undefined && newPropsList.length > 0) {
+    const propsToAdd = newPropsList.filter((newProp) => !propsList
+      .some((prop) => usedPropTypesAreEquivalent(prop, newProp))
+    );
+    if (propsToAdd.length > 0) {
+      return propsList.concat(propsToAdd);
     }
-  });
-
-  return propsList.concat(propsToAdd);
+  }
+  return propsList;
 }
 
 function isReturnsConditionalJSX(node, property, strict) {
@@ -80,6 +83,10 @@ function isReturnsSequentialJSX(node, property) {
   return node[property]
     && node[property].type === 'SequenceExpression'
     && jsxUtil.isJSX(node[property].expressions[node[property].expressions.length - 1]);
+}
+
+function validPropType(propType) {
+  return !propType.node || propType.node.kind !== 'init';
 }
 
 const Lists = new WeakMap();
@@ -154,9 +161,9 @@ class Components {
       props,
       {
         usedPropTypes: mergeUsedPropTypes(
-          component.usedPropTypes || [],
-          props.usedPropTypes || []
-        )
+          component.usedPropTypes,
+          props.usedPropTypes
+        ) || []
       }
     );
   }
@@ -188,11 +195,11 @@ class Components {
         }
         if (component) {
           const componentUsedPropTypes = val.usedPropTypes;
-          const newUsedProps = componentUsedPropTypes && componentUsedPropTypes.filter((propType) => !propType.node || propType.node.kind !== 'init');
+          const newUsedProps = componentUsedPropTypes && componentUsedPropTypes.filter(validPropType);
 
           const componentId = getId(component.node);
 
-          usedPropTypes[componentId] = mergeUsedPropTypes(usedPropTypes[componentId] || [], newUsedProps || []) || [];
+          usedPropTypes[componentId] = mergeUsedPropTypes(usedPropTypes[componentId], newUsedProps) || [];
         }
       }
     }
@@ -203,7 +210,7 @@ class Components {
         const id = getId(thisList[j].node);
         list[j] = thisList[j];
         if (usedPropTypes[id]) {
-          list[j].usedPropTypes = mergeUsedPropTypes(list[j].usedPropTypes || [], usedPropTypes[id]) || [];
+          list[j].usedPropTypes = mergeUsedPropTypes(list[j].usedPropTypes, usedPropTypes[id]) || [];
         }
       }
     }
@@ -219,24 +226,39 @@ class Components {
    */
   length() {
     const list = Lists.get(this);
-    return Object.keys(list).filter((i) => list[i].confidence >= 2).length;
+    return values(list).reduce((count, val) => (val.confidence >= 2 ? count + 1 : count), 0);
   }
 }
 
 function getWrapperFunctions(context, pragma) {
-  const componentWrapperFunctions = context.settings.componentWrapperFunctions || [];
+  const componentWrapperFunctions = context.settings.componentWrapperFunctions;
 
-  // eslint-disable-next-line arrow-body-style
-  return componentWrapperFunctions.map((wrapperFunction) => {
-    return typeof wrapperFunction === 'string'
-      ? {property: wrapperFunction}
-      : Object.assign({}, wrapperFunction, {
-        object: wrapperFunction.object === '<pragma>' ? pragma : wrapperFunction.object
-      });
-  }).concat([
+  const extras = [
     {property: 'forwardRef', object: pragma},
     {property: 'memo', object: pragma}
-  ]);
+  ];
+
+  if (componentWrapperFunctions && componentWrapperFunctions.length > 0) {
+    const pragmaWrapper = {
+      object: pragma
+    };
+    return componentWrapperFunctions.map(
+      (wrapperFunction) => {
+        if (typeof wrapperFunction === 'string') {
+          return {property: wrapperFunction};
+        }
+        return wrapperFunction.object === '<pragma>'
+          ? Object.assign({}, wrapperFunction, pragmaWrapper)
+          : wrapperFunction;
+      })
+      .concat(extras);
+  }
+
+  return extras;
+}
+
+function isNameComponentOrPureComponent(tag) {
+  return tag.name === 'React.Component' || tag.name === 'React.PureComponent';
 }
 
 function componentRule(rule, context) {
@@ -312,9 +334,7 @@ function componentRule(rule, context) {
         tags: ['extends', 'augments']
       });
 
-      const relevantTags = commentAst.tags.filter((tag) => tag.name === 'React.Component' || tag.name === 'React.PureComponent');
-
-      return relevantTags.length > 0;
+      return commentAst.tags.some(isNameComponentOrPureComponent);
     },
 
     /**
@@ -501,19 +521,23 @@ function componentRule(rule, context) {
       }
 
       const returnsConditionalJSX = isReturnsConditionalJSX(node, property, strict);
+      if (returnsConditionalJSX) {
+        return true;
+      }
       const returnsLogicalJSX = isReturnsLogicalJSX(node, property, strict);
+      if (returnsLogicalJSX) {
+        return true;
+      }
       const returnsSequentialJSX = isReturnsSequentialJSX(node, property);
-
+      if (returnsSequentialJSX) {
+        return true;
+      }
       const returnsJSX = node[property] && jsxUtil.isJSX(node[property]);
+      if (returnsJSX) {
+        return true;
+      }
       const returnsPragmaCreateElement = this.isCreateElement(node[property]);
-
-      return !!(
-        returnsConditionalJSX
-        || returnsLogicalJSX
-        || returnsSequentialJSX
-        || returnsJSX
-        || returnsPragmaCreateElement
-      );
+      return !!returnsPragmaCreateElement;
     },
 
     /**
@@ -628,8 +652,7 @@ function componentRule(rule, context) {
      */
     nodeWrapsComponent(node) {
       const childComponent = this.getNameOfWrappedComponent(node.arguments);
-      const componentList = this.getDetectedComponents();
-      return !!childComponent && arrayIncludes(componentList, childComponent);
+      return !!childComponent && arrayIncludes(this.getDetectedComponents(), childComponent);
     },
 
     isPragmaComponentWrapper(node) {

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -264,6 +264,7 @@ function isNameComponentOrPureComponent(tag) {
 function componentRule(rule, context) {
   const createClass = pragmaUtil.getCreateClassFromContext(context);
   const pragma = pragmaUtil.getFromContext(context);
+  let pragmaLowerCase;
   const sourceCode = context.getSourceCode();
   const components = new Components();
   const wrapperFunctions = getWrapperFunctions(context, pragma);
@@ -403,9 +404,11 @@ function componentRule(rule, context) {
               && requireExpression.callee
               && requireExpression.callee.name === 'require'
               && requireExpression.arguments[0]
-              && requireExpression.arguments[0].value === pragma.toLocaleLowerCase()
             ) {
-              return true;
+              pragmaLowerCase = pragmaLowerCase || pragma.toLocaleLowerCase();
+              if (requireExpression.arguments[0].value === pragmaLowerCase) {
+                return true;
+              }
             }
 
             return false;
@@ -415,9 +418,11 @@ function componentRule(rule, context) {
           if (
             latestDef.parent
             && latestDef.parent.type === 'ImportDeclaration'
-            && latestDef.parent.source.value === pragma.toLocaleLowerCase()
           ) {
-            return true;
+            pragmaLowerCase = pragmaLowerCase || pragma.toLocaleLowerCase();
+            if (latestDef.parent.source.value === pragmaLowerCase) {
+              return true;
+            }
           }
         }
       }

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -27,7 +27,12 @@ function usedPropTypesAreEquivalent(propA, propB) {
     if (!propA.allNames && !propB.allNames) {
       return true;
     }
-    if (Array.isArray(propA.allNames) && Array.isArray(propB.allNames) && propA.allNames.join('') === propB.allNames.join('')) {
+    if (Array.isArray(propA.allNames)
+      && Array.isArray(propB.allNames)
+      && (
+        (propA.allNames === propB.allNames)
+        || propA.allNames.join('') === propB.allNames.join('')
+      )) {
       return true;
     }
     return false;
@@ -235,6 +240,10 @@ function componentRule(rule, context) {
   const components = new Components();
   const wrapperFunctions = getWrapperFunctions(context, pragma);
 
+  let es5ComponentRegex;
+  let es6ComponentRegex;
+  let pureComponentRegex;
+
   // Utilities for component detection
   const utils = {
 
@@ -248,7 +257,8 @@ function componentRule(rule, context) {
       if (!node.parent) {
         return false;
       }
-      return new RegExp(`^(${pragma}\\.)?${createClass}$`).test(sourceCode.getText(node.parent.callee));
+      es5ComponentRegex = es5ComponentRegex || new RegExp(`^(${pragma}\\.)?${createClass}$`);
+      return es5ComponentRegex.test(sourceCode.getText(node.parent.callee));
     },
 
     /**
@@ -265,7 +275,8 @@ function componentRule(rule, context) {
       if (!node.superClass) {
         return false;
       }
-      return new RegExp(`^(${pragma}\\.)?(Pure)?Component$`).test(sourceCode.getText(node.superClass));
+      es6ComponentRegex = es6ComponentRegex || new RegExp(`^(${pragma}\\.)?(Pure)?Component$`);
+      return es6ComponentRegex.test(sourceCode.getText(node.superClass));
     },
 
     /**
@@ -308,7 +319,8 @@ function componentRule(rule, context) {
      */
     isPureComponent(node) {
       if (node.superClass) {
-        return new RegExp(`^(${pragma}\\.)?PureComponent$`).test(sourceCode.getText(node.superClass));
+        pureComponentRegex = pureComponentRegex || new RegExp(`^(${pragma}\\.)?PureComponent$`);
+        return pureComponentRegex.test(sourceCode.getText(node.superClass));
       }
       return false;
     },

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -173,35 +173,41 @@ class Components {
     const usedPropTypes = {};
 
     // Find props used in components for which we are not confident
-    Object.keys(thisList).filter((i) => thisList[i].confidence < 2).forEach((i) => {
-      let component = null;
-      let node = null;
-      node = thisList[i].node;
-      while (!component && node.parent) {
-        node = node.parent;
-        // Stop moving up if we reach a decorator
-        if (node.type === 'Decorator') {
-          break;
+    for (const val of values(thisList)) {
+      if (val.confidence < 2) {
+        let component = null;
+        let node = null;
+        node = val.node;
+        while (!component && node.parent) {
+          node = node.parent;
+          // Stop moving up if we reach a decorator
+          if (node.type === 'Decorator') {
+            break;
+          }
+          component = this.get(node);
         }
-        component = this.get(node);
-      }
-      if (component) {
-        const newUsedProps = (thisList[i].usedPropTypes || []).filter((propType) => !propType.node || propType.node.kind !== 'init');
+        if (component) {
+          const componentUsedPropTypes = val.usedPropTypes;
+          const newUsedProps = componentUsedPropTypes && componentUsedPropTypes.filter((propType) => !propType.node || propType.node.kind !== 'init');
 
-        const componentId = getId(component.node);
+          const componentId = getId(component.node);
 
-        usedPropTypes[componentId] = mergeUsedPropTypes(usedPropTypes[componentId] || [], newUsedProps);
+          usedPropTypes[componentId] = mergeUsedPropTypes(usedPropTypes[componentId] || [], newUsedProps || []) || [];
+        }
       }
-    });
+    }
 
     // Assign used props in not confident components to the parent component
-    Object.keys(thisList).filter((j) => thisList[j].confidence >= 2).forEach((j) => {
-      const id = getId(thisList[j].node);
-      list[j] = thisList[j];
-      if (usedPropTypes[id]) {
-        list[j].usedPropTypes = mergeUsedPropTypes(list[j].usedPropTypes || [], usedPropTypes[id]);
+    for (const j of Object.keys(thisList)) {
+      if (thisList[j].confidence >= 2) {
+        const id = getId(thisList[j].node);
+        list[j] = thisList[j];
+        if (usedPropTypes[id]) {
+          list[j].usedPropTypes = mergeUsedPropTypes(list[j].usedPropTypes || [], usedPropTypes[id]) || [];
+        }
       }
-    });
+    }
+
     return list;
   }
 

--- a/lib/util/annotations.js
+++ b/lib/util/annotations.js
@@ -19,12 +19,20 @@ function isAnnotatedFunctionPropsDeclaration(node, context) {
 
   const typeNode = node.params[0].type === 'AssignmentPattern' ? node.params[0].left : node.params[0];
 
-  const tokens = context.getFirstTokens(typeNode, 2);
   const isAnnotated = typeNode.typeAnnotation;
   const isDestructuredProps = typeNode.type === 'ObjectPattern';
-  const isProps = tokens[0].value === 'props' || (tokens[1] && tokens[1].value === 'props');
 
-  return (isAnnotated && (isDestructuredProps || isProps));
+  if (isAnnotated) {
+    if (isDestructuredProps) {
+      return true;
+    }
+
+    const tokens = context.getFirstTokens(typeNode, 2);
+    const isProps = tokens[0].value === 'props' || (tokens[1] && tokens[1].value === 'props');
+    return isProps;
+  }
+
+  return false;
 }
 
 module.exports = {

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -79,6 +79,11 @@ function getComponentProperties(node) {
   }
 }
 
+function getLastNewLine(string) {
+  const match = string.match(/\n(.*)$/);
+  return match ? match[1] : string;
+}
+
 /**
  * Gets the first node in a line from the initial node, excluding whitespace.
  * @param {Object} context The node to check
@@ -92,11 +97,11 @@ function getFirstNodeInLine(context, node) {
   do {
     token = sourceCode.getTokenBefore(token);
     lines = token.type === 'JSXText'
-      ? token.value.split('\n')
+      ? getLastNewLine(token.value)
       : null;
   } while (
     token.type === 'JSXText'
-        && /^\s*$/.test(lines[lines.length - 1])
+        && /^\s*$/.test(lines)
   );
   return token;
 }

--- a/lib/util/ast.js
+++ b/lib/util/ast.js
@@ -4,6 +4,8 @@
 
 'use strict';
 
+const PROPERTY_NAME_TYPES = ['MethodDefinition', 'Property'];
+
 /**
  * Find a return statment in the current node
  *
@@ -43,7 +45,7 @@ function findReturnStatement(node) {
  * @returns {Object} Property name node.
  */
 function getPropertyNameNode(node) {
-  if (node.key || ['MethodDefinition', 'Property'].indexOf(node.type) !== -1) {
+  if (node.key || PROPERTY_NAME_TYPES.indexOf(node.type) !== -1) {
     return node.key;
   }
   if (node.type === 'MemberExpression') {

--- a/lib/util/isFirstLetterCapitalized.js
+++ b/lib/util/isFirstLetterCapitalized.js
@@ -9,8 +9,7 @@ function isFirstLetterCapitalized(word) {
   if (!word) {
     return false;
   }
-  const firstLetter = word.charAt(0);
-  return firstLetter.toUpperCase() === firstLetter;
+  return /^[A-Z]/.test(word);
 }
 
 module.exports = isFirstLetterCapitalized;

--- a/lib/util/jsx.js
+++ b/lib/util/jsx.js
@@ -49,13 +49,15 @@ function isFragment(node, reactPragma, fragmentPragma) {
   return false;
 }
 
+const VALID_NODE_TYPES = ['JSXElement', 'JSXFragment'];
+
 /**
  * Checks if a node represents a JSX element or fragment.
  * @param {object} node - node to check.
  * @returns {boolean} Whether or not the node if a JSX element or fragment.
  */
 function isJSX(node) {
-  return node && ['JSXElement', 'JSXFragment'].indexOf(node.type) >= 0;
+  return node && VALID_NODE_TYPES.indexOf(node.type) >= 0;
 }
 
 /**

--- a/lib/util/linkComponents.js
+++ b/lib/util/linkComponents.js
@@ -12,7 +12,9 @@ const DEFAULT_LINK_ATTRIBUTE = 'href';
 function getLinkComponents(context) {
   const settings = context.settings || {};
   const linkComponents = /** @type {typeof DEFAULT_LINK_COMPONENTS} */ (
-    DEFAULT_LINK_COMPONENTS.concat(settings.linkComponents || [])
+    settings.linkComponents
+      ? DEFAULT_LINK_COMPONENTS.concat(settings.linkComponents)
+      : DEFAULT_LINK_COMPONENTS
   );
   return new Map(linkComponents.map((value) => {
     if (typeof value === 'string') {

--- a/lib/util/propWrapper.js
+++ b/lib/util/propWrapper.js
@@ -5,21 +5,24 @@
 'use strict';
 
 function getPropWrapperFunctions(context) {
-  return new Set(context.settings.propWrapperFunctions || []);
+  return new Set(context.settings.propWrapperFunctions || null);
 }
 
 function isPropWrapperFunction(context, name) {
   if (typeof name !== 'string') {
     return false;
   }
-  const propWrapperFunctions = getPropWrapperFunctions(context);
-  const splitName = name.split('.');
-  return Array.from(propWrapperFunctions).some((func) => {
-    if (splitName.length === 2 && func.object === splitName[0] && func.property === splitName[1]) {
-      return true;
-    }
-    return name === func || func.property === name;
-  });
+  const propWrapperFunctions = context.settings.propWrapperFunctions;
+  if (propWrapperFunctions && propWrapperFunctions.length > 0) {
+    const splitName = name.split('.');
+    return propWrapperFunctions.some((func) => {
+      if (splitName.length === 2 && func.object === splitName[0] && func.property === splitName[1]) {
+        return true;
+      }
+      return name === func || func.property === name;
+    });
+  }
+  return false;
 }
 
 module.exports = {

--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -447,18 +447,20 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
   }
 
   function handleCustomValidators(component) {
-    const propTypes = component.declaredPropTypes;
-    if (!propTypes) {
-      return;
-    }
-
-    values(propTypes).forEach((val) => {
-      const node = val.node;
-
-      if (node.value && astUtil.isFunctionLikeExpression(node.value)) {
-        markPropTypesAsUsed(node.value);
+    if (mustBeValidated(component)) {
+      const propTypes = component.declaredPropTypes;
+      if (!propTypes) {
+        return;
       }
-    });
+
+      values(propTypes).forEach((val) => {
+        const node = val.node;
+
+        if (node.value && astUtil.isFunctionLikeExpression(node.value)) {
+          markPropTypesAsUsed(node.value);
+        }
+      });
+    }
   }
 
   return {
@@ -555,7 +557,7 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
     'Program:exit'() {
       const list = components.list();
 
-      values(list).filter((component) => mustBeValidated(component)).forEach(handleCustomValidators);
+      values(list).forEach(handleCustomValidators);
     }
   };
 };

--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -4,6 +4,7 @@
 
 'use strict';
 
+const values = require('object.values');
 const astUtil = require('./ast');
 const versionUtil = require('./version');
 const ast = require('./ast');
@@ -451,8 +452,8 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
       return;
     }
 
-    Object.keys(propTypes).forEach((key) => {
-      const node = propTypes[key].node;
+    values(propTypes).forEach((val) => {
+      const node = val.node;
 
       if (node.value && astUtil.isFunctionLikeExpression(node.value)) {
         markPropTypesAsUsed(node.value);
@@ -554,9 +555,7 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
     'Program:exit'() {
       const list = components.list();
 
-      Object.keys(list).filter((component) => mustBeValidated(list[component])).forEach((component) => {
-        handleCustomValidators(list[component]);
-      });
+      values(list).filter((component) => mustBeValidated(component)).forEach(handleCustomValidators);
     }
   };
 };

--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -70,6 +70,15 @@ function detectReactVersion(context) {
   }
 }
 
+const isANumber = (part) => typeof part === 'number';
+
+function normalizeParts(parts) {
+  if (parts.length === 3 && parts.every(isANumber)) {
+    return parts;
+  }
+  return Array.from({length: 3}, (_, i) => (parts[i] || 0));
+}
+
 function getReactVersionFromContext(context) {
   let confVer = '999.999.999';
   // .eslintrc shared settings (http://eslint.org/docs/user-guide/configuring#adding-shared-settings)
@@ -89,7 +98,7 @@ function getReactVersionFromContext(context) {
     warnedForMissingVersion = true;
   }
   confVer = /^[0-9]+\.[0-9]+$/.test(confVer) ? `${confVer}.0` : confVer;
-  return confVer.split('.').map((part) => Number(part));
+  return normalizeParts(confVer.split('.').map(Number));
 }
 
 // TODO, semver-major: remove context fallback
@@ -127,34 +136,45 @@ function getFlowVersionFromContext(context) {
     throw 'Could not retrieve flowVersion from settings'; // eslint-disable-line no-throw-literal
   }
   confVer = /^[0-9]+\.[0-9]+$/.test(confVer) ? `${confVer}.0` : confVer;
-  return confVer.split('.').map((part) => Number(part));
+  return normalizeParts(confVer.split('.').map(Number));
 }
 
-function normalizeParts(parts) {
-  return Array.from({length: 3}, (_, i) => (parts[i] || 0));
+function isLessThan(a, b) {
+  const higherMajor = a[0] < b[0];
+  if (higherMajor) {
+    return true;
+  }
+  const higherMinor = a[0] === b[0] && a[1] < b[1];
+  if (higherMinor) {
+    return true;
+  }
+  const higherOrEqualPatch = a[0] === b[0]
+    && a[1] === b[1]
+    && a[2] <= b[2];
+  return higherOrEqualPatch;
 }
 
-function test(context, methodVer, confVer) {
-  const methodVers = normalizeParts(String(methodVer || '').split('.').map((part) => Number(part)));
-  const confVers = normalizeParts(confVer);
-  const higherMajor = methodVers[0] < confVers[0];
-  const higherMinor = methodVers[0] === confVers[0] && methodVers[1] < confVers[1];
-  const higherOrEqualPatch = methodVers[0] === confVers[0]
-    && methodVers[1] === confVers[1]
-    && methodVers[2] <= confVers[2];
-
-  return higherMajor || higherMinor || higherOrEqualPatch;
+function test(methodVer, confVer) {
+  const methodVers = normalizeParts(
+    (typeof methodVer === 'string'
+      ? methodVer
+      : String(methodVer || '')
+    ).split('.').map(Number)
+  );
+  return isLessThan(methodVers, confVer);
 }
 
 function testReactVersion(context, methodVer) {
-  return test(context, methodVer, getReactVersionFromContext(context));
+  return test(methodVer, getReactVersionFromContext(context));
 }
 
 function testFlowVersion(context, methodVer) {
-  return test(context, methodVer, getFlowVersionFromContext(context));
+  return test(methodVer, getFlowVersionFromContext(context));
 }
 
 module.exports = {
+  getReactVersionFromContext,
+  isLessThan,
   testReactVersion,
   testFlowVersion,
   resetWarningFlag,

--- a/tests/util/isFirstLetterCapitalized.js
+++ b/tests/util/isFirstLetterCapitalized.js
@@ -20,4 +20,11 @@ describe('isFirstLetterCapitalized', () => {
     assert.equal(isFirstLetterCapitalized('IsCapitalized'), true);
     assert.equal(isFirstLetterCapitalized('UPPERCASE'), true);
   });
+
+  it('should return false for non-letters', () => {
+    assert.strictEqual(isFirstLetterCapitalized('42'), false);
+    assert.strictEqual(isFirstLetterCapitalized('!'), false);
+    assert.strictEqual(isFirstLetterCapitalized('$$$'), false);
+    assert.strictEqual(isFirstLetterCapitalized(' Space'), false);
+  });
 });


### PR DESCRIPTION
Hello!
eslint-plugin-react is an amazing plugin - it catches so many problems that I consider it indispensable :) 

Recently on a large-ish project I noticed some of the rules running relatively slowly, so I decided to see if I could speed them up.
In the end I was able to find quite a few opportunities to do less work, mainly by avoiding memory allocations.

I'd really appreciate any feedback on better ways to benchmark the plugin, and how safe these optimisations are.
They pass all the tests, though I appreciate it's not always possible to be 100% confident changes are correct, especially given the large number of changes here - luckily most of them are relatively localised.
I've tried to avoid changing the existing logic as much as possible, though sometimes speed has been picked over readability - I'd appreciate any thoughts on that too.
I've tried to make sure the changes will work on node 4, but that probably needs more thorough testing.

There's a list of the changes summarised at the bottom of this message. Thanks!

---

Benchmark results:

The project I benchmarked this against using `cloc` registers as about 550 files, with about 50k lines of code in .tsx files all containing React components.
The changes knock off about 70 - 100ms off the slowest rules, roughly 30% faster, with a sample result here:
```
Rule                                       | Time (ms) | Relative
:------------------------------------------|----------:|--------:
react/jsx-indent                           |   365.723 |     5.8%
react/no-deprecated                        |   296.861 |     4.7%
react/boolean-prop-naming                  |   286.611 |     4.6%
react/destructuring-assignment             |   283.235 |     4.5%
react/no-unstable-nested-components        |   172.198 |     2.7%
react/no-access-state-in-setstate          |   169.871 |     2.7%
react/jsx-no-bind                          |   161.568 |     2.6%
react/no-direct-mutation-state             |   155.857 |     2.5%
react/prefer-stateless-function            |   150.361 |     2.4%
react/display-name                         |   147.024 |     2.3%
react/no-string-refs                       |   144.832 |     2.3%
react/jsx-sort-props                       |   142.020 |     2.3%
react/no-typos                             |   141.018 |     2.2%
react/default-props-match-prop-types       |   140.545 |     2.2%
react/void-dom-elements-no-children        |   139.404 |     2.2%
```
to
```
Rule                                       | Time (ms) | Relative
:------------------------------------------|----------:|--------:
react/jsx-indent                           |   264.386 |     6.4%
react/boolean-prop-naming                  |   176.753 |     4.3%
react/destructuring-assignment             |   146.563 |     3.6%
react/jsx-sort-props                       |   142.513 |     3.5%
react/no-access-state-in-setstate          |   117.366 |     2.8%
react/no-deprecated                        |   109.879 |     2.7%
react/no-direct-mutation-state             |   107.110 |     2.6%
react/void-dom-elements-no-children        |    98.467 |     2.4%
react/display-name                         |    97.823 |     2.4%
react/no-unstable-nested-components        |    95.287 |     2.3%
react/jsx-no-bind                          |    94.966 |     2.3%
react/default-props-match-prop-types       |    92.893 |     2.3%
react/sort-comp                            |    91.416 |     2.2%
react/prefer-stateless-function            |    86.666 |     2.1%
react/no-typos                             |    84.784 |     2.1%
```

I used the following .eslintrc.js:
```
module.exports = {
  root: true,
  parser: "@typescript-eslint/parser",
  settings: {
    react: {
      pragma: "React",
      fragment: "Fragment",
      version: "detect",
    },
  },
  extends: ["plugin:react/all"],
}
```
with the versions:
```
    "eslint": "^7.25.0",
    "eslint-plugin-react": "^7.23.2",
    "@typescript-eslint/eslint-plugin": "^4.22.0",
    "@typescript-eslint/parser": "^4.22.0",
```
across the .tsx files in the project, 200 times by running:
```
$ script timings
$ for i in {1..200}; do TIMING=100 npx eslint . --ext tsx -o eslintlog; done
````
for both `7.23.2` and then with the `lib` directory swapped in from this branch.

I then averaged all 200 runs in this google sheet:
https://docs.google.com/spreadsheets/d/1Y5QZ_tsAyXrzgw5Rre21Gmzl95jT9irZmxfwSeF1oI0/edit?usp=sharing

---
Optimisations:

- Avoid allocating empty objects or arrays when possible
- Combine filter -> forEach chains
- Replace Object.keys with values/entries where possible
- Extract deeply nested functions to avoid reallocation
- Push expensive operations below guards / early returns
- Promote shared or mostly-constant conditionals
- Swap compound boolean expressions to proriotise cheap short circuiting
- Avoid dynamically generating RegExps when possible
- Lazily initialise and cache complex objects and necessarily dynamic RegExps
- Move expensive and shared calculations to higher scopes
- Replace string splits and trims with RegExps
- Avoid redundant array concatenations
- Split expensive conditional checks across multiple guards
- Move expensive booleans into conditional expressions to exploit short circuiting
- Swap out filters for finds where possible
- Turn arrays into objects/map/dictionary lookups where possible
- Swap array function orders where safe and efficient
- Cache string transformations