### PR TITLE
[fix] `jsx-uses-vars`: ignore namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 * [`jsx-handler-names`]: properly substitute value into message ([#2975][] @G-Rath)
+* [`jsx-uses-vars`]: ignore namespaces ([#2985][] @remcohaszing)
 
 ### Changed
 * [Docs] [`jsx-newline`]: Fix minor spelling error on rule name ([#2974][] @DennisSkoko)
@@ -18,6 +19,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [readme] fix missing trailing commas ([#2980][] @sugardon)
 * [readme] fix broken anchor link ([#2982][] @vzvu3k6k)
 
+[#2985]: https://github.com/yannickcr/eslint-plugin-react/pull/2985
 [#2982]: https://github.com/yannickcr/eslint-plugin-react/pull/2982
 [#2980]: https://github.com/yannickcr/eslint-plugin-react/pull/2980
 [#2977]: https://github.com/yannickcr/eslint-plugin-react/pull/2977

--- a/lib/rules/jsx-uses-vars.js
+++ b/lib/rules/jsx-uses-vars.js
@@ -26,10 +26,11 @@ module.exports = {
     return {
       JSXOpeningElement(node) {
         let name;
-        if (node.name.namespace && node.name.namespace.name) {
+        if (node.name.namespace) {
           // <Foo:Bar>
-          name = node.name.namespace.name;
-        } else if (node.name.name) {
+          return;
+        }
+        if (node.name.name) {
           // <Foo>
           name = node.name.name;
         } else if (node.name.object) {

--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -82,12 +82,6 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
     }, {
       code: `
         /* eslint jsx-uses-vars: 1 */
-        var App;
-        <App:Hello />
-      `
-    }, {
-      code: `
-        /* eslint jsx-uses-vars: 1 */
         class HelloMessage {};
         <HelloMessage />
       `
@@ -143,7 +137,7 @@ ruleTester.run('no-unused-vars', ruleNoUnusedVars, {
         var Hello;
         React.render(<App:Hello/>);
       `,
-      errors: [{message: '\'Hello\' is defined but never used.'}]
+      errors: [{message: '\'App\' is defined but never used.'}, {message: '\'Hello\' is defined but never used.'}]
     }, {
       code: `
         /* eslint jsx-uses-vars: 1 */


### PR DESCRIPTION
JSX namespaces are transpiled into strings, not identifiers.

This can be seen in [here](https://www.typescriptlang.org/play?#code/MYewdgzgLgBAZiEMC8MA8BBAXAIRgegD4g) for TypeScript.

Babel behaves the same, but it requires a configuration which isn’t supported by their playground.