### PR TITLE
Add jsx-sort-props ignoreTags option

### DIFF
--- a/docs/rules/jsx-sort-props.md
+++ b/docs/rules/jsx-sort-props.md
@@ -98,6 +98,16 @@ With `reservedFirst: ["key"]`, the following will **not** warn:
 <Hello key={'uuid'} name="John" ref="ref" />
 ```
 
+### `ignoreTags`
+
+An array of element (tag) names to ignore when checking the properties order.
+
+With `ignoreTags: ["Can"]`, the following will **not** warn:
+
+```jsx
+<Can i="create" a="post" />
+```
+
 ## When not to use
 
 This rule is a formatting preference and not following it won't negatively affect the quality of your code. If alphabetizing props isn't a part of your coding standards, then you can leave this rule off.

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -249,6 +249,9 @@ module.exports = {
         },
         reservedFirst: {
           type: ['array', 'boolean']
+        },
+        ignoreTags: {
+          type: 'array'
         }
       },
       additionalProperties: false
@@ -265,9 +268,27 @@ module.exports = {
     const reservedFirst = configuration.reservedFirst || false;
     const reservedFirstError = validateReservedFirstConfig(context, reservedFirst);
     let reservedList = Array.isArray(reservedFirst) ? reservedFirst : RESERVED_PROPS_LIST;
+    const ignoreTags = configuration.ignoreTags || [];
+    const getTagNameFromMemberExpression = (node) => `${node.property.parent.object.name}.${node.property.name}`;
 
     return {
       JSXOpeningElement(node) {
+        if (ignoreTags.length > 0) {
+          const jsxOpeningElement = node.name;
+          const type = jsxOpeningElement.type;
+          let tagName;
+          if (type === 'JSXIdentifier') {
+            tagName = jsxOpeningElement.name;
+          } else if (type === 'JSXMemberExpression') {
+            tagName = getTagNameFromMemberExpression(jsxOpeningElement);
+          } else {
+            tagName = undefined;
+          }
+          if (tagName && ignoreTags.includes(tagName)) {
+            return;
+          }
+        }
+
         // `dangerouslySetInnerHTML` is only "reserved" on DOM components
         if (reservedFirst && !jsxUtil.isDOMComponent(node)) {
           reservedList = reservedList.filter((prop) => prop !== 'dangerouslySetInnerHTML');

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -99,6 +99,9 @@ const reservedFirstAsEmptyArrayArgs = [{
 const reservedFirstAsInvalidArrayArgs = [{
   reservedFirst: ['notReserved']
 }];
+const ignoreTagsApp = [{
+  ignoreTags: ['App']
+}];
 
 ruleTester.run('jsx-sort-props', rule, {
   valid: [
@@ -165,6 +168,10 @@ ruleTester.run('jsx-sort-props', rule, {
     {
       code: '<App key="key" c="c" b />',
       options: reservedFirstWithShorthandLast
+    },
+    {
+      code: '<App c b a />;',
+      options: ignoreTagsApp
     }
   ],
   invalid: [
@@ -484,6 +491,12 @@ ruleTester.run('jsx-sort-props', rule, {
       code: '<App key={5} />',
       options: reservedFirstAsInvalidArrayArgs,
       errors: [expectedInvalidReservedFirstError]
+    },
+    {
+      code: '<NoApp c b a />;',
+      options: ignoreTagsApp,
+      errors: [expectedError],
+      output: '<NoApp a b c />;'
     }
   ]
 });


### PR DESCRIPTION
This PR adds an ability to set ignored tags when checking the `jsx-sort-props` rule.

Generally, we like the idea of sorting props but in some cases it does not make sense. For example, when we use the `Can` component from [React CASL](https://casl.js.org/v4/en/package/casl-react):

```jsx
<Can I="create" a="post">
```

The rule forces us to sort props.

```jsx
<Can a="post" I="create">
```

We'd love to have an option to ignore some tags - which I propose here.

```
ignoreTags: ["Can"]
```

Tests and docs provided. The tag name detection code inside the rule has been "borrowed" from [jsx-props-no-spreading](https://github.com/yannickcr/eslint-plugin-react/blob/f24c353aca1225dbdd0d75a8e1c02d6b711b94c9/lib/rules/jsx-props-no-spreading.js).