### PR TITLE
Get rid of red in jsx-no-target-blank documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Refactor] [`no-invalid-html-attribute`]: sort HTML_ELEMENTS and messages ([#3182][] @Primajin)
 * [Docs] [`forbid-foreign-prop-types`]: document `allowInPropTypes` option ([#1815][] @ljharb)
 * [Refactor] [`jsx-sort-default-props`]: remove unnecessary code ([#1817][] @ljharb)
+* [Docs] [`jsx-no-target-blank`]: fix syntax highlighting ([#3199][] @shamrin)
 
+[#3199]: https://github.com/yannickcr/eslint-plugin-react/pull/3199
 [#3198]: https://github.com/yannickcr/eslint-plugin-react/pull/3198
 [#3195]: https://github.com/yannickcr/eslint-plugin-react/pull/3195
 [#3191]: https://github.com/yannickcr/eslint-plugin-react/pull/3191

--- a/docs/rules/jsx-no-target-blank.md
+++ b/docs/rules/jsx-no-target-blank.md
@@ -9,7 +9,7 @@ This rule aims to prevent user generated link hrefs and form actions from creati
 
 ## Rule Options
 
-```json
+```js
 ...
 "react/jsx-no-target-blank": [<enabled>, {
   "allowReferrer": <allow-referrer>,


### PR DESCRIPTION
Documentation is hard to read with `json` Markdown code block:

<img width="439" alt="image" src="https://user-images.githubusercontent.com/510678/153038680-e0d0e0d4-ba26-4833-a6cd-85730e9ecf3c.png">

This PR fixes it.

I've ended up on [the page](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) after clicking the popup in VS Code:

<img width="591" alt="image" src="https://user-images.githubusercontent.com/510678/153039107-ee6f6f2c-db57-4c5e-812c-74bdf4f786a6.png">