### PR TITLE
[New] support eslint 8.x

### DIFF
--- a/.github/workflows/node-4+.yml
+++ b/.github/workflows/node-4+.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         node-version: ${{ fromJson(needs.matrix.outputs.latest) }}
         eslint:
+          - 8
           - 7
           - 6
           - 5
@@ -45,24 +46,46 @@ jobs:
             babel-eslint: 10
           - node-version: 4
             babel-eslint: 9
+          - node-version: 15
+            eslint: 8
+          - node-version: 13
+            eslint: 8
+          - node-version: 11
+            eslint: 8
+          - node-version: 11
+            eslint: 7
+          - node-version: 10
+            eslint: 8
+          - node-version: 9
+            eslint: 8
           - node-version: 9
             eslint: 7
           - node-version: 8
+            eslint: 8
+          - node-version: 8
             eslint: 7
+          - node-version: 7
+            eslint: 8
           - node-version: 7
             eslint: 7
           - node-version: 7
             eslint: 6
           - node-version: 6
+            eslint: 8
+          - node-version: 6
             eslint: 7
           - node-version: 6
             eslint: 6
+          - node-version: 5
+            eslint: 8
           - node-version: 5
             eslint: 7
           - node-version: 5
             eslint: 6
           - node-version: 5
             eslint: 5
+          - node-version: 4
+            eslint: 8
           - node-version: 4
             eslint: 7
           - node-version: 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ## Unreleased
 
 ### Added
