### PR TITLE
Add --fix-type support

### DIFF
--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -21,6 +21,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       category: 'Stylistic Issues',
       description: 'Enforces consistent naming for boolean props',

--- a/lib/rules/button-has-type.js
+++ b/lib/rules/button-has-type.js
@@ -30,6 +30,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Forbid "button" element without an explicit "type" attribute',
       category: 'Possible Errors',

--- a/lib/rules/default-props-match-prop-types.js
+++ b/lib/rules/default-props-match-prop-types.js
@@ -21,6 +21,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce all defaultProps are defined and not "required" in propTypes.',
       category: 'Best Practices',

--- a/lib/rules/destructuring-assignment.js
+++ b/lib/rules/destructuring-assignment.js
@@ -54,6 +54,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce consistent usage of destructuring assignment of props, state, and context',
       category: 'Stylistic Issues',

--- a/lib/rules/display-name.js
+++ b/lib/rules/display-name.js
@@ -23,6 +23,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent missing displayName in a React component definition',
       category: 'Best Practices',

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -24,7 +24,7 @@ const messages = {
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description: 'Forbid certain props on components',
       category: 'Best Practices',

--- a/lib/rules/forbid-component-props.js
+++ b/lib/rules/forbid-component-props.js
@@ -24,6 +24,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Forbid certain props on components',
       category: 'Best Practices',

--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -24,7 +24,7 @@ const messages = {
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description: 'Forbid certain props on DOM Nodes',
       category: 'Best Practices',

--- a/lib/rules/forbid-dom-props.js
+++ b/lib/rules/forbid-dom-props.js
@@ -24,6 +24,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Forbid certain props on DOM Nodes',
       category: 'Best Practices',

--- a/lib/rules/forbid-elements.js
+++ b/lib/rules/forbid-elements.js
@@ -21,6 +21,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Forbid certain elements',
       category: 'Best Practices',

--- a/lib/rules/forbid-elements.js
+++ b/lib/rules/forbid-elements.js
@@ -21,7 +21,7 @@ const messages = {
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description: 'Forbid certain elements',
       category: 'Best Practices',

--- a/lib/rules/forbid-foreign-prop-types.js
+++ b/lib/rules/forbid-foreign-prop-types.js
@@ -15,6 +15,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Forbid using another component\'s propTypes',
       category: 'Best Practices',

--- a/lib/rules/forbid-prop-types.js
+++ b/lib/rules/forbid-prop-types.js
@@ -27,6 +27,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Forbid certain propTypes',
       category: 'Best Practices',

--- a/lib/rules/function-component-definition.js
+++ b/lib/rules/function-component-definition.js
@@ -100,6 +100,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Standardize the way function component get defined',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-boolean-value.js
+++ b/lib/rules/jsx-boolean-value.js
@@ -56,6 +56,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce boolean attributes notation in JSX',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-child-element-spacing.js
+++ b/lib/rules/jsx-child-element-spacing.js
@@ -46,13 +46,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Ensures inline tags are not rendered without spaces between them',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-child-element-spacing'),
     },
-    fixable: null,
+    // fixable: null,
 
     messages,
 

--- a/lib/rules/jsx-child-element-spacing.js
+++ b/lib/rules/jsx-child-element-spacing.js
@@ -53,7 +53,6 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-child-element-spacing'),
     },
-    // fixable: null,
 
     messages,
 

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -19,13 +19,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Validate closing bracket location in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-closing-bracket-location'),
     },
-    fixable: 'code',
+    fixable: 'whitespace',
 
     messages,
 

--- a/lib/rules/jsx-closing-bracket-location.js
+++ b/lib/rules/jsx-closing-bracket-location.js
@@ -26,7 +26,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-closing-bracket-location'),
     },
-    fixable: 'whitespace',
+    fixable: 'code',
 
     messages,
 

--- a/lib/rules/jsx-closing-tag-location.js
+++ b/lib/rules/jsx-closing-tag-location.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Validate closing tag location for multiline JSX',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -38,6 +38,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description:
         'Disallow unnecessary JSX expressions when literals alone are sufficient '

