### PR TITLE
[Fix] `no-unused-class-component-methods`: add getChildContext lifecycle method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 
 ### Fixed
 * [`no-invalid-html-attribute`]: allow `link` `rel` to have `apple-touch-icon`, `mask-icon` ([#3132][] @ljharb)
+* [`no-unused-class-component-methods`]: add `getChildContext` lifecycle method ([#3136][] @yoyo837)
 
+[#3136]: https://github.com/yannickcr/eslint-plugin-react/pull/3136
 [#3132]: https://github.com/yannickcr/eslint-plugin-react/issue/3132
 
 ## [7.27.0] - 2021.11.09

--- a/lib/rules/no-unused-class-component-methods.js
+++ b/lib/rules/no-unused-class-component-methods.js
@@ -21,6 +21,7 @@ const LIFECYCLE_METHODS = new Set([
   'componentWillReceiveProps',
   'componentWillUnmount',
   'componentWillUpdate',
+  'getChildContext',
   'getSnapshotBeforeUpdate',
   'render',
   'shouldComponentUpdate',

--- a/tests/lib/rules/no-unused-class-component-methods.js
+++ b/tests/lib/rules/no-unused-class-component-methods.js
@@ -438,6 +438,7 @@ ruleTester.run('no-unused-class-component-methods', rule, {
           componentDidUpdate() {}
           componentDidCatch() {}
           componentWillUnmount() {}
+          getChildContext() {}
           render() {
             return <SomeComponent />;
           }
@@ -467,6 +468,7 @@ ruleTester.run('no-unused-class-component-methods', rule, {
           componentDidUpdate() {},
           componentDidCatch() {},
           componentWillUnmount() {},
+          getChildContext() {},
           render() {
             return <SomeComponent />;
           },


### PR DESCRIPTION
fix #3135