### PR TITLE
[Fix] `hook-use-state`: Allow UPPERCASE setState setter prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ## Unreleased
 
+### Fixed
+* [`hook-use-state`]: Allow UPPERCASE setState setter prefixes ([#3244][] @duncanbeevers)
+
+[#3244]: https://github.com/yannickcr/eslint-plugin-react/pull/3244
+
 ## [7.29.4] - 2022.03.13
 
 ### Fixed

--- a/lib/rules/hook-use-state.js
+++ b/lib/rules/hook-use-state.js
@@ -66,13 +66,17 @@ module.exports = {
         ? setterVariable.name
         : undefined;
 
-      const expectedSetterVariableName = valueVariableName ? (
-        `set${valueVariableName.charAt(0).toUpperCase()}${valueVariableName.slice(1)}`
-      ) : undefined;
+      const caseCandidateMatch = valueVariableName ? valueVariableName.match(/(^[a-z]+)(.*)/) : undefined;
+      const upperCaseCandidatePrefix = caseCandidateMatch ? caseCandidateMatch[1] : undefined;
+      const caseCandidateSuffix = caseCandidateMatch ? caseCandidateMatch[2] : undefined;
+      const expectedSetterVariableNames = upperCaseCandidatePrefix ? [
+        `set${upperCaseCandidatePrefix.charAt(0).toUpperCase()}${upperCaseCandidatePrefix.slice(1)}${caseCandidateSuffix}`,
+        `set${upperCaseCandidatePrefix.toUpperCase()}${caseCandidateSuffix}`,
+      ] : [];
 
       const isSymmetricGetterSetterPair = valueVariable
         && setterVariable
-        && setterVariableName === expectedSetterVariableName
+        && expectedSetterVariableNames.indexOf(setterVariableName) !== -1
         && variableNodes.length === 2;
 
       if (!isSymmetricGetterSetterPair) {
@@ -80,9 +84,13 @@ module.exports = {
           {
             desc: 'Destructure useState call into value + setter pair',
             fix: (fixer) => {
+              if (expectedSetterVariableNames.length === 0) {
+                return;
+              }
+
               const fix = fixer.replaceTextRange(
                 node.parent.id.range,
-                `[${valueVariableName}, ${expectedSetterVariableName}]`
+                `[${valueVariableName}, ${expectedSetterVariableNames[0]}]`
               );
 
               return fix;

--- a/tests/lib/rules/hook-use-state.js
+++ b/tests/lib/rules/hook-use-state.js
@@ -38,6 +38,33 @@ const tests = {
     {
       code: `
         import { useState } from 'react'
+        function useRGB() {
+          const [rgb, setRGB] = useState()
+          return [rgb, setRGB]
+        }
+      `,
+    },
+    {
+      code: `
+        import { useState } from 'react'
+        function useRGBValue() {
+          const [rgbValue, setRGBValue] = useState()
+          return [rgbValue, setRGBValue]
+        }
+      `,
+    },
+    {
+      code: `
+        import { useState } from 'react'
+        function useCustomColorValue() {
+          const [customColorValue, setCustomColorValue] = useState()
+          return [customColorValue, setCustomColorValue]
+        }
+      `,
+    },
+    {
+      code: `
+        import { useState } from 'react'
         function useColor() {
           const [color, setColor] = useState('#ffffff')
           return [color, setColor]


### PR DESCRIPTION
Closes https://github.com/yannickcr/eslint-plugin-react/issues/3243

This PR allows `useState` destructured variable names to use ALL-UPPER-CASE for the first segment of the setter variable name.

### Example

```js
// Previously invalid, now valid
const [rgbColor, setRGBColor] = useState();
```

### Discussion

The existing suggested variable name `setRgbColor` is still the sole suggestion; `setRGBColor` is considered valid, but is never suggested.

This should be a non-breaking change as all previously-valid code is still considered valid.