--- a/lib/rules/jsx-curly-newline.js
+++ b/lib/rules/jsx-curly-newline.js
@@ -44,16 +44,13 @@ const messages = {
 module.exports = {
   meta: {
     type: 'layout',
-
     docs: {
       description: 'Enforce consistent line breaks inside jsx curly',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-curly-newline'),
     },
-
     fixable: 'whitespace',
-
     schema: [
       {
         oneOf: [

--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -43,7 +43,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-curly-spacing'),
     },
-    fixable: 'whitespace',
+    fixable: 'code',
 
     messages,
 

--- a/lib/rules/jsx-curly-spacing.js
+++ b/lib/rules/jsx-curly-spacing.js
@@ -36,13 +36,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Enforce or disallow spaces inside of curly braces in JSX attributes',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-curly-spacing'),
     },
-    fixable: 'code',
+    fixable: 'whitespace',
 
     messages,
 

--- a/lib/rules/jsx-equals-spacing.js
+++ b/lib/rules/jsx-equals-spacing.js
@@ -28,7 +28,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-equals-spacing'),
     },
-    fixable: 'whitespace',
+    fixable: 'code',
 
     messages,
 

--- a/lib/rules/jsx-equals-spacing.js
+++ b/lib/rules/jsx-equals-spacing.js
@@ -21,13 +21,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Disallow or enforce spaces around equal signs in JSX attributes',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-equals-spacing'),
     },
-    fixable: 'code',
+    fixable: 'whitespace',
 
     messages,
 

--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -29,6 +29,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Restrict file extensions that may contain JSX',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -19,13 +19,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Ensure proper position of the first property in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-first-prop-new-line'),
     },
-    fixable: 'code',
+    fixable: 'whitespace',
 
     messages,
 

--- a/lib/rules/jsx-first-prop-new-line.js
+++ b/lib/rules/jsx-first-prop-new-line.js
@@ -26,7 +26,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-first-prop-new-line'),
     },
-    fixable: 'whitespace',
+    fixable: 'code',
 
     messages,
 

--- a/lib/rules/jsx-fragments.js
+++ b/lib/rules/jsx-fragments.js
@@ -29,6 +29,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce shorthand or standard form for React fragments',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-handler-names.js
+++ b/lib/rules/jsx-handler-names.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce event handler naming conventions in JSX',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -44,13 +44,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Validate props indentation in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-indent-props'),
     },
-    fixable: 'code',
+    fixable: 'whitespace',
 
     messages,
 

--- a/lib/rules/jsx-indent-props.js
+++ b/lib/rules/jsx-indent-props.js
@@ -51,7 +51,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-indent-props'),
     },
-    fixable: 'whitespace',
+    fixable: 'code',
 
     messages,
 

--- a/lib/rules/jsx-indent.js
+++ b/lib/rules/jsx-indent.js
@@ -46,6 +46,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Validate JSX indentation',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-key.js
+++ b/lib/rules/jsx-key.js
@@ -30,6 +30,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Report missing `key` props in iterators/collection literals',
       category: 'Possible Errors',

--- a/lib/rules/jsx-max-depth.js
+++ b/lib/rules/jsx-max-depth.js
@@ -22,6 +22,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Validate JSX maximum depth',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -25,13 +25,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Limit maximum of props on a single line in JSX',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-max-props-per-line'),
     },
-    fixable: 'code',
+    fixable: 'whitespace',
 
     messages,
 

--- a/lib/rules/jsx-max-props-per-line.js
+++ b/lib/rules/jsx-max-props-per-line.js
@@ -32,7 +32,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-max-props-per-line'),
     },
-    fixable: 'whitespace',
+    fixable: 'code',
 
     messages,
 

--- a/lib/rules/jsx-newline.js
+++ b/lib/rules/jsx-newline.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Require or prevent a new line after jsx elements and expressions.',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-no-bind.js
+++ b/lib/rules/jsx-no-bind.js
@@ -26,6 +26,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevents usage of Function.prototype.bind and arrow functions in React component props',
       category: 'Best Practices',

