### PR TITLE
[Fix] fix `prefer-exact-props` and improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Fixed
 * [`prop-types`], `propTypes`: add support for exported type inference ([#3163][] @vedadeepta)
 * [`no-invalid-html-attribute`]: allow 'shortcut icon' on `link` ([#3174][] @Primajin)
+* [`prefer-exact-props`] improve performance for `Identifier` visitor ([#3190][] @meowtec)
 
 ### Changed
 * [readme] change [`jsx-runtime`] link from branch to sha ([#3160][] @tatsushitoji)
@@ -20,6 +21,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Docs] [`jsx-no-target-blank`]: Improve readme ([#3169][] @apepper)
 * [Docs] [`display-name`]: improve examples ([#3189][] @golopot)
 
+[#3190]: https://github.com/yannickcr/eslint-plugin-react/pull/3190
 [#3189]: https://github.com/yannickcr/eslint-plugin-react/pull/3189
 [#3186]: https://github.com/yannickcr/eslint-plugin-react/pull/3186
 [#3174]: https://github.com/yannickcr/eslint-plugin-react/pull/3174

--- a/lib/rules/prefer-exact-props.js
+++ b/lib/rules/prefer-exact-props.js
@@ -120,7 +120,7 @@ module.exports = {
       },
 
       Identifier(node) {
-        if (!utils.getParentStatelessComponent(node)) {
+        if (!utils.getStatelessComponent(node.parent)) {
           return;
         }
 

--- a/tests/lib/rules/prefer-exact-props.js
+++ b/tests/lib/rules/prefer-exact-props.js
@@ -98,6 +98,18 @@ ruleTester.run('prefer-exact-props', rule, {
     },
     {
       code: `
+        type Props = {|
+          foo: string
+        |}
+        function Component(props: Props) {
+          let someVar: { foo: string };
+          return <div />;
+        }
+      `,
+      features: ['flow'],
+    },
+    {
+      code: `
         function Component(props: {| foo : string |}) {
           return <div />;
         }


### PR DESCRIPTION
Use `getStatelessComponent` instead of `getParentStatelessComponent` because the second will find the component to it's ancestors. That is incorrect and could cause performance problem.
See the changed test case.