### PR TITLE
[Dev Deps] update `eslint-remote-tester`

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "eslint-config-airbnb-base": "^14.2.1",
     "eslint-plugin-eslint-plugin": "^2.3.0 || ^3.5.3 || ^4.0.1",
     "eslint-plugin-import": "^2.25.2",
-    "eslint-remote-tester": "^1.3.1",
+    "eslint-remote-tester": "^2.0.1",
     "eslint-remote-tester-repositories": "^0.0.3",
     "eslint-scope": "^3.7.3",
     "espree": "^3.5.4",


### PR DESCRIPTION
Fixes "Invalid hook call" of https://github.com/yannickcr/eslint-plugin-react/runs/4057441339?check_suite_focus=true. See https://github.com/AriPerkkio/eslint-remote-tester/pull/302. The previous smoke test was unable to log any output to stdout, but the test was still run successfully. Everything was linted properly, it was just the output which was missing.

- `eslint-remote-tester@2` fixes the react version conflicts. It also improves erroneous ruleId parsing when used with ESLint v8. It is compatible with ESLint 7. https://github.com/AriPerkkio/eslint-remote-tester/blob/master/CHANGELOG.md
