### PR TITLE
[Fix] `no-unstable-components`: improve handling of objects containing render functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 * [`no-unused-prop-types`], `usedPropTypes`: avoid crash with typescript-eslint parser (@ljharb)
 * [`display-name`]: unwrap TS `as` expressions ([#3110][] @ljharb)
 * [`destructuring-assignment`]: detect refs nested in functions ([#3102] @ljharb)
+* [`no-unstable-components`]: improve handling of objects containing render function properties ([#3111] @fizwidget)
 
+[#3111]: https://github.com/yannickcr/eslint-plugin-react/pull/3111
 [#3110]: https://github.com/yannickcr/eslint-plugin-react/pull/3110
 [#3102]: https://github.com/yannickcr/eslint-plugin-react/issue/3102
 [#3092]: https://github.com/yannickcr/eslint-plugin-react/pull/3092

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -106,6 +106,19 @@ function isJSXAttributeOfExpressionContainerMatcher(node) {
 }
 
 /**
+ * Matcher used to check whether given node is an object `Property`
+ * @param {ASTNode} node The AST node
+ * @returns {Boolean} True if node is a `Property`, false if not
+ */
+function isPropertyOfObjectExpressionMatcher(node) {
+  return (
+    node
+    && node.parent
+    && node.parent.type === 'Property'
+  );
+}
+
+/**
  * Matcher used to check whether given node is a `CallExpression`
  * @param {ASTNode} node The AST node
  * @returns {Boolean} True if node is a `CallExpression`, false if not
@@ -358,14 +371,19 @@ module.exports = {
     }
 
     /**
-     * Check whether given node is declared inside a component prop.
+     * Check whether given node is declared inside a component/object prop.
      * ```jsx
      * <Component footer={() => <div />} />
+     * { footer: () => <div /> }
      * ```
      * @param {ASTNode} node The AST node being checked
      * @returns {Boolean} True if node is a component declared inside prop, false if not
      */
     function isComponentInProp(node) {
+      if (isPropertyOfObjectExpressionMatcher(node)) {
+        return utils.isReturningJSX(node);
+      }
+
       const jsxAttribute = getClosestMatchingParent(node, context, isJSXAttributeOfExpressionContainerMatcher);
 
       if (!jsxAttribute) {

--- a/tests/lib/rules/no-unstable-nested-components.js
+++ b/tests/lib/rules/no-unstable-nested-components.js
@@ -385,6 +385,78 @@ ruleTester.run('no-unstable-nested-components', rule, {
     },
     {
       code: `
+      function ParentComponent() {
+        return (
+          <SomeComponent>
+            {
+              thing.match({
+                renderLoading: () => <div />,
+                renderSuccess: () => <div />,
+                renderFailure: () => <div />,
+              })
+            }
+          </SomeComponent>
+        )
+      }
+      `,
+    },
+    {
+      code: `
+      function ParentComponent() {
+        const thingElement = thing.match({
+          renderLoading: () => <div />,
+          renderSuccess: () => <div />,
+          renderFailure: () => <div />,
+        });
+        return (
+          <SomeComponent>
+            {thingElement}
+          </SomeComponent>
+        )
+      }
+      `,
+    },
+    {
+      code: `
+      function ParentComponent() {
+        return (
+          <SomeComponent>
+            {
+              thing.match({
+                loading: () => <div />,
+                success: () => <div />,
+                failure: () => <div />,
+              })
+            }
+          </SomeComponent>
+        )
+      }
+      `,
+      options: [{
+        allowAsProps: true,
+      }],
+    },
+    {
+      code: `
+      function ParentComponent() {
+        const thingElement = thing.match({
+          loading: () => <div />,
+          success: () => <div />,
+          failure: () => <div />,
+        });
+        return (
+          <SomeComponent>
+            {thingElement}
+          </SomeComponent>
+        )
+      }
+      `,
+      options: [{
+        allowAsProps: true,
+      }],
+    },
+    {
+      code: `
         function ParentComponent() {
           return (
             <ComponentForProps renderFooter={() => <div />} />
@@ -500,6 +572,9 @@ ruleTester.run('no-unstable-nested-components', rule, {
           return <Table rows={rows} />;
         }
       `,
+      options: [{
+        allowAsProps: true,
+      }],
     },
     /* TODO These minor cases are currently falsely marked due to component detection
     {
@@ -1041,6 +1116,64 @@ ruleTester.run('no-unstable-nested-components', rule, {
       `,
       // Only a single error should be shown. This can get easily marked twice.
       errors: [{ message: ERROR_MESSAGE }],
+    },
+    {
+      code: `
+      function ParentComponent() {
+        return (
+          <SomeComponent>
+            {
+              thing.match({
+                loading: () => <div />,
+                success: () => <div />,
+                failure: () => <div />,
+              })
+            }
+          </SomeComponent>
+        )
+      }
+      `,
+      errors: [
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+      ],
+    },
+    {
+      code: `
+      function ParentComponent() {
+        const thingElement = thing.match({
+          loading: () => <div />,
+          success: () => <div />,
+          failure: () => <div />,
+        });
+        return (
+          <SomeComponent>
+            {thingElement}
+          </SomeComponent>
+        )
+      }
+      `,
+      errors: [
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+        { message: ERROR_MESSAGE_COMPONENT_AS_PROPS },
+      ],
+    },
+    {
+      code: `
+      function ParentComponent() {
+        const rows = [
+          {
+            name: 'A',
+            notPrefixedWithRender: (props) => <Row {...props} />
+          },
+        ];
+
+        return <Table rows={rows} />;
+      }
+      `,
+      errors: [{ message: ERROR_MESSAGE_COMPONENT_AS_PROPS }],
     },
   ]),
 });


### PR DESCRIPTION
Hi folks, I ran into some false-positives when trying to enable this rule in a repository I work in. Hopefully the new test cases make the problem clear, but to summarise, this pattern currently causes the rule to fail (regardless whether `allowAsProps` is set):
```jsx
<SomeComponent>
  {thing.match({
    loading: () => <Loading />,
    success: () => <Success />,
    failure: () => <Error />,
  })}
</SomeComponent>
```

I consider this to be a false-positive because there aren't _actually_ any unstable components here - the functions are being used as "render functions", not as React components.

This PR tweaks the rule such that:
* When `allowAsProps` is _disabled_, this pattern should only be allowed if the property names are prefixed with `render`.
* When `allowAsProps` is _enabled_, this pattern should be allowed regardless of whether the property names are prefixed with `render`.

This effectively means object properties and component properties will be treated in the same way (which is not currently the case). Seems logical to me - let me know if I'm missing something though! 🙂

Cheers,
James