### PR TITLE
Pin link to code in react-in-jsx-scope docs

### DIFF
--- a/docs/rules/react-in-jsx-scope.md
+++ b/docs/rules/react-in-jsx-scope.md
@@ -44,4 +44,4 @@ var Hello = <div>Hello {this.props.name}</div>;
 
 If you are not using JSX, or if you are setting `React` as a global variable.
 
-If you are using the [new JSX transform from React 17](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports), you should disable this rule by extending [`react/jsx-runtime`](https://github.com/yannickcr/eslint-plugin-react/blob/HEAD/index.js#L163-L176) in your eslint config (add `"plugin:react/jsx-runtime"` to `"extends"`).
+If you are using the [new JSX transform from React 17](https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html#removing-unused-react-imports), you should disable this rule by extending [`react/jsx-runtime`](https://github.com/yannickcr/eslint-plugin-react/blob/8cf47a8ac2242ee00ea36eac4b6ae51956ba4411/index.js#L165-L179) in your eslint config (add `"plugin:react/jsx-runtime"` to `"extends"`).


### PR DESCRIPTION
The lines have shifted since this was added, causing the incorrect
range to be highlighted. We can fix this by pinning the link to a specific
git SHA.