### PR TITLE
chore: Add the .vscode setting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ node_modules
 npm-debug.log
 sftp-config.json
 eslint-remote-tester-results
+**/.vscode/*
+!**/.vscode/launch.template.json
 
 # Only apps should have lockfiles
 yarn.lock

--- a/.vscode/launch.template.json
+++ b/.vscode/launch.template.json
@@ -1,0 +1,21 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+    {
+      "type": "node",
+      "protocol": "inspector",
+      "request": "launch",
+      "name": "Mocha Tests (currently opened test)",
+      "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+      "args": [
+        "${command:extension.commandvariable.file.filePosix}"
+      ],
+      "env": {
+        "NODE_ENV": "testing"
+      },
+      "sourceMaps": true,
+      "smartStep": true,
+      "console": "integratedTerminal",
+    }
+	]
+}


### PR DESCRIPTION
I wanted to configure vscode, so I added .vscode to gitignore.
If, for some reason, you have not added .vscode to gitignore, please close this PR.

In addition, I've added a launch.json template.
Please rename launch.template.json to launch.json.
With the test file open in vscode, press f5 to start the debugger.