### PR TITLE
[Refactor] `void-dom-elements-no-children`: improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Changed
 * [Docs] [`jsx-newline`]: Fix minor spelling error on rule name ([#2974][] @DennisSkoko)
+* [Refactor] [`void-dom-elements-no-children`]: improve performance
 
+[#2977]: https://github.com/yannickcr/eslint-plugin-react/pull/2977
 [#2975]: https://github.com/yannickcr/eslint-plugin-react/pull/2975
 [#2974]: https://github.com/yannickcr/eslint-plugin-react/pull/2974
 [#2972]: https://github.com/yannickcr/eslint-plugin-react/pull/2972

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -393,25 +393,29 @@ function componentRule(rule, context) {
      * @returns {Boolean} True if createElement called from pragma
      */
     isCreateElement(node) {
-      const calledOnPragma = (
+      // match `React.createElement()`
+      if (
         node
         && node.callee
         && node.callee.object
         && node.callee.object.name === pragma
         && node.callee.property
         && node.callee.property.name === 'createElement'
-      );
+      ) {
+        return true;
+      }
 
-      const calledDirectly = (
+      // match `createElement()`
+      if (
         node
         && node.callee
         && node.callee.name === 'createElement'
-      );
-
-      if (this.isDestructuredFromPragmaImport('createElement')) {
-        return calledDirectly || calledOnPragma;
+        && this.isDestructuredFromPragmaImport('createElement')
+      ) {
+        return true;
       }
-      return calledOnPragma;
+
+      return false;
     },
 
     /**


### PR DESCRIPTION
closes #1126.

The rule spends lots of time in`utils.isCreateElement` -> `isDestructuredFromPragmaImport`.  This pr reduces that expensive function call by short-circuiting it when possible.

Benchmarks:
```
Before this pr:
$ TIMING=50 npx eslint . | grep react/void-dom
react/void-dom-elements-no-children             |   263.673 |     3.6%
react/void-dom-elements-no-children             |   256.981 |     3.4%
react/void-dom-elements-no-children             |   230.990 |     3.3%
react/void-dom-elements-no-children             |   235.888 |     3.2%
react/void-dom-elements-no-children             |   251.152 |     3.5%

After this pr:
react/void-dom-elements-no-children             |   106.662 |     1.6%
react/void-dom-elements-no-children             |   106.205 |     1.6%
react/void-dom-elements-no-children             |   106.061 |     1.6%
react/void-dom-elements-no-children             |   103.666 |     1.6%
react/void-dom-elements-no-children             |   103.363 |     1.6%
```