### PR TITLE
[New Rule] add props-destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ Enable the rules that you would like to use.
 |  | 🔧 | [react/prefer-read-only-props](docs/rules/prefer-read-only-props.md) | Require read-only props. |
 |  |  | [react/prefer-stateless-function](docs/rules/prefer-stateless-function.md) | Enforce stateless components to be written as a pure function |
 | ✔ |  | [react/prop-types](docs/rules/prop-types.md) | Prevent missing props validation in a React component definition |
-| ✔ |  | [react/props-destructuring](docs/rules/props-destructuring.md) | Prevent multiline props destructuring in a React component definition |
+|  |  | [react/props-destructuring](docs/rules/props-destructuring.md) | Prevent multiline props destructuring in a React component definition |
 | ✔ |  | [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md) | Prevent missing React when using JSX |
 |  |  | [react/require-default-props](docs/rules/require-default-props.md) | Enforce a defaultProps definition for every prop that is not a required prop. |
 |  |  | [react/require-optimization](docs/rules/require-optimization.md) | Enforce React components to have a shouldComponentUpdate method |

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ Enable the rules that you would like to use.
 |  | 🔧 | [react/prefer-read-only-props](docs/rules/prefer-read-only-props.md) | Require read-only props. |
 |  |  | [react/prefer-stateless-function](docs/rules/prefer-stateless-function.md) | Enforce stateless components to be written as a pure function |
 | ✔ |  | [react/prop-types](docs/rules/prop-types.md) | Prevent missing props validation in a React component definition |
+| ✔ |  | [react/props-destructuring](docs/rules/props-destructuring.md) | Prevent multiline props destructuring in a React component definition |
 | ✔ |  | [react/react-in-jsx-scope](docs/rules/react-in-jsx-scope.md) | Prevent missing React when using JSX |
 |  |  | [react/require-default-props](docs/rules/require-default-props.md) | Enforce a defaultProps definition for every prop that is not a required prop. |
 |  |  | [react/require-optimization](docs/rules/require-optimization.md) | Enforce React components to have a shouldComponentUpdate method |

