### PR TITLE
[New] `jsx-no-target-blank`: Improve fixer with option `allowReferrer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Added
 * add [`hook-use-state`] rule to enforce symmetric useState hook variable names ([#2921][] @duncanbeevers)
+* [`jsx-no-target-blank`]: Improve fixer with option `allowReferrer` ([#3167][] @apepper)
 
 ### Fixed
 * [`prop-types`], `propTypes`: add support for exported type inference ([#3163][] @vedadeepta)
@@ -17,6 +18,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Docs] HTTP => HTTPS ([#3133][] @Schweinepriester)
 
 [#3174]: https://github.com/yannickcr/eslint-plugin-react/pull/3174
+[#3167]: https://github.com/yannickcr/eslint-plugin-react/pull/3167
 [#3163]: https://github.com/yannickcr/eslint-plugin-react/pull/3163
 [#3160]: https://github.com/yannickcr/eslint-plugin-react/pull/3160
 [#3133]: https://github.com/yannickcr/eslint-plugin-react/pull/3133

--- a/lib/rules/jsx-no-target-blank.js
+++ b/lib/rules/jsx-no-target-blank.js
@@ -175,6 +175,7 @@ module.exports = {
             || (enforceDynamicLinks === 'always' && hasDynamicLink(node, linkAttribute));
           if (hasDangerousLink && !hasSecureRel(node, allowReferrer, warnOnSpreadAttributes, spreadAttributeIndex)) {
             const messageId = allowReferrer ? 'noTargetBlankWithoutNoopener' : 'noTargetBlankWithoutNoreferrer';
+            const relValue = allowReferrer ? 'noopener' : 'noreferrer';
             report(context, messages[messageId], messageId, {
               node,
               fix(fixer) {
@@ -188,11 +189,11 @@ module.exports = {
                 }
 
                 if (!relAttribute) {
-                  return fixer.insertTextAfter(nodeWithAttrs.attributes.slice(-1)[0], ' rel="noreferrer"');
+                  return fixer.insertTextAfter(nodeWithAttrs.attributes.slice(-1)[0], ` rel="${relValue}"`);
                 }
 
                 if (!relAttribute.value) {
-                  return fixer.insertTextAfter(relAttribute, '="noreferrer"');
+                  return fixer.insertTextAfter(relAttribute, `="${relValue}"`);
                 }
 
                 if (relAttribute.value.type === 'Literal') {

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -248,8 +248,14 @@ ruleTester.run('jsx-no-target-blank', rule, {
       errors: defaultErrors,
     },
     {
+      code: '<a href="https://example.com/20" target="_blank" rel></a>',
+      output: '<a href="https://example.com/20" target="_blank" rel="noopener"></a>',
+      options: [{ allowReferrer: true }],
+      errors: [{ messageId: 'noTargetBlankWithoutNoopener' }],
+    },
+    {
       code: '<a href="https://example.com/20" target="_blank"></a>',
-      output: '<a href="https://example.com/20" target="_blank" rel="noreferrer"></a>',
+      output: '<a href="https://example.com/20" target="_blank" rel="noopener"></a>',
       options: [{ allowReferrer: true }],
       errors: [{ messageId: 'noTargetBlankWithoutNoopener' }],
     },


### PR DESCRIPTION
> If you do not support Internet Explorer (any version), Chrome < 49, Opera < 36, Firefox < 52, desktop Safari < 10.1 or iOS Safari < 10.3, you may set `allowReferrer` to `true`, keep the HTTP Referer header and only add `rel="noopener"` to your links.

Source: https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md#when-to-override-it

This PR improves the fixer to use `rel="noopener"` if `allowReferrer` is set.