### PR TITLE
[fix] `jsx-no-undef`: ignore namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 * [`jsx-handler-names`]: properly substitute value into message ([#2975][] @G-Rath)
 * [`jsx-uses-vars`]: ignore namespaces ([#2985][] @remcohaszing)
+* [`jsx-no-undef`]: ignore namespaces ([#2986][] @remcohaszing)
 
 ### Changed
 * [Docs] [`jsx-newline`]: Fix minor spelling error on rule name ([#2974][] @DennisSkoko)
@@ -19,6 +20,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [readme] fix missing trailing commas ([#2980][] @sugardon)
 * [readme] fix broken anchor link ([#2982][] @vzvu3k6k)
 
+[#2986]: https://github.com/yannickcr/eslint-plugin-react/pull/2986
 [#2985]: https://github.com/yannickcr/eslint-plugin-react/pull/2985
 [#2982]: https://github.com/yannickcr/eslint-plugin-react/pull/2982
 [#2980]: https://github.com/yannickcr/eslint-plugin-react/pull/2980

--- a/lib/rules/jsx-no-undef.js
+++ b/lib/rules/jsx-no-undef.js
@@ -102,8 +102,7 @@ module.exports = {
             } while (node && node.type !== 'JSXIdentifier');
             break;
           case 'JSXNamespacedName':
-            node = node.name.namespace;
-            break;
+            return;
           default:
             break;
         }

--- a/tests/lib/rules/jsx-no-undef.js
+++ b/tests/lib/rules/jsx-no-undef.js
@@ -46,6 +46,8 @@ ruleTester.run('jsx-no-undef', rule, {
   }, {
     code: '/*eslint no-undef:1*/ var React, app; React.render(<app.foo.Bar />);'
   }, {
+    code: '/*eslint no-undef:1*/ var React; React.render(<Apppp:Foo />);'
+  }, {
     code: `
       /*eslint no-undef:1*/
       var React;
@@ -86,12 +88,6 @@ ruleTester.run('jsx-no-undef', rule, {
     errors: [{
       messageId: 'undefined',
       data: {identifier: 'Appp'}
-    }]
-  }, {
-    code: '/*eslint no-undef:1*/ var React; React.render(<Apppp:Foo />);',
-    errors: [{
-      messageId: 'undefined',
-      data: {identifier: 'Apppp'}
     }]
   }, {
     code: '/*eslint no-undef:1*/ var React; React.render(<appp.Foo />);',


### PR DESCRIPTION
JSX namespaces are transpiled into strings, not identifiers.

This can be seen in [here](https://www.typescriptlang.org/play?#code/MYewdgzgLgBAZiEMC8MA8BBAXAIRgegD4g) for TypeScript.

Babel behaves the same, but it requires a configuration which isn’t supported by their playground.