### PR TITLE
[Fix] `prop-types`: fix false positives on renames in object destructuring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ This change log adheres to standards from [Keep a CHANGELOG](http://keepachangel
 ### Fixed
 * [`no-invalid-html-attribute`]: allow `link` `rel` to have `apple-touch-icon`, `mask-icon` ([#3132][] @ljharb)
 * [`no-unused-class-component-methods`]: add `getChildContext` lifecycle method ([#3136][] @yoyo837)
+* [`prop-types`]: fix false positives on renames in object destructuring ([#3142][] @golopot)
 
 ### Changed
 * [readme] fix syntax typo ([#3141][] @moselhy)
 
+[#3142]: https://github.com/yannickcr/eslint-plugin-react/pull/3142
 [#3141]: https://github.com/yannickcr/eslint-plugin-react/pull/3141
 [#3136]: https://github.com/yannickcr/eslint-plugin-react/pull/3136
 [#3132]: https://github.com/yannickcr/eslint-plugin-react/issue/3132

--- a/lib/util/usedPropTypes.js
+++ b/lib/util/usedPropTypes.js
@@ -395,7 +395,7 @@ module.exports = function usedPropTypesInstructions(context, components, utils) 
           if (properties[k].value.type === 'ObjectPattern') {
             markPropTypesAsUsed(properties[k].value, parentNames.concat([propName]));
           } else if (properties[k].value.type === 'Identifier') {
-            propVariables.set(propName, parentNames.concat(propName));
+            propVariables.set(properties[k].value.name, parentNames.concat(propName));
           }
         }
         break;

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -4921,7 +4921,7 @@ ruleTester.run('no-unused-prop-types', rule, {
             foo: PropTypes.string,
             bar: PropTypes.string,
           };
-        
+
           componentWillUpdate (nextProps) {
             if (nextProps.foo) {
               return true;
@@ -4994,7 +4994,7 @@ ruleTester.run('no-unused-prop-types', rule, {
             foo: PropTypes.string,
             bar: PropTypes.string,
           };
-        
+
           shouldComponentUpdate (nextProps) {
             if (nextProps.foo) {
               return true;
@@ -5086,7 +5086,7 @@ ruleTester.run('no-unused-prop-types', rule, {
             foo: PropTypes.string,
             bar: PropTypes.string,
           };
-        
+
           componentDidUpdate (nextProps) {
             if (nextProps.foo) {
               return true;
@@ -5319,7 +5319,7 @@ ruleTester.run('no-unused-prop-types', rule, {
     {
       // None of the props are used issue #1162
       code: `
-        import React from "react"; 
+        import React from "react";
         var Hello = React.createReactClass({
          propTypes: {
            name: React.PropTypes.string

--- a/tests/lib/rules/prop-types.js
+++ b/tests/lib/rules/prop-types.js
@@ -3542,6 +3542,28 @@ ruleTester.run('prop-types', rule, {
         }
       `,
       features: ['class fields'],
+    },
+
+    // #2944
+    {
+      code: `
+        const styles = { width: 0 };
+
+        function Foo(props) {
+          const { styles: x } = props;
+          return (
+            <p>
+              {styles.width} {x._}
+            </p>
+          );
+        }
+
+        Foo.propTypes = {
+          styles: PropTypes.shape({
+            _: PropTypes.number,
+          }),
+        };
+      `,
     }
   )),
 


### PR DESCRIPTION
Fixes #2944.

```js
const { styles: x } = props;
```
Our code incorrectly picks up `styles` as a prop, while `x` is the correct one.