### PR TITLE
Add caching to linting script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "React specific linting rules for ESLint",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint --cache .",
     "postlint": "npm run type-check",
     "pretest": "npm run lint",
     "test": "npm run unit-test",


### PR DESCRIPTION
Quick PR to add `--cache` to the `lint` script, which should speed up linting by a few seconds.