### PR TITLE
[Test] parsers.all augments suggestion code output

### DIFF
--- a/tests/helpers/parsers.js
+++ b/tests/helpers/parsers.js
@@ -66,12 +66,52 @@ const parsers = {
           testObject.parserOptions ? `parserOptions: ${JSON.stringify(testObject.parserOptions)}` : [],
           testObject.options ? `options: ${JSON.stringify(testObject.options)}` : []
         );
+
         const extraComment = `\n// ${extras.join(', ')}`;
+
+        // Augment expected fix code output with extraComment
+        const nextCode = { code: testObject.code + extraComment };
+        const nextOutput = testObject.output && { output: testObject.output + extraComment };
+
+        // Augment expected suggestion outputs with extraComment
+        // `errors` may be a number (expected number of errors) or an array of
+        // error objects.
+        const nextErrors = testObject.errors
+          && typeof testObject.errors !== 'number'
+          && {
+            errors: testObject.errors.map(
+              (errorObject) => {
+                const nextSuggestions = errorObject.suggestions && {
+                  suggestions: errorObject.suggestions.map(
+                    (suggestion) => {
+                      const nextSuggestion = Object.assign(
+                        {},
+                        suggestion,
+                        { output: suggestion.output + extraComment }
+                      );
+
+                      return nextSuggestion;
+                    }
+                  ),
+                };
+
+                const nextErrorObject = Object.assign(
+                  {},
+                  errorObject,
+                  nextSuggestions
+                );
+
+                return nextErrorObject;
+              }
+            ),
+          };
+
         return Object.assign(
           {},
           testObject,
-          { code: testObject.code + extraComment },
-          testObject.output && { output: testObject.output + extraComment }
+          nextCode,
+          nextOutput,
+          nextErrors
         );
       }
 


### PR DESCRIPTION
In order to generate suggestions for https://github.com/yannickcr/eslint-plugin-react/pull/2921 I need support for augmenting suggestions in the `parsers.all` work, to ensure my spec examples get decorated with the `extraComment`.

### 🗣 Discussion

parsers.all generates an `extraComment` which is appended to test case examples and their expected output.
Eslint's suggestions API also allows recommended code changes, and RuleTester compares expected changes against generated changes. However, `parsers.all` didn't augment these expected outputs with the `extraComment`.

![2021-12-10 at 8 28 PM](https://user-images.githubusercontent.com/7367/145664843-5bb6ca39-4be4-4c2c-83d7-0be67a3d8740.png)

### 📋 Next steps

I intend to include these changes with the `hook-use-state` PR where the utility will be more obvious, but I wanted to open discussion here in case my approach needs to be refined, and to keep the already long-running `hook-use-state` PR focused.