### PR TITLE
Feat/index

### DIFF
--- a/docs/rules/no-array-index-key.md
+++ b/docs/rules/no-array-index-key.md
@@ -67,6 +67,14 @@ things.map((thing) => (
   <Hello key={thing.id} />
 ));
 
+things.map((thing, i) => (
+  <Hello key={thing.id + i} />
+));
+
+things.map((thing, i) => (
+  <Hello key={`${thing.id}${i}`} />
+));
+
 things.map((thing) => (
   React.cloneElement(thing, { key: thing.id })
 ));

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -51,21 +51,19 @@ module.exports = {
     };
 
     function isArrayIndex(node) {
-      return node.type === 'Identifier'
-        && indexParamNames.indexOf(node.name) !== -1;
+      return (
+        node.type === 'Identifier' && indexParamNames.indexOf(node.name) !== -1
+      );
     }
 
     function isUsingReactChildren(node) {
       const callee = node.callee;
-      if (
-        !callee
-        || !callee.property
-        || !callee.object
-      ) {
+      if (!callee || !callee.property || !callee.object) {
         return null;
       }
 
-      const isReactChildMethod = ['map', 'forEach'].indexOf(callee.property.name) > -1;
+      const isReactChildMethod =
+        ['map', 'forEach'].indexOf(callee.property.name) > -1;
       if (!isReactChildMethod) {
         return null;
       }
@@ -74,7 +72,11 @@ module.exports = {
       if (obj && obj.name === 'Children') {
         return true;
       }
-      if (obj && obj.object && obj.object.name === pragma.getFromContext(context)) {
+      if (
+        obj &&
+        obj.object &&
+        obj.object.name === pragma.getFromContext(context)
+      ) {
         return true;
       }
 
@@ -83,7 +85,10 @@ module.exports = {
 
     function getMapIndexParamName(node) {
       const callee = node.callee;
-      if (callee.type !== 'MemberExpression' && callee.type !== 'OptionalMemberExpression') {
+      if (
+        callee.type !== 'MemberExpression' &&
+        callee.type !== 'OptionalMemberExpression'
+      ) {
         return null;
       }
       if (callee.property.type !== 'Identifier') {
@@ -107,7 +112,8 @@ module.exports = {
 
       const params = callbackArg.params;
 
-      const indexParamPosition = iteratorFunctionsToIndexParamPosition[callee.property.name];
+      const indexParamPosition =
+        iteratorFunctionsToIndexParamPosition[callee.property.name];
       if (params.length < indexParamPosition + 1) {
         return null;
       }
@@ -140,12 +146,22 @@ module.exports = {
       }
 
       if (node.type === 'TemplateLiteral') {
-        // key={`foo-${bar}`}
-        node.expressions.filter(isArrayIndex).forEach(() => {
-          report(context, messages.noArrayIndex, 'noArrayIndex', {
-            node,
+        const hasIndex = node.expressions.filter(isArrayIndex);
+        const hasAnotherIdentifier =
+          node.expressions.length -
+            // key={`${'foo'}`}
+            node.expressions.filter((exp) => exp.type === 'StringLiteral').length >
+          1;
+
+        // allow key={`${someId}${index}`}
+        if (hasIndex && !hasAnotherIdentifier) {
+          // key={`foo-${bar}`}
+          node.expressions.filter(isArrayIndex).forEach(() => {
+            report(context, messages.noArrayIndex, 'noArrayIndex', {
+              node,
+            });
           });
-        });
+        }
 
         return;
       }
@@ -153,6 +169,14 @@ module.exports = {
       if (node.type === 'BinaryExpression') {
         // key={'foo' + bar}
         const identifiers = getIdentifiersFromBinaryExpression(node);
+
+        // allow key={someId + index}
+        if (
+          identifiers.length > 0 &&
+          identifiers.some((node) => node.type === 'Identifier')
+        ) {
+          return;
+        }
 
         identifiers.filter(isArrayIndex).forEach(() => {
           report(context, messages.noArrayIndex, 'noArrayIndex', {
@@ -174,10 +198,13 @@ module.exports = {
     return {
       'CallExpression, OptionalCallExpression'(node) {
         if (
-          node.callee
-          && (node.callee.type === 'MemberExpression' || node.callee.type === 'OptionalMemberExpression')
-          && ['createElement', 'cloneElement'].indexOf(node.callee.property.name) !== -1
-          && node.arguments.length > 1
+          node.callee &&
+          (node.callee.type === 'MemberExpression' ||
+            node.callee.type === 'OptionalMemberExpression') &&
+          ['createElement', 'cloneElement'].indexOf(
+            node.callee.property.name
+          ) !== -1 &&
+          node.arguments.length > 1
         ) {
           // React.createElement
           if (!indexParamNames.length) {

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -56,14 +56,20 @@ module.exports = {
       );
     }
 
+    // w/o index
+    function isOtherIdentifier(node) {
+      return (
+        node.type === 'Identifier' && !indexParamNames.includes(node.name)
+      );
+    }
+
     function isUsingReactChildren(node) {
       const callee = node.callee;
       if (!callee || !callee.property || !callee.object) {
         return null;
       }
 
-      const isReactChildMethod =
-        ['map', 'forEach'].indexOf(callee.property.name) > -1;
+      const isReactChildMethod = ['map', 'forEach'].indexOf(callee.property.name) > -1;
       if (!isReactChildMethod) {
         return null;
       }
@@ -73,9 +79,9 @@ module.exports = {
         return true;
       }
       if (
-        obj &&
-        obj.object &&
-        obj.object.name === pragma.getFromContext(context)
+        obj
+        && obj.object
+        && obj.object.name === pragma.getFromContext(context)
       ) {
         return true;
       }
@@ -86,8 +92,8 @@ module.exports = {
     function getMapIndexParamName(node) {
       const callee = node.callee;
       if (
-        callee.type !== 'MemberExpression' &&
-        callee.type !== 'OptionalMemberExpression'
+        callee.type !== 'MemberExpression'
+        && callee.type !== 'OptionalMemberExpression'
       ) {
         return null;
       }
@@ -112,8 +118,7 @@ module.exports = {
 
       const params = callbackArg.params;
 
-      const indexParamPosition =
-        iteratorFunctionsToIndexParamPosition[callee.property.name];
+      const indexParamPosition = iteratorFunctionsToIndexParamPosition[callee.property.name];
       if (params.length < indexParamPosition + 1) {
         return null;
       }
@@ -146,17 +151,13 @@ module.exports = {
       }
 
       if (node.type === 'TemplateLiteral') {
-        const hasIndex = node.expressions.filter(isArrayIndex);
-        const hasAnotherIdentifier =
-          node.expressions.length -
-            // key={`${'foo'}`}
-            node.expressions.filter((exp) => exp.type === 'StringLiteral').length >
-          1;
-
+        const indexIdentifiers = node.expressions.filter(isArrayIndex);
         // allow key={`${someId}${index}`}
-        if (hasIndex && !hasAnotherIdentifier) {
+        const anotherIdentifiers = node.expressions.filter(isOtherIdentifier);
+
+        if (indexIdentifiers.length > 0 && anotherIdentifiers === 0) {
           // key={`foo-${bar}`}
-          node.expressions.filter(isArrayIndex).forEach(() => {
+          indexIdentifiers.forEach(() => {
             report(context, messages.noArrayIndex, 'noArrayIndex', {
               node,
             });
@@ -169,20 +170,19 @@ module.exports = {
       if (node.type === 'BinaryExpression') {
         // key={'foo' + bar}
         const identifiers = getIdentifiersFromBinaryExpression(node);
-
+        const indexIdentifiers = identifiers.filter(isArrayIndex);
         // allow key={someId + index}
-        if (
-          identifiers.length > 0 &&
-          identifiers.some((node) => node.type === 'Identifier')
-        ) {
-          return;
-        }
+        const anotherIdentifiers = identifiers.filter(isOtherIdentifier);
 
-        identifiers.filter(isArrayIndex).forEach(() => {
-          report(context, messages.noArrayIndex, 'noArrayIndex', {
-            node,
+        if (
+          indexIdentifiers.length > 0 && anotherIdentifiers === 0
+        ) {
+          indexIdentifiers.forEach(() => {
+            report(context, messages.noArrayIndex, 'noArrayIndex', {
+              node,
+            });
           });
-        });
+        }
       }
     }
 
@@ -198,13 +198,13 @@ module.exports = {
     return {
       'CallExpression, OptionalCallExpression'(node) {
         if (
-          node.callee &&
-          (node.callee.type === 'MemberExpression' ||
-            node.callee.type === 'OptionalMemberExpression') &&
-          ['createElement', 'cloneElement'].indexOf(
+          node.callee
+          && (node.callee.type === 'MemberExpression'
+            || node.callee.type === 'OptionalMemberExpression')
+          && ['createElement', 'cloneElement'].indexOf(
             node.callee.property.name
-          ) !== -1 &&
-          node.arguments.length > 1
+          ) !== -1
+          && node.arguments.length > 1
         ) {
           // React.createElement
           if (!indexParamNames.length) {

--- a/lib/rules/no-array-index-key.js
+++ b/lib/rules/no-array-index-key.js
@@ -155,7 +155,7 @@ module.exports = {
         // allow key={`${someId}${index}`}
         const anotherIdentifiers = node.expressions.filter(isOtherIdentifier);
 
-        if (indexIdentifiers.length > 0 && anotherIdentifiers === 0) {
+        if (indexIdentifiers.length > 0 && anotherIdentifiers.length === 0) {
           // key={`foo-${bar}`}
           indexIdentifiers.forEach(() => {
             report(context, messages.noArrayIndex, 'noArrayIndex', {
@@ -175,7 +175,7 @@ module.exports = {
         const anotherIdentifiers = identifiers.filter(isOtherIdentifier);
 
         if (
-          indexIdentifiers.length > 0 && anotherIdentifiers === 0
+          indexIdentifiers.length > 0 && anotherIdentifiers.length === 0
         ) {
           indexIdentifiers.forEach(() => {
             report(context, messages.noArrayIndex, 'noArrayIndex', {

--- a/tests/lib/rules/no-array-index-key.js
+++ b/tests/lib/rules/no-array-index-key.js
@@ -49,6 +49,12 @@ ruleTester.run('no-array-index-key', rule, {
       code: 'foo.map((baz, i) => <Foo key={baz.id} />)',
     },
     {
+      code: 'foo.map((baz, i) => <Foo key={i + baz.id} />)',
+    },
+    {
+      code: 'foo.map((baz, i) => <Foo key={`${baz.id}${i}`} />)',
+    },
+    {
       code: 'foo.map((baz, i) => <Foo key={\'foo\' + baz.id} />)',
     },
     {


### PR DESCRIPTION
allow using `index` with other unique indentifier, like 

```js
 {
      code: 'foo.map((baz, i) => <Foo key={i + baz.id} />)',
    },
    {
      code: 'foo.map((baz, i) => <Foo key={`${baz.id}${i}`} />)',
    },
```

