### PR TITLE
[Fix] `boolean-prop-naming`: handle React.FC, intersection, union types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Fixed
 * [`no-unused-state`]: avoid a crash on a class field gDSFP ([#3236][] @ljharb)
+* [`boolean-prop-naming`]: handle React.FC, intersection, union types ([#3241][] @ljharb)
 
+[#3241]: https://github.com/yannickcr/eslint-plugin-react/pull/3241
 [#3236]: https://github.com/yannickcr/eslint-plugin-react/issues/3236
 
 ## [7.29.3] - 2022.03.03

--- a/lib/rules/boolean-prop-naming.js
+++ b/lib/rules/boolean-prop-naming.js
@@ -228,6 +228,65 @@ module.exports = {
       args.filter((arg) => arg.type === 'ObjectExpression').forEach((object) => validatePropNaming(node, object.properties));
     }
 
+    function getComponentTypeAnnotation(component) {
+      // If this is a functional component that uses a global type, check it
+      if (
+        (component.node.type === 'FunctionDeclaration' || component.node.type === 'ArrowFunctionExpression')
+        && component.node.params
+        && component.node.params.length > 0
+        && component.node.params[0].typeAnnotation
+      ) {
+        return component.node.params[0].typeAnnotation.typeAnnotation;
+      }
+
+      if (
+        component.node.parent
+        && component.node.parent.type === 'VariableDeclarator'
+        && component.node.parent.id
+        && component.node.parent.id.type === 'Identifier'
+        && component.node.parent.id.typeAnnotation
+        && component.node.parent.id.typeAnnotation.typeAnnotation
+        && component.node.parent.id.typeAnnotation.typeAnnotation.typeParameters
+        && (
+          component.node.parent.id.typeAnnotation.typeAnnotation.typeParameters.type === 'TSTypeParameterInstantiation'
+          || component.node.parent.id.typeAnnotation.typeAnnotation.typeParameters.type === 'TypeParameterInstantiation'
+        )
+      ) {
+        return component.node.parent.id.typeAnnotation.typeAnnotation.typeParameters.params.find(
+          (param) => param.type === 'TSTypeReference' || param.type === 'GenericTypeAnnotation'
+        );
+      }
+    }
+
+    function findAllTypeAnnotations(identifier, node) {
+      if (node.type === 'TSTypeLiteral' || node.type === 'ObjectTypeAnnotation') {
+        const currentNode = [].concat(
+          objectTypeAnnotations.get(identifier.name) || [],
+          node
+        );
+        objectTypeAnnotations.set(identifier.name, currentNode);
+      } else if (
+        node.type === 'TSParenthesizedType'
+        && (
+          node.typeAnnotation.type === 'TSIntersectionType'
+          || node.typeAnnotation.type === 'TSUnionType'
+        )
+      ) {
+        node.typeAnnotation.types.forEach((type) => {
+          findAllTypeAnnotations(identifier, type);
+        });
+      } else if (
+        node.type === 'TSIntersectionType'
+        || node.type === 'TSUnionType'
+        || node.type === 'IntersectionTypeAnnotation'
+        || node.type === 'UnionTypeAnnotation'
+      ) {
+        node.types.forEach((type) => {
+          findAllTypeAnnotations(identifier, type);
+        });
+      }
+    }
+
     // --------------------------------------------------------------------------
     // Public
     // --------------------------------------------------------------------------
@@ -292,16 +351,11 @@ module.exports = {
       },
 
       TypeAlias(node) {
-        // Cache all ObjectType annotations, we will check them at the end
-        if (node.right.type === 'ObjectTypeAnnotation') {
-          objectTypeAnnotations.set(node.id.name, node.right);
-        }
+        findAllTypeAnnotations(node.id, node.right);
       },
 
       TSTypeAliasDeclaration(node) {
-        if (node.typeAnnotation.type === 'TSTypeLiteral') {
-          objectTypeAnnotations.set(node.id.name, node.typeAnnotation);
-        }
+        findAllTypeAnnotations(node.id, node.typeAnnotation);
       },
 
       // eslint-disable-next-line object-shorthand
@@ -311,19 +365,11 @@ module.exports = {
         }
 
         const list = components.list();
+
         Object.keys(list).forEach((component) => {
-          // If this is a functional component that uses a global type, check it
-          if (
-            (
-              list[component].node.type === 'FunctionDeclaration'
-              || list[component].node.type === 'ArrowFunctionExpression'
-            )
-            && list[component].node.params
-            && list[component].node.params.length
-            && list[component].node.params[0].typeAnnotation
-          ) {
-            const typeNode = list[component].node.params[0].typeAnnotation;
-            const annotation = typeNode.typeAnnotation;
+          const annotation = getComponentTypeAnnotation(list[component]);
+
+          if (annotation) {
             let propType;
             if (annotation.type === 'GenericTypeAnnotation') {
               propType = objectTypeAnnotations.get(annotation.id.name);
@@ -334,10 +380,12 @@ module.exports = {
             }
 
             if (propType) {
-              validatePropNaming(
-                list[component].node,
-                propType.properties || propType.members
-              );
+              [].concat(propType).forEach((prop) => {
+                validatePropNaming(
+                  list[component].node,
+                  prop.properties || prop.members
+                );
+              });
             }
           }
 

--- a/tests/lib/rules/boolean-prop-naming.js
+++ b/tests/lib/rules/boolean-prop-naming.js
@@ -417,6 +417,86 @@ ruleTester.run('boolean-prop-naming', rule, {
       features: ['ts'],
       errors: [],
     },
+    {
+      code: `
+        type Props = {
+          isEnabled: boolean
+        } & OtherProps
+        const HelloNew = (props: Props) => { return <div /> };
+      `,
+      options: [{ rule: '^is[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types'],
+      errors: [],
+    },
+    {
+      code: `
+        type Props = {
+          isEnabled: boolean
+        } & {
+          hasLOL: boolean
+        } & OtherProps
+        const HelloNew = (props: Props) => { return <div /> };
+      `,
+      options: [{ rule: '(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types'],
+      errors: [],
+    },
+    {
+      code: `
+        type Props = {
+          isEnabled: boolean
+        }
+
+        const HelloNew: React.FC<Props> = (props) => { return <div /> };
+      `,
+      options: [{ rule: '^is[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types'],
+      errors: [],
+    },
+    {
+      code: `
+        type Props = {
+          isEnabled: boolean
+        } & {
+          hasLOL: boolean
+        }
+
+        const HelloNew: React.FC<Props> = (props) => { return <div /> };
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types'],
+      errors: [],
+    },
+    {
+      code: `
+        type Props = {
+          isEnabled: boolean
+        } | {
+          hasLOL: boolean
+        }
+
+        const HelloNew = (props: Props) => { return <div /> };
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types'],
+      errors: [],
+    },
+    {
+      code: `
+        type Props = {
+          isEnabled: boolean
+        } & ({
+          hasLOL: boolean
+        } | {
+          isLOL: boolean
+        })
+
+        const HelloNew = (props: Props) => { return <div /> };
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types'],
+      errors: [],
+    },
   ]),
 
   invalid: parsers.all([
@@ -1047,6 +1127,115 @@ ruleTester.run('boolean-prop-naming', rule, {
       errors: [
         {
           message: 'Prop name (enabled) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          enabled: boolean
+        } & OtherProps
+
+        const HelloNew = (props: Props) => { return <div /> };
+      `,
+      options: [{ rule: '^is[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types', 'no-ts-old'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          enabled: boolean
+        } & {
+          hasLOL: boolean
+        } & OtherProps
+
+        const HelloNew = (props: Props) => { return <div /> };
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types', 'no-ts-old'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          enabled: boolean
+        }
+
+        const HelloNew: React.FC<Props> = (props) => { return <div /> };
+      `,
+      options: [{ rule: '^is[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types', 'no-ts-old'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^is[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          enabled: boolean
+        } & {
+          hasLOL: boolean
+        }
+
+        const HelloNew: React.FC<Props> = (props) => { return <div /> };
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types', 'no-ts-old'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          enabled: boolean
+        } | {
+          hasLOL: boolean
+        }
+
+        const HelloNew = (props: Props) => { return <div /> };
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types', 'no-ts-old'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
+        },
+      ],
+    },
+    {
+      code: `
+        type Props = {
+          enabled: boolean
+        } & ({
+          hasLOL: boolean
+        } | {
+          lol: boolean
+        })
+
+        const HelloNew = (props: Props) => { return <div /> };
+      `,
+      options: [{ rule: '^(is|has)[A-Z]([A-Za-z0-9]?)+' }],
+      features: ['types', 'no-ts-old'],
+      errors: [
+        {
+          message: 'Prop name (enabled) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
+        },
+        {
+          message: 'Prop name (lol) doesn\'t match rule (^(is|has)[A-Z]([A-Za-z0-9]?)+)',
         },
       ],
     },


### PR DESCRIPTION
**Types of changes**

This PR fixes #3197, therefore, the `boolean-prop-naming` rule validates correctly the following code: 

```tsx
import type { FC } from 'react' // or import { FC } from 'react'

type Props = {
  enabled: boolean // ❌ error
} 

export const Component: FC<Props> = props => { 
  return <div /> 
}
```

```tsx
import * as React from 'react' 

type Props = {
  enabled: boolean // ❌ error
} 

export const Component: React.FC<Props> = props => { 
  return <div /> 
}
```

```tsx
import type { FC } from 'react' // or import { FC } from 'react'

type Props = {
  isEnabled: boolean // ✅
} 

export const Component: FC<Props> = props => { 
  return <div /> 
}
```

```tsx
import * as React from 'react' 

type Props = {
  isEnabled: boolean // ✅
} 

export const Component: React.FC<Props> = props => { 
  return <div /> 
}
```

Moreover, previously, the plugin could not handle a case like this:

```tsx
import * as React from 'react'
import { BoxProps } from '@mobily/stacks'

type Props = {
  isEnabled: boolean, // ⬅️ this was completely ignored
} & BoxProps

export const Component = (props: Props) => { 
  return <div /> 
}
```

or

```tsx
import * as React from 'react'

type Props = {
  isEnabled: boolean, 
} & {
  lol: boolean, // ⬅️ same here, both property types were ignored
}

export const Component = (props: Props) => { 
  return <div /> 
}
```

Now, the plugin handles the intersection and union types as well, so the following will be validated correctly:

```tsx
import * as React from 'react'

type Props = {
  isEnabled: boolean, // ✅
} & {
  lol: boolean, // ❌ error
}

export const Component = (props: Props) => { 
  return <div /> 
}
```

```tsx
import * as React from 'react'

type Props = {
  isEnabled: boolean, // ✅
} | {
  lol: boolean, // ❌ error
}

export const Component = (props: Props) => { 
  return <div /> 
}
```

```tsx
import * as React from 'react'

type Props = {
  isEnabled: boolean, // ✅
} & ({
  lol: boolean, // ❌ error
} | {
  hasLOL: boolean, // ✅
})

export const Component = (props: Props) => { 
  return <div /> 
}
```
