### PR TITLE
[Fix] `display-name`: fix misinterpreted function components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 * [`jsx-no-useless-fragments`]: Handle insignificant whitespace correctly when `allowExpressions` is `true` ([#3061][] @benj-dobs)
 * [`prop-types`], `propTypes`: handle implicit `children` prop in react's generic types ([#3064][] @vedadeepta)
+* [`display-name`]: fix arrow function returning result of function call with JSX arguments being interpreted as component ([#3065][], @danielfinke)
 
+[#3065]: https://github.com/yannickcr/eslint-plugin-react/pull/3065
 [#3064]: https://github.com/yannickcr/eslint-plugin-react/pull/3064
 [#3061]: https://github.com/yannickcr/eslint-plugin-react/pull/3061
 

--- a/lib/util/jsx.js
+++ b/lib/util/jsx.js
@@ -130,6 +130,7 @@ function isReturningJSX(isCreateElement, ASTnode, context, strict, ignoreNull) {
             if (isCreateElement(childNode)) {
               setFound();
             }
+            this.skip();
             break;
           case 'Literal':
             if (!ignoreNull && childNode.value === null) {

--- a/tests/util/jsx.js
+++ b/tests/util/jsx.js
@@ -27,9 +27,7 @@ describe('jsxUtil', () => {
     const assertValid = (codeStr) => assert(
       isReturningJSX(() => false, parseCode(codeStr), mockContext)
     );
-    const assertInValid = (codeStr) => assert(
-      !!isReturningJSX(() => false, parseCode(codeStr), mockContext)
-    );
+
     it('Works when returning JSX', () => {
       assertValid(`
         function Test() {
@@ -71,11 +69,27 @@ describe('jsxUtil', () => {
     });
 
     it('Can ignore null', () => {
-      assertInValid(`
+      assertValid(`
         function Test() {
           return null;
         }
       `);
+    });
+
+    it('Ignores JSX arguments to function calls used as return value of arrow functions', () => {
+      let astNode = parseCode(`const obj = {
+        prop: () => test(<a>something</a>)
+      }`);
+      let arrowFunctionExpression = astNode.declarations[0].init.properties[0].value;
+
+      assert(!isReturningJSX(() => false, arrowFunctionExpression, mockContext));
+
+      astNode = parseCode(`const obj = {
+        prop: () => { return test(<a>something</a>); }
+      }`);
+      arrowFunctionExpression = astNode.declarations[0].init.properties[0].value;
+
+      assert(!isReturningJSX(() => false, arrowFunctionExpression, mockContext));
     });
   });
 });


### PR DESCRIPTION
- when determining if an `ArrowFunctionExpression` returns JSX, do not check arguments to a returned `CallExpression`

Arrow function expressions that return the result of a function call taking JSX arguments are incorrectly deemed to be returning JSX. This leads to some misinterpretations of arrow functions as function components, which are then flagged as "missing display name".

## Examples:

### `ArrowFunctionExpression` as `Property` value
```
const obj = {
  prop: () => console.log(<a>something</a>)
};
const obj2 = {
  prop: () => { return console.log(<a>something</a>); }
};
```

### `ArrowFunctionExpression` as RHS of `AssignmentExpression`
```
let obj3;
obj3 = () => console.log(<a>something</a>);
```

I think any other examples of `ArrowFunctionExpressions` that pass `utils.isInAllowedPositionForComponent` at https://github.com/yannickcr/eslint-plugin-react/blob/810806e58d5a611e6743227c91d859c2c02563bb/lib/util/Components.js#L648-L650 will hit this too (excl. a `VariableDeclarator` as it's handled on [L635](https://github.com/yannickcr/eslint-plugin-react/blob/810806e58d5a611e6743227c91d859c2c02563bb/lib/util/Components.js#L635) ahead of time).