### PR TITLE
Don't flag whitespace around `<br/>` tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`jsx-handler-names`]: properly substitute value into message ([#2975][] @G-Rath)
 * [`jsx-uses-vars`]: ignore namespaces ([#2985][] @remcohaszing)
 * [`jsx-no-undef`]: ignore namespaces ([#2986][] @remcohaszing)
+* [`jsx-child-element-spacing`]: Don't flag whitespace around `<br/>` tags ([#2989][] @pascalpp)
 
 ### Changed
 * [Docs] [`jsx-newline`]: Fix minor spelling error on rule name ([#2974][] @DennisSkoko)
@@ -20,6 +21,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [readme] fix missing trailing commas ([#2980][] @sugardon)
 * [readme] fix broken anchor link ([#2982][] @vzvu3k6k)
 
+[#2989]: https://github.com/yannickcr/eslint-plugin-react/pull/2989
 [#2986]: https://github.com/yannickcr/eslint-plugin-react/pull/2986
 [#2985]: https://github.com/yannickcr/eslint-plugin-react/pull/2985
 [#2982]: https://github.com/yannickcr/eslint-plugin-react/pull/2982

--- a/lib/rules/jsx-child-element-spacing.js
+++ b/lib/rules/jsx-child-element-spacing.js
@@ -3,6 +3,8 @@
 const docsUrl = require('../util/docsUrl');
 
 // This list is taken from https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
+
+// Note: 'br' is not included because whitespace around br tags is inconsequential to the rendered output
 const INLINE_ELEMENTS = new Set([
   'a',
   'abbr',
@@ -10,7 +12,6 @@ const INLINE_ELEMENTS = new Set([
   'b',
   'bdo',
   'big',
-  'br',
   'button',
   'cite',
   'code',

--- a/tests/lib/rules/jsx-child-element-spacing.js
+++ b/tests/lib/rules/jsx-child-element-spacing.js
@@ -139,6 +139,31 @@ ruleTester.run('jsx-child-element-spacing', rule, {
         B
       </App>
     `
+  }, {
+    code: `
+      <App>
+        A
+        <br/>
+        B
+      </App>
+    `
+  }, {
+    code: `
+      <App>
+        A<br/>
+        B
+      </App>
+    `
+  }, {
+    code: `
+      <App>
+        A<br/>B
+      </App>
+    `
+  }, {
+    code: `
+      <App>A<br/>B</App>
+    `
   }],
 
   invalid: [{


### PR DESCRIPTION
Ref: https://github.com/yannickcr/eslint-plugin-react/issues/2988

This PR simply removes BR from the set of inline elements, because I don't think there's any case where whitespace around a br tag would result in a different result rendered in the browser.

Adds example tests for code that should not be flagged by this rule:

```
<App>
  A
  <br/>
  B
</App>

<App>
  A<br/>
  B
</App>

<App>
  A<br/>B
</App>

<App>A<br/>B</App>
```