### PR TITLE
[New] `no-unknown-property`: Allow crossOrigin on image tag (SVG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 
 ### Added
 * [`destructuring-assignment`]: add option `destructureInSignature` ([#3235][] @golopot)
+* [`no-unknown-property`]: Allow crossOrigin on image tag (SVG) ([#3251][] @zpao)
 
 ### Fixed
 * [`hook-use-state`]: Allow UPPERCASE setState setter prefixes ([#3244][] @duncanbeevers)
 * `propTypes`: add `VFC` to react generic type param map ([#3230][] @dlech)
 
+[#3251]: https://github.com/yannickcr/eslint-plugin-react/pull/3251
 [#3244]: https://github.com/yannickcr/eslint-plugin-react/pull/3244
 [#3235]: https://github.com/yannickcr/eslint-plugin-react/pull/3235
 [#3230]: https://github.com/yannickcr/eslint-plugin-react/issues/3230

--- a/lib/rules/no-unknown-property.js
+++ b/lib/rules/no-unknown-property.js
@@ -27,7 +27,8 @@ const DOM_ATTRIBUTE_NAMES = {
 };
 
 const ATTRIBUTE_TAGS_MAP = {
-  crossOrigin: ['script', 'img', 'video', 'audio', 'link'],
+  // image is required for SVG support, all other tags are HTML.
+  crossOrigin: ['script', 'img', 'video', 'audio', 'link', 'image'],
 };
 
 const SVGDOM_ATTRIBUTE_NAMES = {

--- a/tests/lib/rules/no-unknown-property.js
+++ b/tests/lib/rules/no-unknown-property.js
@@ -53,6 +53,7 @@ ruleTester.run('no-unknown-property', rule, {
     { code: '<script crossOrigin />' },
     { code: '<audio crossOrigin />' },
     { code: '<div hasOwnProperty="should not be allowed tag" />' },
+    { code: '<svg><image crossOrigin /></svg>' },
   ]),
   invalid: parsers.all([
     {
@@ -220,7 +221,7 @@ ruleTester.run('no-unknown-property', rule, {
           data: {
             name: 'crossOrigin',
             tagName: 'div',
-            allowedTags: 'script, img, video, audio, link',
+            allowedTags: 'script, img, video, audio, link, image',
           },
         },
       ],


### PR DESCRIPTION
Fixes #3250