### PR TITLE
feat: added "ignore" option to react version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ You should also specify settings that will be shared across all the plugin rules
       "version": "detect", // React version. "detect" automatically picks the version you have installed.
                            // You can also use `16.0`, `16.3`, etc, if you want to override the detected value.
                            // It will default to "latest" and warn if missing, and to "detect" in the future
+                           // You can also use "ignore" to ignore the version check. This is useful for removing the warning when using preact.
       "flowVersion": "0.53" // Flow version
     },
     "propWrapperFunctions": [

--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -79,12 +79,15 @@ function getReactVersionFromContext(context) {
     let settingsVersion = context.settings.react.version;
     if (settingsVersion === 'detect') {
       settingsVersion = detectReactVersion(context);
+    } else if (settingsVersion === 'ignore') {
+      settingsVersion = defaultVersion;
+    } else {
+      if (typeof settingsVersion !== 'string') {
+        error('Warning: React version specified in eslint-plugin-react-settings must be a string; '
+          + `got “${typeof settingsVersion}”`);
+      }
+      confVer = String(settingsVersion);
     }
-    if (typeof settingsVersion !== 'string') {
-      error('Warning: React version specified in eslint-plugin-react-settings must be a string; '
-        + `got “${typeof settingsVersion}”`);
-    }
-    confVer = String(settingsVersion);
   } else if (!warnedForMissingVersion) {
     error('Warning: React version not specified in eslint-plugin-react settings. '
       + 'See https://github.com/yannickcr/eslint-plugin-react#configuration .');


### PR DESCRIPTION
I am using this eslint rule in a project which is based on [Preact](https://preactjs.com) and this PR allows the React version not specified error to be disabled.