--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -35,6 +35,7 @@ function checkText(node, context) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Comments inside children section of tag should be placed inside braces',
       category: 'Possible Errors',

--- a/lib/rules/jsx-no-comment-textnodes.js
+++ b/lib/rules/jsx-no-comment-textnodes.js
@@ -35,7 +35,7 @@ function checkText(node, context) {
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description: 'Comments inside children section of tag should be placed inside braces',
       category: 'Possible Errors',

--- a/lib/rules/jsx-no-constructed-context-values.js
+++ b/lib/rules/jsx-no-constructed-context-values.js
@@ -130,6 +130,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevents JSX context provider values from taking values that will cause needless rerenders.',
       category: 'Best Practices',

--- a/lib/rules/jsx-no-duplicate-props.js
+++ b/lib/rules/jsx-no-duplicate-props.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Enforce no duplicate props',
       category: 'Possible Errors',

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -26,6 +26,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent using string literals in React component definition',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-no-script-url.js
+++ b/lib/rules/jsx-no-script-url.js
@@ -49,6 +49,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Forbid `javascript:` URLs',
       category: 'Best Practices',

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -103,6 +103,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     fixable: 'code',
     docs: {
       description: 'Forbid `target="_blank"` attribute without `rel="noreferrer"`',

--- a/lib/rules/jsx-no-undef.js
+++ b/lib/rules/jsx-no-undef.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Disallow undeclared variables in JSX',
       category: 'Possible Errors',

--- a/lib/rules/jsx-one-expression-per-line.js
+++ b/lib/rules/jsx-one-expression-per-line.js
@@ -23,6 +23,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Limit to one expression per line in JSX',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-pascal-case.js
+++ b/lib/rules/jsx-pascal-case.js
@@ -78,6 +78,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce PascalCase for user-defined JSX components',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-props-no-multi-spaces.js
+++ b/lib/rules/jsx-props-no-multi-spaces.js
@@ -26,7 +26,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-props-no-multi-spaces'),
     },
-    fixable: 'whitespace',
+    fixable: 'code',
 
     messages,
 

--- a/lib/rules/jsx-props-no-multi-spaces.js
+++ b/lib/rules/jsx-props-no-multi-spaces.js
@@ -19,13 +19,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Disallow multiple spaces between inline JSX props',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('jsx-props-no-multi-spaces'),
     },
-    fixable: 'code',
+    fixable: 'whitespace',
 
     messages,
 

--- a/lib/rules/jsx-props-no-spreading.js
+++ b/lib/rules/jsx-props-no-spreading.js
@@ -40,6 +40,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent JSX prop spreading',
       category: 'Best Practices',

--- a/lib/rules/jsx-sort-default-props.js
+++ b/lib/rules/jsx-sort-default-props.js
@@ -21,6 +21,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce default props alphabetical sorting',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -215,6 +215,7 @@ function validateReservedFirstConfig(context, reservedFirst) {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce props alphabetical sorting',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -32,7 +32,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-space-before-closing'),
     },
-    fixable: 'whitespace',
+    fixable: 'code',
 
     messages,
 

