### PR TITLE
[Fix] sets default for jsx-no-bind.ignoreRefs to true

### DIFF
--- a/docs/rules/jsx-no-bind.md
+++ b/docs/rules/jsx-no-bind.md
@@ -23,7 +23,7 @@ Examples of **correct** code for this rule:
 ```js
 "react/jsx-no-bind": [<enabled>, {
   "ignoreDOMComponents": <boolean> || false,
-  "ignoreRefs": <boolean> || false,
+  "ignoreRefs": <boolean> || true,
   "allowArrowFunctions": <boolean> || false,
   "allowFunctions": <boolean> || false,
   "allowBind": <boolean> || false

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -16,6 +16,10 @@ const jsxUtil = require('../util/jsx');
 // Rule Definition
 // -----------------------------------------------------------------------------
 
+const defaultOptions = {
+  ignoreRefs: true
+};
+
 module.exports = {
   meta: {
     docs: {
@@ -48,7 +52,7 @@ module.exports = {
           type: 'boolean'
         },
         ignoreRefs: {
-          default: false,
+          default: defaultOptions.ignoreRefs,
           type: 'boolean'
         },
         ignoreDOMComponents: {
@@ -61,7 +65,7 @@ module.exports = {
   },
 
   create: Components.detect((context) => {
-    const configuration = context.options[0] || {};
+    const configuration = Object.assign({}, defaultOptions, context.options[0]);
 
     // Keep track of all the variable names pointing to a bind call,
     // bind expression or an arrow function in different block statements

--- a/tests/lib/rules/jsx-no-bind.js
+++ b/tests/lib/rules/jsx-no-bind.js
@@ -42,18 +42,15 @@ ruleTester.run('jsx-no-bind', rule, {
       code: '<div onClick={getHandler()}></div>'
     },
 
-    // bind() and arrow functions in refs explicitly ignored
+    // bind() and arrow functions in refs explicitly allowed
     {
-      code: '<div ref={c => this._input = c}></div>',
-      options: [{ignoreRefs: true}]
+      code: '<div ref={c => this._input = c}></div>'
     },
     {
-      code: '<div ref={this._refCallback.bind(this)}></div>',
-      options: [{ignoreRefs: true}]
+      code: '<div ref={this._refCallback.bind(this)}></div>'
     },
     {
-      code: '<div ref={function (c) {this._input = c}}></div>',
-      options: [{ignoreRefs: true}]
+      code: '<div ref={function (c) {this._input = c}}></div>'
     },
 
     // bind() explicitly allowed
@@ -309,6 +306,7 @@ ruleTester.run('jsx-no-bind', rule, {
     },
     {
       code: '<div ref={this._refCallback.bind(this)}></div>',
+      options: [{ignoreRefs: false}],
       errors: [{messageId: 'bindCall'}]
     },
     {
@@ -478,6 +476,7 @@ ruleTester.run('jsx-no-bind', rule, {
     },
     {
       code: '<div ref={c => this._input = c}></div>',
+      options: [{ignoreRefs: false}],
       errors: [{messageId: 'arrowFunc'}]
     },
     {
@@ -593,6 +592,7 @@ ruleTester.run('jsx-no-bind', rule, {
     },
     {
       code: '<div ref={function (c) { this._input = c }}></div>',
+      options: [{ignoreRefs: false}],
       errors: [{messageId: 'func'}]
     },
     {


### PR DESCRIPTION
## TL;DR
Refs are special.  Inline arrow functions in refs do not cause re-renders like they do for props.

## Context
The `jsx-no-bind` rule exists to prevent users from a common (and easy to make) mistake where unnecessary renders occur.  This makes sense for props, but there are two special cases to this, `ref`, and `key`.  For the longest time both of these were value types (strings), but later on `ref` patterns emerged that used callbacks.

## Problem
I have seen many codebases that do things like:
```ts
  setRef(container: HTMLDivElement | null) {
    this.container = container;
  }
```
in react component classes out of a misunderstanding and an over-generalization of the `jsx-no-bind` rule.

## Demo
I prepared a demo that demonstrates what I'm talking about, https://codesandbox.io/s/inline-arrow-refs-do-not-cause-rerenders-4cdmf?file=/src/App.js.

<img height="300" src="https://user-images.githubusercontent.com/15232461/118696553-6596c580-b7dc-11eb-9212-190e657044d6.png" />


## Solution
This PR switches the default of `ignoreRefs` from `false` to `true`.

## One step further
I believe that it's not a matter of preference, and that even encouraging users to do `setRef` above is a clear antipattern.  I believe it is an antipattern because it reinforces a misunderstanding about how refs actually work in react.  Despite that, I'm trying to be considerate to people that like things how they like things.  Due to that, instead of removing `ignoreRefs` altogether (and hardcoding the behavior to what `true` functions as today), I've oped to make a PR that just switches the default.