### PR TITLE
[Docs] `jsx-no-target-blank`: adjust options description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Changed
 * [Tests] test on the new babel eslint parser ([#3113] @ljharb)
+* [Docs] [`jsx-no-target-blank`]: adjust options description ([#3214] @gebsh)
 
+[#3214]: https://github.com/yannickcr/eslint-plugin-react/pull/3214
 [#3122]: https://github.com/yannickcr/eslint-plugin-react/pull/3122
 [#3113]: https://github.com/yannickcr/eslint-plugin-react/pull/3113
 [#3112]: https://github.com/yannickcr/eslint-plugin-react/pull/3112

--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -14,19 +14,19 @@ This rule aims to prevent user generated link hrefs and form actions from creati
 "react/jsx-no-target-blank": [<enabled>, {
   "allowReferrer": <allow-referrer>,
   "enforceDynamicLinks": <enforce>,
+  "warnOnSpreadAttributes": <warn>,
   "links": <boolean>,
   "forms": <boolean>,
 }]
 ...
 ```
 
-* `allowReferrer`: optional boolean. If `true` does not require `noreferrer` (i. e. `noopener` alone is enough, this leaves IE vulnerable). Defaults to `false`.
 * `enabled`: for enabling the rule.
-* `enforceDynamicLinks`: optional string, 'always' or 'never'
+* `allowReferrer`: optional boolean. If `true` does not require `noreferrer` (i. e. `noopener` alone is enough, this leaves IE vulnerable). Defaults to `false`.
+* `enforceDynamicLinks`: optional string, `'always'` or `'never'`.
 * `warnOnSpreadAttributes`: optional boolean. Defaults to `false`.
-* `enforceDynamicLinks` - enforce: optional string, 'always' or 'never'
-* `links` - Prevent usage of unsafe `target='_blank'` inside links, defaults to `true`
-* `forms` - Prevent usage of unsafe `target='_blank'` inside forms, defaults to `false`
+* `links`: prevent usage of unsafe `target='_blank'` inside links, defaults to `true`.
+* `forms`: prevent usage of unsafe `target='_blank'` inside forms, defaults to `false`.
 
 ### `enforceDynamicLinks`
 


### PR DESCRIPTION
Fixes #3123.

Additionally:

- I added the missing `warnOnSpreadAttributes` option to the code block with a rule configuration.
- Rearranged items on the enumeration list so that they match the order of options in the mentioned code block.
- Adjusted formatting of those items so that all of them have the same style. (I chose the colon over the hyphen, as that's how most other rules have their options described.)