### PR TITLE
[Dev Deps] Upgrade `eslint-plugin-eslint-plugin` to v4

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -43,6 +43,10 @@
           "requireParamDescription": false,
           "requireReturnDescription": false,
         }],
+
+        "eslint-plugin/consistent-output": 0,
+        "eslint-plugin/require-meta-schema": 0,
+        "eslint-plugin/require-meta-type": 0
     },
     "overrides": [
       {

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -142,7 +142,10 @@ module.exports = {
         }
         case 'CallExpression': {
           const innerNode = node.arguments && node.arguments[0];
-          if (propWrapperUtil.isPropWrapperFunction(context, context.getSource(node.callee)) && innerNode) {
+          if (
+            propWrapperUtil.isPropWrapperFunction(context, context.getSourceCode().getText(node.callee))
+            && innerNode
+          ) {
             checkNode(innerNode);
           }
           break;

--- a/lib/rules/jsx-closing-tag-location.js
+++ b/lib/rules/jsx-closing-tag-location.js
@@ -27,7 +27,6 @@ module.exports = {
       url: docsUrl('jsx-closing-tag-location'),
     },
     fixable: 'whitespace',
-
     messages,
   },
 

--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -371,13 +371,13 @@ module.exports = {
       }
 
       const sourceCode = context.getSourceCode();
-      const first = context.getFirstToken(node);
+      const first = sourceCode.getFirstToken(node);
       const last = sourceCode.getLastToken(node);
-      let second = context.getTokenAfter(first, { includeComments: true });
+      let second = sourceCode.getTokenAfter(first, { includeComments: true });
       let penultimate = sourceCode.getTokenBefore(last, { includeComments: true });
 
       if (!second) {
-        second = context.getTokenAfter(first);
+        second = sourceCode.getTokenAfter(first);
         const leadingComments = sourceCode.getNodeByRangeIndex(second.range[0]).leadingComments;
         second = leadingComments ? leadingComments[0] : second;
       }

--- a/lib/rules/jsx-sort-default-props.js
+++ b/lib/rules/jsx-sort-default-props.js
@@ -61,7 +61,7 @@ module.exports = {
       // (babel-eslint@5 does not expose property name so we have to rely on tokens)
       }
       if (node.type === 'ClassProperty') {
-        const tokens = context.getFirstTokens(node, 2);
+        const tokens = context.getSourceCode().getFirstTokens(node, 2);
         return tokens[1] && tokens[1].type === 'Identifier' ? tokens[1].value : tokens[0].value;
       }
       return '';

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "babel-eslint": "^8 || ^9 || ^10.1.0",
     "eslint": "^3 || ^4 || ^5 || ^6 || ^7",
     "eslint-config-airbnb-base": "^14.2.1",
-    "eslint-plugin-eslint-plugin": "^2.3.0 || ^3.5.3",
+    "eslint-plugin-eslint-plugin": "^2.3.0 || ^3.5.3 || ^4.0.1",
     "eslint-plugin-import": "^2.25.2",
     "eslint-remote-tester": "^1.3.1",
     "eslint-remote-tester-repositories": "^0.0.3",


### PR DESCRIPTION
https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/releases/tag/v4.0.0

* Replaces a few deprecated ESLint functions - [eslint-plugin/no-deprecated-context-methods](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/no-deprecated-context-methods.md)

[eslint-plugin/require-meta-type](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/require-meta-type.md) would be a good rule to enable later.