### PR TITLE
[Fix] `no-invalid-html-attribute`: allow 'shortcut icon' on `link`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 * [`prop-types`], `propTypes`: add support for exported type inference ([#3163][] @vedadeepta)
+* [`no-invalid-html-attribute`]: allow 'shortcut icon' on `link` ([#3174][] @Primajin)
 
 ### Changed
 * [readme] change [`jsx-runtime`] link from branch to sha ([#3160][] @tatsushitoji)
 * [Docs] HTTP => HTTPS ([#3133][] @Schweinepriester)
 
+[#3174]: https://github.com/yannickcr/eslint-plugin-react/pull/3174
 [#3163]: https://github.com/yannickcr/eslint-plugin-react/pull/3163
 [#3160]: https://github.com/yannickcr/eslint-plugin-react/pull/3160
 [#3133]: https://github.com/yannickcr/eslint-plugin-react/pull/3133

--- a/lib/rules/no-invalid-html-attribute.js
+++ b/lib/rules/no-invalid-html-attribute.js
@@ -39,8 +39,14 @@ const rel = new Map([
   ['prerender', new Set(['link'])],
   ['prev', new Set(['link', 'area', 'a', 'form'])],
   ['search', new Set(['link', 'area', 'a', 'form'])],
+  ['shortcut', new Set(['link'])], // generally allowed but needs pair with "icon"
+  ['shortcut\u0020icon', new Set(['link'])],
   ['stylesheet', new Set(['link'])],
   ['tag', new Set(['area', 'a'])],
+]);
+
+const pairs = new Map([
+  ['shortcut', new Set(['icon'])],
 ]);
 
 /**
@@ -49,6 +55,14 @@ const rel = new Map([
  */
 const VALID_VALUES = new Map([
   ['rel', rel],
+]);
+
+/**
+ * Map between attributes and a mapping between pair-values and a set of values they are valid with
+ * @type {Map<string, Map<string, Set<string>>>}
+ */
+const VALID_PAIR_VALUES = new Map([
+  ['rel', pairs],
 ]);
 
 /**
@@ -216,6 +230,8 @@ const messages = {
   noMethod: 'The ”{{attributeName}}“ attribute cannot be a method.',
   onlyMeaningfulFor: 'The ”{{attributeName}}“ attribute only has meaning on the tags: {{tagNames}}',
   emptyIsMeaningless: 'An empty “{{attributeName}}” attribute is meaningless.',
+  notAlone: '“{{reportingValue}}” must be directly followed by “{{missingValue}}”.',
+  notPaired: '“{{reportingValue}}” can not be directly followed by “{{secondValue}}” without “{{missingValue}}”.',
 };
 
 function splitIntoRangedParts(node, regex) {
@@ -256,10 +272,10 @@ function checkLiteralValueNode(context, attributeName, node, parentNode, parentN
     return;
   }
 
-  const parts = splitIntoRangedParts(node, /([^\s]+)/g);
-  for (const part of parts) {
-    const allowedTags = VALID_VALUES.get(attributeName).get(part.value);
-    const reportingValue = part.reportingValue;
+  const singleAttributeParts = splitIntoRangedParts(node, /(\S+)/g);
+  for (const singlePart of singleAttributeParts) {
+    const allowedTags = VALID_VALUES.get(attributeName).get(singlePart.value);
+    const reportingValue = singlePart.reportingValue;
     if (!allowedTags) {
       report(context, messages.neverValid, 'neverValid', {
         node,
@@ -268,7 +284,7 @@ function checkLiteralValueNode(context, attributeName, node, parentNode, parentN
           reportingValue,
         },
         fix(fixer) {
-          return fixer.removeRange(part.range);
+          return fixer.removeRange(singlePart.range);
         },
       });
     } else if (!allowedTags.has(parentNodeName)) {
@@ -280,20 +296,54 @@ function checkLiteralValueNode(context, attributeName, node, parentNode, parentN
           elementName: parentNodeName,
         },
         fix(fixer) {
-          return fixer.removeRange(part.range);
+          return fixer.removeRange(singlePart.range);
         },
       });
     }
   }
 
+  const allowedPairsForAttribute = VALID_PAIR_VALUES.get(attributeName);
+  if (allowedPairsForAttribute) {
+    const pairAttributeParts = splitIntoRangedParts(node, /(?=(\b\S+\s*\S+))/g);
+    for (const pairPart of pairAttributeParts) {
+      for (const [pairing, siblings] of allowedPairsForAttribute) {
+        const attributes = pairPart.reportingValue.split('\u0020');
+        const [firstValue, secondValue] = attributes;
+        if (firstValue === pairing) {
+          const lastValue = attributes[attributes.length - 1]; // in case of multiple white spaces
+          if (!siblings.has(lastValue)) {
+            const message = secondValue ? messages.notPaired : messages.notAlone;
+            const messageId = secondValue ? 'notPaired' : 'notAlone';
+            report(context, message, messageId, {
+              node,
+              data: {
+                reportingValue: firstValue,
+                secondValue,
+                missingValue: [...siblings].join(', '),
+              },
+            });
+          }
+        }
+      }
+    }
+  }
+
   const whitespaceParts = splitIntoRangedParts(node, /(\s+)/g);
   for (const whitespacePart of whitespaceParts) {
-    if (whitespacePart.value !== ' ' || whitespacePart.range[0] === (node.range[0] + 1) || whitespacePart.range[1] === (node.range[1] - 1)) {
+    if (whitespacePart.range[0] === (node.range[0] + 1) || whitespacePart.range[1] === (node.range[1] - 1)) {
       report(context, messages.spaceDelimited, 'spaceDelimited', {
         node,
         data: { attributeName },
         fix(fixer) {
           return fixer.removeRange(whitespacePart.range);
+        },
+      });
+    } else if (whitespacePart.value !== '\u0020') {
+      report(context, messages.spaceDelimited, 'spaceDelimited', {
+        node,
+        data: { attributeName },
+        fix(fixer) {
+          return fixer.replaceTextRange(whitespacePart.range, '\u0020');
         },
       });
     }

--- a/tests/lib/rules/no-invalid-html-attribute.js
+++ b/tests/lib/rules/no-invalid-html-attribute.js
@@ -130,6 +130,9 @@ ruleTester.run('no-invalid-html-attribute', rule, {
     { code: '<link rel="icon"></link>' },
     { code: 'React.createElement("link", { rel: "icon" })' },
     { code: 'React.createElement("link", { rel: ["icon"] })' },
+    { code: '<link rel="shortcut icon"></link>' },
+    { code: 'React.createElement("link", { rel: "shortcut icon" })' },
+    { code: 'React.createElement("link", { rel: ["shortcut icon"] })' },
     { code: '<link rel="license"></link>' },
     { code: 'React.createElement("link", { rel: "license" })' },
     { code: 'React.createElement("link", { rel: ["license"] })' },
@@ -451,6 +454,26 @@ ruleTester.run('no-invalid-html-attribute', rule, {
       ],
     },
     {
+      code: '<a rel="noreferrer        noopener"></a>',
+      output: '<a rel="noreferrer noopener"></a>',
+      errors: [
+        {
+          messageId: 'spaceDelimited',
+          data: { attributeName: 'rel' },
+        },
+      ],
+    },
+    {
+      code: '<a rel="noreferrer\xa0\xa0noopener"></a>',
+      output: '<a rel="noreferrer noopener"></a>',
+      errors: [
+        {
+          messageId: 'spaceDelimited',
+          data: { attributeName: 'rel' },
+        },
+      ],
+    },
+    {
       code: '<a rel={"noreferrer noopener foobar"}></a>',
       output: '<a rel={"noreferrer noopener "}></a>',
       errors: [
@@ -611,6 +634,73 @@ ruleTester.run('no-invalid-html-attribute', rule, {
             attributeName: 'rel',
             elementName: 'a',
           },
+        },
+      ],
+    },
+    {
+      code: '<link rel="shortcut"></link>',
+      errors: [
+        {
+          messageId: 'notAlone',
+          data: {
+            reportingValue: 'shortcut',
+            missingValue: 'icon',
+          },
+        },
+      ],
+    },
+    {
+      code: '<link rel="shortcut foo"></link>',
+      output: '<link rel="shortcut "></link>',
+      errors: [
+        {
+          messageId: 'neverValid',
+          data: {
+            reportingValue: 'foo',
+            attributeName: 'rel',
+          },
+        },
+        {
+          messageId: 'notPaired',
+          data: {
+            reportingValue: 'shortcut',
+            secondValue: 'foo',
+            missingValue: 'icon',
+          },
+        },
+      ],
+    },
+    {
+      code: '<link rel="shortcut  icon"></link>',
+      output: '<link rel="shortcut icon"></link>',
+      errors: [
+        {
+          messageId: 'spaceDelimited',
+          data: { attributeName: 'rel' },
+        },
+      ],
+    },
+    {
+      code: '<link rel="shortcut  foo"></link>',
+      output: '<link rel="shortcut foo"></link>',
+      errors: [
+        {
+          messageId: 'neverValid',
+          data: {
+            reportingValue: 'foo',
+            attributeName: 'rel',
+          },
+        },
+        {
+          messageId: 'notAlone',
+          data: {
+            reportingValue: 'shortcut',
+            missingValue: 'icon',
+          },
+        },
+        {
+          messageId: 'spaceDelimited',
+          data: { attributeName: 'rel' },
         },
       ],
     },

--- a/tests/lib/rules/no-invalid-html-attribute.js
+++ b/tests/lib/rules/no-invalid-html-attribute.js
@@ -232,6 +232,83 @@ ruleTester.run('no-invalid-html-attribute', rule, {
   ],
   invalid: [
     {
+      code: '<a rel="alternatex"></a>',
+      output: '<a rel=""></a>',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
+      code: 'React.createElement("a", { rel: "alternatex" })',
+      output: 'React.createElement("a", { rel: "alternatex" })',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
+      code: 'React.createElement("a", { rel: ["alternatex"] })',
+      output: 'React.createElement("a", { rel: ["alternatex"] })',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
+      code: '<a rel="alternatex alternate"></a>',
+      output: '<a rel=" alternate"></a>',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
+      code: 'React.createElement("a", { rel: "alternatex alternate" })',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
+      code: 'React.createElement("a", { rel: ["alternatex alternate"] })',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
+      code: '<a rel="alternate alternatex"></a>',
+      output: '<a rel="alternate "></a>',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
+      code: 'React.createElement("a", { rel: "alternate alternatex" })',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
+      code: 'React.createElement("a", { rel: ["alternate alternatex"] })',
+      errors: [
+        {
+          messageId: 'neverValid',
+        },
+      ],
+    },
+    {
       code: '<html rel></html>',
       output: '<html ></html>',
       errors: [


### PR DESCRIPTION
Closes #3172 

## Description

For historical reasons, the icon keyword may be preceded by the keyword "shortcut".

[https://html.spec.whatwg.org/multipage/links.html#rel-icon](https://html.spec.whatwg.org/multipage/links.html#rel-icon) (last sentence before the next paragraph about `license`)

## Intentions

1. First of all I'm checking if there are pairs registered for the given attribute name after all.
2. Now I'm splitting the attribute value(s) into *overlapping* pairs. If you want to check on the funky regex: https://regex101.com/r/aJXAEz/1
3. now I'm iterating pair by pair
4. on each pair I check what are the possible siblings for my current item - currently there is only 1:1 but potentially there could be a pair where `foo` can go with `bar` OR `baz` but NEVER `qux`
5. now I check if my pair is separated by a single space or multiple in between
6. Check if the first value has a corresponding pairing
7. Get the last value as this is the "real" second one
8. Check if this is not one of the anticipated siblings
9. set message and message id based on, if the second value is truthy
    1. if it is the attribute was not paired with the right one
    2. if its not it stands alone which makes it invalid.
10. report the issue
11. check if there is only one option what the sibling could be, if there is only one anyways let's autofix it for the user! 🎉 

## Demo

This introduces two new messages:

```html
<link rel="shortcut"></link>
```
Reports: `“shortcut” must be directly followed by “icon”.`

<br><br>

```html
<link rel="shortcut manifest"></link>
```
Reports: `“shortcut” can not be directly followed by “manifest” without “icon”.`<br>
