### PR TITLE
[Fix] `jsx-no-useless-fragments`: Allow whitespace when `allowExpressions` is `true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Fixed
+* [`jsx-no-useless-fragments`]: Handle insignificant whitespace correctly when `allowExpressions` is `true` ([#3061][] @benj-dobs)
+
+[#3061]: https://github.com/yannickcr/eslint-plugin-react/pull/3061
+
 ## [7.25.1] - 2021.08.29
 
 ### Fixed

--- a/docs/rules/jsx-no-useless-fragment.md
+++ b/docs/rules/jsx-no-useless-fragment.md
@@ -64,4 +64,8 @@ Examples of **correct** code for the rule, when `"allowExpressions"` is `true`:
 
 ```jsx
 <>{foo}</>
+
+<>
+  {foo}
+</>
 ```

--- a/lib/rules/jsx-no-useless-fragment.js
+++ b/lib/rules/jsx-no-useless-fragment.js
@@ -77,10 +77,6 @@ function containsCallExpression(node) {
     && node.expression.type === 'CallExpression';
 }
 
-function isFragmentWithSingleExpression(node) {
-  return node && node.children.length === 1 && node.children[0].type === 'JSXExpressionContainer';
-}
-
 module.exports = {
   meta: {
     type: 'suggestion',
@@ -113,6 +109,15 @@ module.exports = {
       return isJSXText(node)
         && isOnlyWhitespace(node.raw)
         && arrayIncludes(node.raw, '\n');
+    }
+
+    function isFragmentWithSingleExpression(node) {
+      const children = node && node.children.filter((child) => !isPaddingSpaces(child));
+      return (
+        children
+        && children.length === 1
+        && children[0].type === 'JSXExpressionContainer'
+      );
     }
 
     /**

--- a/tests/lib/rules/jsx-no-useless-fragment.js
+++ b/tests/lib/rules/jsx-no-useless-fragment.js
@@ -72,6 +72,15 @@ ruleTester.run('jsx-no-useless-fragment', rule, {
       code: '<>{moo}</>',
       parser: parsers.BABEL_ESLINT,
       options: [{allowExpressions: true}]
+    },
+    {
+      code: `
+        <>
+          {moo}
+        </>
+      `,
+      parser: parsers.BABEL_ESLINT,
+      options: [{allowExpressions: true}]
     }
   ],
   invalid: [


### PR DESCRIPTION
Bug fix.

Problem: When `react/jsx-no-useless-fragment` has `allowExpression` set to `true`, the following code produces an error:

```jsx
<>
  {foo ? (
    <Bar />
  ) : (
    <Baz />
  )}
</>
```

This PR amends the `allowExpressions` rule added in #3006 to allow insignificant whitespace around the expression.