### PR TITLE
disable react/react-in-jsx-scope for react versions 17 and above

### DIFF
--- a/lib/rules/react-in-jsx-scope.js
+++ b/lib/rules/react-in-jsx-scope.js
@@ -6,6 +6,7 @@
 'use strict';
 
 const variableUtil = require('../util/variable');
+const versionUtil = require('../util/version');
 const pragmaUtil = require('../util/pragma');
 const docsUrl = require('../util/docsUrl');
 const report = require('../util/report');
@@ -37,6 +38,10 @@ module.exports = {
 
     function checkIfReactIsInScope(node) {
       const variables = variableUtil.variablesInScope(context);
+      const majorVersion = versionUtil.getReactMajorVersion(context);
+      if(majorVersion >= 17) {
+        return;
+      }
       if (variableUtil.findVariable(variables, pragma)) {
         return;
       }

--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -153,9 +153,14 @@ function testFlowVersion(context, methodVer) {
   return test(context, methodVer, getFlowVersionFromContext(context));
 }
 
+function getReactMajorVersion(context) {
+  return getReactVersionFromContext(context)[0];
+}
+
 module.exports = {
   testReactVersion,
   testFlowVersion,
   resetWarningFlag,
   resetDetectedVersion,
+  getReactMajorVersion,
 };


### PR DESCRIPTION
disable `react/react-in-jsx-scope` for react versions 17 and above because importing react for jsx components was deprecated in react 17 and will be removed in react 18