### PR TITLE
[readme] remove global usage and eslint version from readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`hook-use-state`]: Allow UPPERCASE setState setter prefixes ([#3244][] @duncanbeevers)
 * `propTypes`: add `VFC` to react generic type param map ([#3230][] @dlech)
 
+### Changed
+* [readme] remove global usage and eslint version from readme ([#3254][] @aladdin-add)
+
+[#3254]: https://github.com/yannickcr/eslint-plugin-react/pull/3254
 [#3251]: https://github.com/yannickcr/eslint-plugin-react/pull/3251
 [#3244]: https://github.com/yannickcr/eslint-plugin-react/pull/3244
 [#3235]: https://github.com/yannickcr/eslint-plugin-react/pull/3235

--- a/README.md
+++ b/README.md
@@ -7,17 +7,11 @@ React specific linting rules for `eslint`
 
 # Installation
 
-Install [`eslint`](https://www.github.com/eslint/eslint) either locally or globally. (Note that locally, per project, is strongly preferred)
-
 ```sh
-$ npm install eslint@7 --save-dev
+$ npm install eslint eslint-plugin-react --save-dev
 ```
 
-If you installed `eslint` globally, you have to install the React plugin globally too. Otherwise, install it locally (strongly preferred)
-
-```sh
-$ npm install eslint-plugin-react --save-dev
-```
+It is also possible to install ESLint globally rather than locally (using npm install eslint --global). However, this is not recommended, and any plugins or shareable configs that you use must be installed locally in either case.
 
 # Configuration
 


### PR DESCRIPTION
I've also updated eslint@7 => eslint@8(latest).