### PR TITLE
[Fix] `destructuring-assignment`: get the contextName correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * component detection: use `estraverse` to improve component detection ([#2992][] @Wesitos)
 * [`destructuring-assignment`], [`no-multi-comp`], [`no-unstable-nested-components`], component detection: improve component detection ([#3001][] @vedadeepta)
 * [`no-deprecated`]: fix crash on rest elements ([#3016][] @ljharb)
+* [`destructuring-assignment`]: get the contextName correctly ([#3025][] @ohhoney1)
 
 ### Changed
 * [Docs] [`jsx-no-bind`]: updates discussion of refs ([#2998][] @dimitropoulos)
 * [Refactor] `utils/Components`: correct spelling and delete unused code ([#3026][] @ohhoney1)
 
 [#3026]: https://github.com/yannickcr/eslint-plugin-react/pull/3026
+[#3025]: https://github.com/yannickcr/eslint-plugin-react/pull/3025
 [#3016]: https://github.com/yannickcr/eslint-plugin-react/issues/3016
 [#3006]: https://github.com/yannickcr/eslint-plugin-react/pull/3006
 [#3001]: https://github.com/yannickcr/eslint-plugin-react/pull/3001

--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -32,7 +32,7 @@ function createSFCParams() {
         const context = params[1];
         return context && !context.destructuring && context.name;
       });
-      return found && found[1] && found.name;
+      return found && found[1] && found[1].name;
     }
   };
 }

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -180,9 +180,9 @@ ruleTester.run('destructuring-assignment', rule, {
   // https://github.com/yannickcr/eslint-plugin-react/issues/2911
   {
     code: `
-      function Foo({context}) {
-        const d = context.describe()
-        return <div>{d}</div>
+      function Foo({ context }) {
+        const d = context.describe();
+        return <div>{d}</div>;
       }
     `,
     options: ['always'],
@@ -411,6 +411,19 @@ ruleTester.run('destructuring-assignment', rule, {
     errors: [{
       messageId: 'useDestructAssignment',
       data: {type: 'props'}
+    }]
+  }, {
+    code: `
+      function Foo(props, context) {
+        const d = context.describe();
+        return <div>{d}</div>;
+      }
+    `,
+    options: ['always'],
+    parser: parsers.BABEL_ESLINT,
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'context'}
     }]
   }]
 });


### PR DESCRIPTION
correct #2929, for issue #2911