--- a/lib/rules/jsx-space-before-closing.js
+++ b/lib/rules/jsx-space-before-closing.js
@@ -24,6 +24,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     deprecated: true,
     docs: {
       description: 'Validate spacing before closing bracket in JSX',
@@ -31,7 +32,7 @@ module.exports = {
       recommended: false,
       url: docsUrl('jsx-space-before-closing'),
     },
-    fixable: 'code',
+    fixable: 'whitespace',
 
     messages,
 

--- a/lib/rules/jsx-tag-spacing.js
+++ b/lib/rules/jsx-tag-spacing.js
@@ -215,6 +215,7 @@ const optionDefaults = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Validate whitespace in and around the JSX opening and closing brackets',
       category: 'Stylistic Issues',

--- a/lib/rules/jsx-uses-react.js
+++ b/lib/rules/jsx-uses-react.js
@@ -14,6 +14,7 @@ const docsUrl = require('../util/docsUrl');
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent React to be marked as unused',
       category: 'Best Practices',

--- a/lib/rules/jsx-uses-vars.js
+++ b/lib/rules/jsx-uses-vars.js
@@ -16,6 +16,7 @@ const isTagName = (name) => isTagNameRe.test(name);
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent variables used in JSX to be marked as unused',
       category: 'Best Practices',

--- a/lib/rules/jsx-wrap-multilines.js
+++ b/lib/rules/jsx-wrap-multilines.js
@@ -35,6 +35,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'layout',
     docs: {
       description: 'Prevent missing parentheses around multilines JSX',
       category: 'Stylistic Issues',

--- a/lib/rules/no-access-state-in-setstate.js
+++ b/lib/rules/no-access-state-in-setstate.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Reports when this.state is accessed within setState',
       category: 'Possible Errors',

--- a/lib/rules/no-adjacent-inline-elements.js
+++ b/lib/rules/no-adjacent-inline-elements.js
@@ -77,8 +77,8 @@ const messages = {
 };
 
 module.exports = {
-  type: 'suggestion',
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent adjacent inline elements not separated by whitespace.',
       category: 'Best Practices',

--- a/lib/rules/no-adjacent-inline-elements.js
+++ b/lib/rules/no-adjacent-inline-elements.js
@@ -77,6 +77,7 @@ const messages = {
 };
 
 module.exports = {
+  type: 'suggestion',
   meta: {
     docs: {
       description: 'Prevent adjacent inline elements not separated by whitespace.',

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -24,7 +24,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'Prevent usage of Array index in keys',
-      category: 'Possible Errors',
+      category: 'Best Practices',
       recommended: false,
       url: docsUrl('no-array-index-key'),
     },

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -21,9 +21,10 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent usage of Array index in keys',
-      category: 'Best Practices',
+      category: 'Possible Errors',
       recommended: false,
       url: docsUrl('no-array-index-key'),
     },

--- a/lib/rules/no-arrow-function-lifecycle.js
+++ b/lib/rules/no-arrow-function-lifecycle.js
@@ -33,6 +33,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Lifecycle methods should be methods on the prototype, not class fields',
       category: 'Best Practices',

--- a/lib/rules/no-children-prop.js
+++ b/lib/rules/no-children-prop.js
@@ -39,6 +39,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent passing of children as props.',
       category: 'Best Practices',

--- a/lib/rules/no-danger-with-children.js
+++ b/lib/rules/no-danger-with-children.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Report when a DOM element is using both children and dangerouslySetInnerHTML',
       category: 'Possible Errors',

--- a/lib/rules/no-danger.js
+++ b/lib/rules/no-danger.js
@@ -45,6 +45,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent usage of dangerous JSX props',
       category: 'Best Practices',

--- a/lib/rules/no-deprecated.js
+++ b/lib/rules/no-deprecated.js
@@ -35,6 +35,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent usage of deprecated methods',
       category: 'Best Practices',

--- a/lib/rules/no-direct-mutation-state.js
+++ b/lib/rules/no-direct-mutation-state.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent direct mutation of this.state',
       category: 'Possible Errors',

--- a/lib/rules/no-find-dom-node.js
+++ b/lib/rules/no-find-dom-node.js
@@ -18,6 +18,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent usage of findDOMNode',
       category: 'Best Practices',

--- a/lib/rules/no-invalid-html-attribute.js
+++ b/lib/rules/no-invalid-html-attribute.js
@@ -478,6 +478,7 @@ function checkCreateProps(context, node, attribute) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     fixable: 'code',
     docs: {
       description: 'Forbid attribute with an invalid values`',

--- a/lib/rules/no-is-mounted.js
+++ b/lib/rules/no-is-mounted.js
@@ -18,6 +18,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent usage of isMounted',
       category: 'Best Practices',

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent multiple component definition per file',
       category: 'Stylistic Issues',

--- a/lib/rules/no-namespace.js
+++ b/lib/rules/no-namespace.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Enforce that namespaces are not used in React elements',
       category: 'Possible Errors',

--- a/lib/rules/no-redundant-should-component-update.js
+++ b/lib/rules/no-redundant-should-component-update.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Flag shouldComponentUpdate when extending PureComponent',
       category: 'Possible Errors',

--- a/lib/rules/no-render-return-value.js
+++ b/lib/rules/no-render-return-value.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent usage of the return value of React.render',
       category: 'Best Practices',

--- a/lib/rules/no-set-state.js
+++ b/lib/rules/no-set-state.js
@@ -19,6 +19,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent usage of setState',
       category: 'Stylistic Issues',

--- a/lib/rules/no-string-refs.js
+++ b/lib/rules/no-string-refs.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent string definitions for references and prevent referencing this.refs',
       category: 'Best Practices',

--- a/lib/rules/no-this-in-sfc.js
+++ b/lib/rules/no-this-in-sfc.js
@@ -18,6 +18,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Report "this" being used in stateless components',
       category: 'Possible Errors',

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -29,6 +29,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent common typos',
       category: 'Stylistic Issues',

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -32,7 +32,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'Prevent common typos',
-      category: 'Possible Errors',
+      category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('no-typos'),
     },

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -29,10 +29,10 @@ const messages = {
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description: 'Prevent common typos',
-      category: 'Stylistic Issues',
+      category: 'Possible Errors',
       recommended: false,
       url: docsUrl('no-typos'),
     },

--- a/lib/rules/no-unescaped-entities.js
+++ b/lib/rules/no-unescaped-entities.js
@@ -37,6 +37,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Detect unescaped HTML entities, which might represent malformed tags',
       category: 'Possible Errors',

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -219,6 +219,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent usage of unknown DOM property',
       category: 'Possible Errors',

--- a/lib/rules/no-unsafe.js
+++ b/lib/rules/no-unsafe.js
@@ -21,6 +21,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent usage of unsafe lifecycle methods',
       category: 'Best Practices',

--- a/lib/rules/no-unstable-nested-components.js
+++ b/lib/rules/no-unstable-nested-components.js
@@ -268,6 +268,7 @@ function resolveComponentName(node) {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent creating unstable components inside components',
       category: 'Possible Errors',

--- a/lib/rules/no-unused-class-component-methods.js
+++ b/lib/rules/no-unused-class-component-methods.js
@@ -100,6 +100,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent declaring unused methods of component class',
       category: 'Best Practices',

--- a/lib/rules/no-unused-prop-types.js
+++ b/lib/rules/no-unused-prop-types.js
@@ -22,6 +22,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent definitions of unused prop types',
       category: 'Best Practices',

--- a/lib/rules/no-unused-state.js
+++ b/lib/rules/no-unused-state.js
@@ -79,6 +79,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent definition of unused state fields',
       category: 'Best Practices',

--- a/lib/rules/prefer-es6-class.js
+++ b/lib/rules/prefer-es6-class.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce ES5 or ES6 class for React Components',
       category: 'Stylistic Issues',

--- a/lib/rules/prefer-exact-props.js
+++ b/lib/rules/prefer-exact-props.js
@@ -22,6 +22,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prefer exact proptype definitions',
       category: 'Possible Errors',

--- a/lib/rules/prefer-read-only-props.js
+++ b/lib/rules/prefer-read-only-props.js
@@ -34,6 +34,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Require read-only props.',
       category: 'Stylistic Issues',

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -23,6 +23,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce stateless components to be written as a pure function',
       category: 'Stylistic Issues',

--- a/lib/rules/prop-types.js
+++ b/lib/rules/prop-types.js
@@ -22,6 +22,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent missing props validation in a React component definition',
       category: 'Best Practices',

--- a/lib/rules/react-in-jsx-scope.js
+++ b/lib/rules/react-in-jsx-scope.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Prevent missing React when using JSX',
       category: 'Possible Errors',

--- a/lib/rules/require-default-props.js
+++ b/lib/rules/require-default-props.js
@@ -21,6 +21,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce a defaultProps definition for every prop that is not a required prop.',
       category: 'Best Practices',

--- a/lib/rules/require-optimization.js
+++ b/lib/rules/require-optimization.js
@@ -15,6 +15,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce React components to have a shouldComponentUpdate method',
       category: 'Best Practices',

--- a/lib/rules/require-render-return.js
+++ b/lib/rules/require-render-return.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Enforce ES5 or ES6 class for returning value in render function',
       category: 'Possible Errors',

--- a/lib/rules/self-closing-comp.js
+++ b/lib/rules/self-closing-comp.js
@@ -21,6 +21,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent extra closing tags for components without children',
       category: 'Stylistic Issues',

--- a/lib/rules/sort-comp.js
+++ b/lib/rules/sort-comp.js
@@ -87,6 +87,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce component methods order',
       category: 'Stylistic Issues',

--- a/lib/rules/sort-prop-types.js
+++ b/lib/rules/sort-prop-types.js
@@ -23,6 +23,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Enforce propTypes declarations alphabetical sorting',
       category: 'Stylistic Issues',

--- a/lib/rules/state-in-constructor.js
+++ b/lib/rules/state-in-constructor.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'State initialization in an ES6 class component should be in a constructor',
       category: 'Stylistic Issues',

--- a/lib/rules/static-property-placement.js
+++ b/lib/rules/static-property-placement.js
@@ -63,7 +63,6 @@ module.exports = {
       recommended: false,
       url: docsUrl('static-property-placement'),
     },
-    // fixable: null, // or 'code' or 'whitespace'
 
     messages,
 

--- a/lib/rules/static-property-placement.js
+++ b/lib/rules/static-property-placement.js
@@ -56,13 +56,14 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Defines where React component static properties should be positioned.',
       category: 'Stylistic Issues',
       recommended: false,
       url: docsUrl('static-property-placement'),
     },
-    fixable: null, // or 'code' or 'whitespace'
+    // fixable: null, // or 'code' or 'whitespace'
 
     messages,
 

--- a/lib/rules/style-prop-object.js
+++ b/lib/rules/style-prop-object.js
@@ -20,6 +20,7 @@ const messages = {
 
 module.exports = {
   meta: {
+    type: 'problem',
     docs: {
       description: 'Enforce style prop value is an object',
       category: 'Possible Errors',

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -52,7 +52,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'Prevent passing of children to void DOM elements (e.g. `<br />`).',
-      category: 'Best Practices',
+      category: 'Possible Errors',
       recommended: false,
       url: docsUrl('void-dom-elements-no-children'),
     },

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -49,7 +49,7 @@ const noChildrenInVoidEl = 'Void DOM element <{{element}} /> cannot receive chil
 
 module.exports = {
   meta: {
-    type: 'suggestion',
+    type: 'problem',
     docs: {
       description: 'Prevent passing of children to void DOM elements (e.g. `<br />`).',
       category: 'Best Practices',

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -52,7 +52,7 @@ module.exports = {
     type: 'problem',
     docs: {
       description: 'Prevent passing of children to void DOM elements (e.g. `<br />`).',
-      category: 'Possible Errors',
+      category: 'Best Practices',
       recommended: false,
       url: docsUrl('void-dom-elements-no-children'),
     },

--- a/lib/rules/void-dom-elements-no-children.js
+++ b/lib/rules/void-dom-elements-no-children.js
@@ -49,6 +49,7 @@ const noChildrenInVoidEl = 'Void DOM element <{{element}} /> cannot receive chil
 
 module.exports = {
   meta: {
+    type: 'suggestion',
     docs: {
       description: 'Prevent passing of children to void DOM elements (e.g. `<br />`).',
       category: 'Best Practices',

--- a/lib/util/makeNoMethodSetStateRule.js
+++ b/lib/util/makeNoMethodSetStateRule.js
@@ -32,6 +32,7 @@ const messages = {
 function makeNoMethodSetStateRule(methodName, shouldCheckUnsafeCb) {
   return {
     meta: {
+      type: 'suggestion',
       docs: {
         description: `Prevent usage of setState in ${methodName}`,
         category: 'Best Practices',


### PR DESCRIPTION
Add `type` property to all rules to support usage of eslint's `--fix-type` option

Fixes #2618. Fixes #2039.

Successor of this PR: https://github.com/yannickcr/eslint-plugin-react/pull/2619

