### PR TITLE
Handle TSTypeReference in no-unused-prop-types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`prop-types`], `propTypes`: add support for exported type inference ([#3163][] @vedadeepta)
 * [`no-invalid-html-attribute`]: allow 'shortcut icon' on `link` ([#3174][] @Primajin)
 * [`prefer-exact-props`] improve performance for `Identifier` visitor ([#3190][] @meowtec)
+* `propTypes`: Handle TSTypeReference in no-unused-prop-type ([#3195][] @niik)
 
 ### Changed
 * [readme] change [`jsx-runtime`] link from branch to sha ([#3160][] @tatsushitoji)
@@ -23,6 +24,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Docs] [`display-name`]: improve examples ([#3189][] @golopot)
 * [Refactor] [`no-invalid-html-attribute`]: sort HTML_ELEMENTS and messages ([#3182][] @Primajin)
 
+[#3195]: https://github.com/yannickcr/eslint-plugin-react/pull/3195
 [#3191]: https://github.com/yannickcr/eslint-plugin-react/pull/3191
 [#3190]: https://github.com/yannickcr/eslint-plugin-react/pull/3190
 [#3189]: https://github.com/yannickcr/eslint-plugin-react/pull/3189

--- a/lib/util/propTypes.js
+++ b/lib/util/propTypes.js
@@ -967,6 +967,7 @@ module.exports = function propTypesInstructions(context, components, utils) {
           ignorePropsValidation = true;
         }
         break;
+      case 'TSTypeReference':
       case 'TSTypeAnnotation': {
         const tsTypeAnnotation = new DeclarePropTypesForTSTypeAnnotation(propTypes, declaredPropTypes);
         ignorePropsValidation = tsTypeAnnotation.shouldIgnorePropTypes;

--- a/tests/lib/rules/no-unused-prop-types.js
+++ b/tests/lib/rules/no-unused-prop-types.js
@@ -6486,6 +6486,23 @@ ruleTester.run('no-unused-prop-types', rule, {
         };
       `,
       errors: [{ message: '\'foo\' PropType is defined but prop is never used' }],
+    },
+
+    {
+      code: `
+        interface Props {
+          readonly firstname: string;
+          readonly lastname: string;
+        }
+
+        class TestComponent extends React.Component<Props> {
+          public render() {
+            return <div>{this.props.firstname}</div>;
+          }
+        }
+      `,
+      features: ['ts', 'no-babel'],
+      errors: [{ message: '\'lastname\' PropType is defined but prop is never used' }],
     }
   )),
 });


### PR DESCRIPTION
:wave: from GitHub Desktop land!

We're currently upgrading to TypeScript 4.5 (https://github.com/desktop/desktop/pull/13768) and while doing that I wanted to start using the `react/no-unused-props-type` rule instead of the `react-unused-props-and-state` from the obsolete `tslint-microsoft-contrib` package.

Unfortunately I couldn't get the rule to produce any errors. I put up a minimal reproduction repository at https://github.com/niik/no-unused-prop-types-repro which illustrates the problem. To test it just clone and run `yarn lint`

Doing so very haphazardly troubleshooting I noticed that when encountering our prop types in `propTypes.js` they were of type `TSTypeReference` which was not being handled in the switch case.  Spotting that `DeclarePropTypesForTSTypeAnnotation` seemed to be able to handle both `TSTypeAnnotation` and `TSTypeReference` internally I simply tried adding it to the switch and lo-and-behold the rule just started working.

Now, obviously I have no idea what I'm doing here so I'm happy to adjust my approach given some guidance from someone who understands eslint/ts-parser internals but running my minimal reproduction repository with my branch (https://github.com/niik/no-unused-prop-types-repro/tree/with-ts-type-reference-fix) reports the error correctly.