--- a/docs/rules/props-destructuring.md
+++ b/docs/rules/props-destructuring.md
@@ -34,14 +34,6 @@ const Component = ({
 );
 ```
 
-```jsx
-
-```
-
-```jsx
-
-```
-
 Examples of **correct** code for this rule:
 
 ```jsx

--- a/docs/rules/props-destructuring.md
+++ b/docs/rules/props-destructuring.md
@@ -4,7 +4,7 @@ Destructuring Component props on multiple line may confuse the reader where the 
 
 ## Rule Details
 
-This rule checks all React Component and verifies that props are not destructuring on multiple lines at component declaration. This rule is off by default.
+This rule checks all React Component and verifies that props are not destructuring on multiple lines at component declaration.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/props-destructuring.md
+++ b/docs/rules/props-destructuring.md
@@ -1,0 +1,87 @@
+# Forbid multiline props destructuring at Component declaration (react/props-destructuring)
+
+Destructuring Component props on multiple line may confuse the reader where the actual block or the function start.
+
+## Rule Details
+
+This rule checks all React Component and verifies that props are not destructuring on multiple lines at component declaration. This rule is off by default.
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+function Component({ 
+  prop1, 
+  prop2 
+}) {
+  return (
+    <div>
+      {prop1}
+      {prop2}
+    </div>
+  );
+}
+```
+
+```jsx
+const Component = ({ 
+  prop1, 
+  prop2 
+}) => (
+  <div>
+    {prop1}
+    {prop2}
+  </div>
+);
+```
+
+```jsx
+
+```
+
+```jsx
+
+```
+
+Examples of **correct** code for this rule:
+
+```jsx
+function Component(props) {
+  const { 
+    prop1, 
+    prop2 
+  } = props;
+  return (
+    <div>
+      {prop1}
+      {prop2}
+    </div>
+  );
+}
+```
+
+```jsx
+function Component({ prop1, prop2 }) {
+  return (
+    <div>
+      {prop1}
+      {prop2}
+    </div>
+  );
+}
+```
+
+```jsx
+const Component = (props) => {
+  const { 
+    prop1,
+    prop2
+  } = props;
+
+  return (
+    <div>
+      {prop1}
+      {prop2}
+    </div>
+  );
+};
+```

--- a/index.js
+++ b/index.js
@@ -86,6 +86,7 @@ const allRules = {
   'prefer-read-only-props': require('./lib/rules/prefer-read-only-props'),
   'prefer-stateless-function': require('./lib/rules/prefer-stateless-function'),
   'prop-types': require('./lib/rules/prop-types'),
+  'props-destructuring': require('./lib/rules/props-destructuring'),
   'react-in-jsx-scope': require('./lib/rules/react-in-jsx-scope'),
   'require-default-props': require('./lib/rules/require-default-props'),
   'require-optimization': require('./lib/rules/require-optimization'),

--- a/lib/rules/props-destructuring.js
+++ b/lib/rules/props-destructuring.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Forbid multiline props destructuring at Component declaration
+ * @author Dragoș Străinu (@strdr4605)
+ */
+
+'use strict';
+
+const docsUrl = require('../util/docsUrl');
+const report = require('../util/report');
+
+// ------------------------------------------------------------------------------
+// Rule Definition
+// ------------------------------------------------------------------------------
+
+const messages = {
+  noMultilinePropsDestructuring:
+    "No multiple lines props destructuring at Component declaration, use 'props' parameter and destructure in function block"
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Forbid multiline props destructuring at Component declaration',
+      category: 'Best Practices',
+      recommended: false,
+      url: docsUrl('props-destructuring')
+    },
+
+    messages,
+
+    schema: []
+  },
+
+  create(context) {
+    function checkPropsDestructuring(node) {
+      const functionName = node.type === 'FunctionDeclaration' ? node.id.name : node.parent.id.name;
+
+      if (functionName[0] !== functionName[0].toUpperCase()) {
+        // Not a React Component
+        return;
+      }
+
+      const firstParam = node.params[0];
+
+      if (firstParam.type === 'ObjectPattern' && firstParam.loc.start.line !== firstParam.loc.end.line) {
+        report(context, messages.noMultilinePropsDestructuring, 'noMultilinePropsDestructuring', {
+          node,
+          loc: {
+            start: {
+              line: firstParam.loc.start.line,
+              column: firstParam.loc.start.column
+            },
+            end: {
+              line: firstParam.loc.end.line,
+              column: firstParam.loc.end.column
+            }
+          }
+        });
+      }
+    }
+
+    return {
+      'FunctionDeclaration[params.length>0]': checkPropsDestructuring,
+      'ArrowFunctionExpression[params.length>0]': checkPropsDestructuring
+    };
+  }
+};

--- a/tests/lib/rules/props-destructuring.js
+++ b/tests/lib/rules/props-destructuring.js
@@ -1,0 +1,121 @@
+/**
+ * @fileoverview Tests for props-destructuring
+ */
+
+'use strict';
+
+// -----------------------------------------------------------------------------
+// Requirements
+// -----------------------------------------------------------------------------
+
+const RuleTester = require('eslint').RuleTester;
+const rule = require('../../../lib/rules/props-destructuring');
+
+const parserOptions = {
+  ecmaVersion: 2018,
+  sourceType: 'module',
+  ecmaFeatures: {
+    jsx: true
+  }
+};
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({parserOptions});
+ruleTester.run('props-destructuring', rule, {
+
+  valid: [{
+    code: `
+      function Component(props) {
+        const {
+          prop1,
+          prop2,
+        } = props;
+        return (
+          <div>
+            {prop1}
+            {prop2}
+          </div>
+        );
+      }
+    `
+  }, {
+    code: `
+      function Component({ prop1, prop2 }) {
+        return (
+          <div>
+            {prop1}
+            {prop2}
+          </div>
+        );
+      }
+    `
+  }, {
+    code: `
+      const Component = (props) => {
+        const {
+          prop1,
+          prop2,
+        } = props;
+
+        return (
+          <div>
+            {prop1}
+            {prop2}
+          </div>
+        );
+      };
+    `
+  }, {
+    code: `
+      const Component = ({ prop1, prop2, }) => (
+        <div>
+          {prop1}
+          {prop2}
+        </div>
+      );
+    `
+  }],
+
+  invalid: [{
+    code: `
+      function Component({
+        prop1,
+        prop2,
+      }) {
+        return (
+          <div>
+            {prop1}
+            {prop2}
+          </div>
+        );
+      }
+    `,
+    errors: [{
+      messageId: 'noMultilinePropsDestructuring',
+      line: 2,
+      column: 26,
+      type: 'FunctionDeclaration'
+    }]
+  }, {
+    code: `
+      const Component = ({
+        prop1,
+        prop2,
+      }) => (
+        <div>
+          {prop1}
+          {prop2}
+        </div>
+      );
+    `,
+    errors: [{
+      messageId: 'noMultilinePropsDestructuring',
+      line: 2,
+      column: 26,
+      type: 'ArrowFunctionExpression'
+    }]
+  }]
+});


### PR DESCRIPTION
This rule checks all React Component and verifies that props are not destructuring on multiple lines at component declaration.