### PR TITLE
[Fix] `prop-types` `propTypes`: bail out unknown generic types inside func params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ## Unreleased
 
+### Fixed
+* [`prop-types`], `propTypes`: bail out unknown generic types inside func params ([#3076] @vedadeepta)
+
+[#3076]: https://github.com/yannickcr/eslint-plugin-react/pull/3076
+
 ## [7.25.2] - 2021.09.16
 
 ### Fixed

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -970,16 +970,6 @@ module.exports = function propTypesInstructions(context, components, utils) {
           }
         });
       } else {
-        // check if its a valid generic type when `X<{...}>`
-        if (
-          param.typeAnnotation
-          && param.typeAnnotation.typeAnnotation
-          && param.typeAnnotation.typeAnnotation.type === 'TSTypeReference'
-          && param.typeAnnotation.typeAnnotation.typeParameters != null
-          && !isValidReactGenericTypeAnnotation(param.typeAnnotation.typeAnnotation)
-        ) {
-          return;
-        }
         markPropTypesAsDeclared(node, resolveTypeAnnotation(param));
       }
     } else {

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3303,6 +3303,19 @@ ruleTester.run('prop-types', rule, {
 
         `,
         parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          type Props<ValueType> = {
+            value: ValueType;
+            onClick: (value: ValueType) => void;
+          };
+
+          const Button = <T,>({ onClick, value }: Props<T>) => {
+            return <button onClick={() => onClick(value)}>BUTTON</button>;
+          };
+        `,
+        parser: parsers['@TYPESCRIPT_ESLINT']
       }
     ]),
     {
@@ -6855,6 +6868,23 @@ ruleTester.run('prop-types', rule, {
               username: string;
           }
           const Person: FC<PersonProps> = (props): React.ReactElement => (
+              <div>{props.username}</div>
+          );
+        `,
+        errors: [
+          {
+            messageId: 'missingPropType',
+            data: {name: 'username'}
+          }
+        ],
+        parser: parsers['@TYPESCRIPT_ESLINT']
+      },
+      {
+        code: `
+          type PersonProps<T> = {
+              x: T;
+          }
+          const Person = (props: PersonProps<string>): React.ReactElement => (
               <div>{props.username}</div>
           );
         `,


### PR DESCRIPTION
Fixes #3074 

when `const Comp = (props: NonReactGeneric<T>) => {...}` proceed as usual instead of early return.