### PR TITLE
[Fix] `jsx-no-target-blank`: Improve readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [readme] change [`jsx-runtime`] link from branch to sha ([#3160][] @tatsushitoji)
 * [Docs] HTTP => HTTPS ([#3133][] @Schweinepriester)
 * [readme] Some grammar fixes ([#3186][] @JJ)
+* [Docs] [`jsx-no-target-blank`]: Improve readme ([#3169][] @apepper)
 
 [#3186]: https://github.com/yannickcr/eslint-plugin-react/pull/3186
 [#3174]: https://github.com/yannickcr/eslint-plugin-react/pull/3174
+[#3169]: https://github.com/yannickcr/eslint-plugin-react/pull/3169
 [#3167]: https://github.com/yannickcr/eslint-plugin-react/pull/3167
 [#3163]: https://github.com/yannickcr/eslint-plugin-react/pull/3163
 [#3160]: https://github.com/yannickcr/eslint-plugin-react/pull/3160

--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -123,6 +123,8 @@ This rule supports the ability to use custom components for forms. To enable thi
 
 ## When To Override It
 
+Modern browsers (Chrome ≥ 88, Edge ≥ 88, Firefox ≥ 79 and Safari ≥ 12.2) automatically imply `rel="noopener"`. Therefore this rule is no longer needed, if legacy browsers are not supported. See https://web.dev/external-anchors-use-rel-noopener/ and https://caniuse.com/mdn-html_elements_a_implicit_noopener for more details.
+
 For links to a trusted host (e.g. internal links to your own site, or links to a another host you control, where you can be certain this security vulnerability does not exist), you may want to keep the HTTP Referer header for analytics purposes.
 
 If you do not support Internet Explorer (any version), Chrome < 49, Opera < 36, Firefox < 52, desktop Safari < 10.1 or iOS Safari < 10.3, you may set `allowReferrer` to `true`, keep the HTTP Referer header and only add `rel="noopener"` to your links.


### PR DESCRIPTION
See https://web.dev/external-anchors-use-rel-noopener/, https://chromestatus.com/feature/6140064063029248 and https://caniuse.com/mdn-html_elements_a_implicit_noopener for some background information on this change.