+* support eslint 8.x ([#3059][] @MichaelDeBoey @ljharb)
 * [`no-unused-class-component-methods`]: Handle unused class component methods ([#2166][] @jakeleventhal @pawelnvk)
 * add [`no-arrow-function-lifecycle`] ([#1980][] @ngtan)
 * add support for `@typescript-eslint/parser` v5 (@ljharb)
@@ -37,6 +38,7 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 [#3110]: https://github.com/yannickcr/eslint-plugin-react/pull/3110
 [#3102]: https://github.com/yannickcr/eslint-plugin-react/issue/3102
 [#3092]: https://github.com/yannickcr/eslint-plugin-react/pull/3092
+[#3059]: https://github.com/yannickcr/eslint-plugin-react/pull/3059
 [#2863]: https://github.com/yannickcr/eslint-plugin-react/pull/2863
 [#2166]: https://github.com/yannickcr/eslint-plugin-react/pull/2166
 [#1980]: https://github.com/yannickcr/eslint-plugin-react/pull/1980

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@typescript-eslint/parser": "^2.34.0 || ^3.10.1 || ^4.0.0 || ^5.0.0",
     "aud": "^1.1.5",
     "babel-eslint": "^8 || ^9 || ^10.1.0",
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7",
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-eslint-plugin": "^2.3.0 || ^3.5.3 || ^4.0.1",
     "eslint-plugin-import": "^2.25.2",
@@ -73,7 +73,7 @@
     "typescript-eslint-parser": "^20.1.1"
   },
   "peerDependencies": {
-    "eslint": "^3 || ^4 || ^5 || ^6 || ^7"
+    "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8"
   },
   "engines": {
     "node": ">=4"

--- a/tests/helpers/getESLintCoreRule.js
+++ b/tests/helpers/getESLintCoreRule.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const version = require('eslint/package.json').version;
+const semver = require('semver');
+
+const isESLintV8 = semver.major(version) >= 8;
+
+// eslint-disable-next-line global-require, import/no-dynamic-require, import/no-unresolved
+const getESLintCoreRule = (ruleId) => (isESLintV8 ? require('eslint/use-at-your-own-risk').builtinRules.get(ruleId) : require(`eslint/lib/rules/${ruleId}`));
+
+module.exports = getESLintCoreRule;

--- a/tests/helpers/parsers.js
+++ b/tests/helpers/parsers.js
@@ -104,7 +104,14 @@ const parsers = {
       const tsNew = !skipTS && !features.has('no-ts-new');
 
       return [].concat(
-        skipBase ? [] : addComment(test, 'default'),
+        skipBase ? [] : addComment(
+          Object.assign({}, test, features.has('class fields') && {
+            parserOptions: Object.assign({}, test.parserOptions, {
+              ecmaVersion: Math.max((test.parserOptions && test.parserOptions.ecmaVersion) || 0, 2022),
+            }),
+          }),
+          'default'
+        ),
         skipOldBabel ? [] : addComment(Object.assign({}, test, {
           parser: parsers.BABEL_ESLINT,
           parserOptions: parsers.babelParserOptions(test, features),

--- a/tests/lib/rules/destructuring-assignment.js
+++ b/tests/lib/rules/destructuring-assignment.js
@@ -646,7 +646,6 @@ ruleTester.run('destructuring-assignment', rule, {
           );
         };
       `,
-      parser: parsers.BABEL_ESLINT,
       errors: [
         {
           messageId: 'useDestructAssignment',
@@ -675,7 +674,6 @@ ruleTester.run('destructuring-assignment', rule, {
             },
         };
       `,
-      parser: parsers.BABEL_ESLINT,
       errors: [
         {
           messageId: 'useDestructAssignment',
@@ -704,7 +702,6 @@ ruleTester.run('destructuring-assignment', rule, {
           };
         }
       `,
-      parser: parsers.BABEL_ESLINT,
       errors: [
         {
           messageId: 'useDestructAssignment',

--- a/tests/lib/rules/jsx-no-undef.js
+++ b/tests/lib/rules/jsx-no-undef.js
@@ -29,8 +29,8 @@ const parserOptions = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions });
-const linter = ruleTester.linter || eslint.linter;
-linter.defineRule('no-undef', require('eslint/lib/rules/no-undef'));
+const linter = ruleTester.linter || eslint.linter || eslint.Linter;
+linter.defineRule('no-undef', require('../../helpers/getESLintCoreRule')('no-undef'));
 
 ruleTester.run('jsx-no-undef', rule, {
   valid: parsers.all([

--- a/tests/lib/rules/jsx-no-useless-fragment.js
+++ b/tests/lib/rules/jsx-no-useless-fragment.js
@@ -8,11 +8,9 @@
 // Requirements
 // -----------------------------------------------------------------------------
 
-const eslint = require('eslint');
+const RuleTester = require('eslint').RuleTester;
 const rule = require('../../../lib/rules/jsx-no-useless-fragment');
 const parsers = require('../../helpers/parsers');
-
-const RuleTester = eslint.RuleTester;
 
 const parserOptions = {
   ecmaVersion: 2018,

--- a/tests/lib/rules/jsx-uses-react.js
+++ b/tests/lib/rules/jsx-uses-react.js
@@ -10,7 +10,7 @@
 // -----------------------------------------------------------------------------
 
 const eslint = require('eslint');
-const rule = require('eslint/lib/rules/no-unused-vars');
+const rule = require('../../helpers/getESLintCoreRule')('no-unused-vars');
 
 const RuleTester = eslint.RuleTester;
 
@@ -35,7 +35,7 @@ const settings = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions });
-const linter = ruleTester.linter || eslint.linter;
+const linter = ruleTester.linter || eslint.linter || eslint.Linter;
 linter.defineRule('jsx-uses-react', require('../../../lib/rules/jsx-uses-react'));
 
 ruleTester.run('no-unused-vars', rule, {

--- a/tests/lib/rules/jsx-uses-vars.js
+++ b/tests/lib/rules/jsx-uses-vars.js
@@ -10,8 +10,8 @@
 // -----------------------------------------------------------------------------
 
 const eslint = require('eslint');
-const ruleNoUnusedVars = require('eslint/lib/rules/no-unused-vars');
-const rulePreferConst = require('eslint/lib/rules/prefer-const');
+const ruleNoUnusedVars = require('../../helpers/getESLintCoreRule')('no-unused-vars');
+const rulePreferConst = require('../../helpers/getESLintCoreRule')('prefer-const');
 
 const RuleTester = eslint.RuleTester;
 
@@ -30,7 +30,7 @@ const parserOptions = {
 // -----------------------------------------------------------------------------
 
 const ruleTester = new RuleTester({ parserOptions });
-const linter = ruleTester.linter || eslint.linter;
+const linter = ruleTester.linter || eslint.linter || eslint.Linter;
 linter.defineRule('jsx-uses-vars', require('../../../lib/rules/jsx-uses-vars'));
 
 ruleTester.run('no-unused-vars', ruleNoUnusedVars, {

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -234,9 +234,6 @@ ruleTester.run('no-unused-prop-types', rule, {
         }
       `,
       features: ['class fields', 'optional chaining'],
-      parserOptions: {
-        ecmaVersion: 2020,
-      },
     },
     {
       code: `
@@ -775,9 +772,6 @@ ruleTester.run('no-unused-prop-types', rule, {
         }
       `,
       features: ['class fields', 'optional chaining'],
-      parserOptions: {
-        ecmaVersion: 2020,
-      },
     },
     {
       code: `


### PR DESCRIPTION
ESLint v8.0.0 is [released](https://eslint.org/blog/2021/10/eslint-v8.0.0-released) 🎉

devDependency compatibility with ESLint 8:

- [x] [`eslint-config-airbnb-base`](https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb-base) (https://github.com/airbnb/javascript/issues/2478)
  - [x] https://github.com/airbnb/javascript/pull/2495
  - [x] [`v15.0.0`](https://github.com/airbnb/javascript/blob/master/packages/eslint-config-airbnb-base/CHANGELOG.md#1500--2021-11-08)
- [x] [`eslint-plugin-eslint-plugin`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin) (https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/issues/175)
  - [x] https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/119
  - [x] https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/151
  - [x] https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/186
  - [x] https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/pull/212
  - [x] [`v4.0.0-0`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/CHANGELOG.md#v400-0)
  - [x] [`v4.0.0`](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/releases/tag/v4.0.0)
- [x] [`eslint-plugin-import`](https://github.com/import-js/eslint-plugin-import) (https://github.com/import-js/eslint-plugin-import/issues/2211)
  - [x] https://github.com/import-js/eslint-plugin-import/pull/2191
  - [x] [`v2.25.0`](https://github.com/import-js/eslint-plugin-import/releases/tag/v2.25.0)

---

Closes #3055