### PR TITLE
[Docs] `jsx-max-props-per-line`: fix options example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 * [`no-namespace`]: fix crash on non-string React.createElement name ([#3082] @ljharb)
 
+### Changed
+* [Docs] [`jsx-max-props-per-line`]: fix options example ([#3083] @MrRaiter)
+
+[#3083]: https://github.com/yannickcr/eslint-plugin-react/pull/3083
 [#3082]: https://github.com/yannickcr/eslint-plugin-react/pull/3082
 
 ## [7.26.0] - 2021.09.20

--- a/docs/rules/jsx-max-props-per-line.md
+++ b/docs/rules/jsx-max-props-per-line.md
@@ -43,7 +43,7 @@ Examples of **correct** code for this rule:
 // OR
 
 ...
-"react/jsx-max-props-per-line": [<enabled>, { "maximum": { single <number> multi: <number> } }]
+"react/jsx-max-props-per-line": [<enabled>, { "maximum": { "single": <number>, "multi": <number> } }]
 ...
 ```
 


### PR DESCRIPTION
Small issues with `jsx-max-props-per-line`  docs