### PR TITLE
[Fix] `prop-types`, `propTypes`: add handling for `FC<Props>`, improve tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`no-typos`]: fix crash on private methods ([#3043][] @ljharb)
 * [`jsx-no-bind`]: handle local function declarations ([#3048][] @p7g)
 * [`prop-types`], `propTypes`: handle React.* TypeScript types ([#3049][] @vedadeepta)
+* [`prop-types`], `propTypes`: add handling for `FC<Props>`, improve tests ([#3051][] @vedadeepta)
 
 ### Changed
 * [Docs] [`jsx-no-bind`]: updates discussion of refs ([#2998][] @dimitropoulos)
@@ -32,6 +33,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [Docs] improve instructions for `jsx-runtime` config ([#3052][] @ljharb)
 
 [#3052]: https://github.com/yannickcr/eslint-plugin-react/issues/3052
+[#3051]: https://github.com/yannickcr/eslint-plugin-react/pull/3051
 [#3049]: https://github.com/yannickcr/eslint-plugin-react/pull/3049
 [#3048]: https://github.com/yannickcr/eslint-plugin-react/pull/3048
 [#3043]: https://github.com/yannickcr/eslint-plugin-react/issues/3043

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -100,7 +100,8 @@ module.exports = function propTypesInstructions(context, components, utils) {
   const defaults = {customValidators: []};
   const configuration = Object.assign({}, defaults, context.options[0] || {});
   const customValidators = configuration.customValidators;
-  const allowedGenericTypes = ['React.SFC', 'React.StatelessComponent', 'React.FunctionComponent', 'React.FC'];
+  const allowedGenericTypes = new Set(['SFC', 'StatelessComponent', 'FunctionComponent', 'FC']);
+  const genericReactTypesImport = new Set();
 
   /**
    * Returns the full scope.
@@ -548,7 +549,8 @@ module.exports = function propTypesInstructions(context, components, utils) {
       let typeName;
       if (astUtil.isTSTypeReference(node)) {
         typeName = node.typeName.name;
-        if (!typeName && node.typeParameters && node.typeParameters.length !== 0) {
+        const shouldTraverseTypeParams = !typeName || genericReactTypesImport.has(typeName);
+        if (shouldTraverseTypeParams && node.typeParameters && node.typeParameters.length !== 0) {
           const nextNode = node.typeParameters.params[0];
           this.visitTSNode(nextNode);
           return;
@@ -940,12 +942,19 @@ module.exports = function propTypesInstructions(context, components, utils) {
         return;
       }
 
-      const typeName = context.getSourceCode().getText(annotation.typeName).replace(/ /g, '');
+      if (annotation.typeName.name) { // if FC<Props>
+        const typeName = annotation.typeName.name;
+        if (!genericReactTypesImport.has(typeName)) {
+          return;
+        }
+      } else if (annotation.typeName.right.name) { // if React.FC<Props>
+        const right = annotation.typeName.right.name;
+        const left = annotation.typeName.left.name;
 
-      if (allowedGenericTypes.indexOf(typeName) === -1) {
-        return;
+        if (!genericReactTypesImport.has(left) || !allowedGenericTypes.has(right)) {
+          return;
+        }
       }
-
       markPropTypesAsDeclared(node, resolveTypeAnnotation(siblingIdentifier));
     }
   }
@@ -1033,6 +1042,27 @@ module.exports = function propTypesInstructions(context, components, utils) {
     FunctionExpression(node) {
       if (node.parent.type !== 'MethodDefinition') {
         markAnnotatedFunctionArgumentsAsDeclared(node);
+      }
+    },
+
+    ImportDeclaration(node) {
+      // parse `import ... from 'react`
+      if (node.source.value === 'react') {
+        node.specifiers.forEach((specifier) => {
+          if (
+            // handles import * as X from 'react'
+            specifier.type === 'ImportNamespaceSpecifier'
+            // handles import React from 'react'
+            || specifier.type === 'ImportDefaultSpecifier'
+          ) {
+            genericReactTypesImport.add(specifier.local.name);
+          }
+
+          // handles import { FC } from 'react' or import { FC as X } from 'react'
+          if (specifier.type === 'ImportSpecifier' && allowedGenericTypes.has(specifier.imported.name)) {
+            genericReactTypesImport.add(specifier.local.name);
+          }
+        });
       }
     },
 

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3150,6 +3150,8 @@ ruleTester.run('prop-types', rule, {
       },
       {
         code: `
+          import React from 'react';
+
           interface PersonProps {
               username: string;
           }
@@ -3161,6 +3163,8 @@ ruleTester.run('prop-types', rule, {
       },
       {
         code: `
+          import React from 'react';
+
           const Person: React.FunctionComponent<PersonProps> = (props): React.ReactElement => (
               <div>{props.username}</div>
           );
@@ -3169,6 +3173,8 @@ ruleTester.run('prop-types', rule, {
       },
       {
         code: `
+          import React from 'react';
+
           interface PersonProps {
               username: string;
           }
@@ -3180,6 +3186,7 @@ ruleTester.run('prop-types', rule, {
       },
       {
         code: `
+          import React from 'react';
           const Person: React.FunctionComponent<{ username: string }> = (props): React.ReactElement => (
               <div>{props.username}</div>
           );
@@ -3188,12 +3195,89 @@ ruleTester.run('prop-types', rule, {
       },
       {
         code: `
+          import React from 'react';
           type PersonProps = {
               username: string;
           }
           const Person: React.FunctionComponent<PersonProps> = (props): React.ReactElement => (
               <div>{props.username}</div>
           );
+        `,
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          import { FunctionComponent } from 'react';
+
+          type PersonProps = {
+              username: string;
+          }
+          const Person: FunctionComponent<PersonProps> = (props): React.ReactElement => (
+              <div>{props.username}</div>
+          );
+        `,
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          import { FC } from 'react';
+          type PersonProps = {
+              username: string;
+          }
+          const Person: FC<PersonProps> = (props): React.ReactElement => (
+              <div>{props.username}</div>
+          );
+        `,
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          import type { FC } from 'react';
+          type PersonProps = {
+              username: string;
+          }
+          const Person: FC<PersonProps> = (props): React.ReactElement => (
+              <div>{props.username}</div>
+          );
+        `,
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          import { FC as X } from 'react';
+          interface PersonProps {
+              username: string;
+          }
+          const Person: X<PersonProps> = (props): React.ReactElement => (
+              <div>{props.username}</div>
+          );
+        `,
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          import * as X from 'react';
+          interface PersonProps {
+              username: string;
+          }
+          const Person: X.FC<PersonProps> = (props): React.ReactElement => (
+              <div>{props.username}</div>
+          );
+        `,
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        // issue: https://github.com/yannickcr/eslint-plugin-react/issues/2786
+        code: `
+          import React from 'react';
+
+          interface Props {
+            item: any;
+          }
+
+          const SomeComponent: React.FC<Props> = ({ item }: Props) => {
+            return item ? <></> : <></>;
+          };
         `,
         parser: parsers['@TYPESCRIPT_ESLINT']
       }
@@ -6703,6 +6787,58 @@ ruleTester.run('prop-types', rule, {
           {
             messageId: 'missingPropType',
             data: {name: 'test'}
+          }
+        ],
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          import React from 'react';
+          interface PersonProps {
+              username: string;
+          }
+          const Person: FunctionComponent<PersonProps> = (props): React.ReactElement => (
+              <div>{props.test}</div>
+          );
+        `,
+        errors: [
+          {
+            messageId: 'missingPropType',
+            data: {name: 'test'}
+          }
+        ],
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          interface PersonProps {
+              username: string;
+          }
+          const Person: X.FC<PersonProps> = (props): React.ReactElement => (
+              <div>{props.username}</div>
+          );
+        `,
+        errors: [
+          {
+            messageId: 'missingPropType',
+            data: {name: 'username'}
+          }
+        ],
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          interface PersonProps {
+              username: string;
+          }
+          const Person: FC<PersonProps> = (props): React.ReactElement => (
+              <div>{props.username}</div>
+          );
+        `,
+        errors: [
+          {
+            messageId: 'missingPropType',
+            data: {name: 'username'}
           }
         ],
         parser: parsers['@TYPESCRIPT_ESLINT']


### PR DESCRIPTION
- add handling for both `React.FC<Props>` & `FC<Props>` (and other React.* variants)
- add test case that closes #2786 

follow up to this: https://github.com/yannickcr/eslint-plugin-react/pull/3049#issuecomment-905796752
