### PR TITLE
[Fix] destructuring-assignment, component detection: handle default export edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`no-deprecated`]: fix crash on rest elements ([#3016][] @ljharb)
 * [`destructuring-assignment`]: get the contextName correctly ([#3025][] @ohhoney1)
 * [`no-typos`]: prevent crash on styled components and forwardRefs ([#3036][] @ljharb)
+* [`destructuring-assignment`], component detection: handle default exports edge case ([#3038][] @vedadeepta)
 
 ### Changed
 * [Docs] [`jsx-no-bind`]: updates discussion of refs ([#2998][] @dimitropoulos)
@@ -23,6 +24,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [Docs] [`jsx-uses-react`], [`react-in-jsx-scope`]: document [`react/jsx-runtime`] config ([#3018][] @pkuczynski @ljharb)
 * [Docs] [`require-default-props`]: fix small typo ([#2994][] @evsasse)
 
+[#3038]: https://github.com/yannickcr/eslint-plugin-react/pull/3038
 [#3036]: https://github.com/yannickcr/eslint-plugin-react/issues/3036
 [#3026]: https://github.com/yannickcr/eslint-plugin-react/pull/3026
 [#3025]: https://github.com/yannickcr/eslint-plugin-react/pull/3025

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -617,6 +617,13 @@ function componentRule(rule, context) {
       }
 
       if (node.type === 'FunctionExpression' || node.type === 'ArrowFunctionExpression') {
+        if (node.parent.type === 'ExportDefaultDeclaration') {
+          if (utils.isReturningJSX(node)) {
+            return node;
+          }
+          return undefined;
+        }
+
         if (node.parent.type === 'VariableDeclarator' && utils.isReturningJSXOrNull(node)) {
           if (isFirstLetterCapitalized(node.parent.id.name)) {
             return node;

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -233,6 +233,17 @@ ruleTester.run('destructuring-assignment', rule, {
         },
       ];
     `
+  }, {
+    code: `
+    export default (fileName) => {
+      const match = fileName.match(/some expression/);
+      if (match) {
+        return fn;
+      }
+      return null;
+    };
+  `
+
   }],
 
   invalid: [{
@@ -424,6 +435,22 @@ ruleTester.run('destructuring-assignment', rule, {
     errors: [{
       messageId: 'useDestructAssignment',
       data: {type: 'context'}
+    }]
+  }, {
+    code: `
+      export default (props) => {
+        const match = props.str.match(/some expression/);
+        if (match) {
+          return <span>jsx</span>;
+        }
+        return null;
+      };
+    `,
+    options: ['always'],
+    parser: parsers.BABEL_ESLINT,
+    errors: [{
+      messageId: 'useDestructAssignment',
+      data: {type: 'props'}
     }]
   }]
 });


### PR DESCRIPTION
Fixes: #3024 

Added code to deal with `ExportDefaultDeclaration` as the parent node of a `ArrowFunctionExpression`