### PR TITLE
[Refactor] improve performance for detecting class components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,9 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [Refactor] fix linter errors ([#3261][] @golopot)
 * [Docs] [`no-unused-prop-types`]: fix syntax errors ([#3259][] @mrdulin)
 * [Refactor] improve performance for detecting function components ([#3265][] @golopot)
+* [Refactor] improve performance for detecting class components ([#3267][] @golopot)
 
+[#3267]: https://github.com/yannickcr/eslint-plugin-react/pull/3267
 [#3266]: https://github.com/yannickcr/eslint-plugin-react/pull/3266
 [#3265]: https://github.com/yannickcr/eslint-plugin-react/pull/3265
 [#3261]: https://github.com/yannickcr/eslint-plugin-react/pull/3261

--- a/lib/util/Components.js
+++ b/lib/util/Components.js
@@ -259,20 +259,29 @@ function componentRule(rule, context) {
   const utils = {
 
     /**
-     * Check if the node is a React ES5 component
+     * Check if an ObjectExpression is a React ES5 component
      *
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if the node is a React ES5 component, false if not
      */
     isES5Component(node) {
-      if (!node.parent) {
+      if (!node.parent || !node.parent.callee) {
         return false;
       }
-      return new RegExp(`^(${pragma}\\.)?${createClass}$`).test(sourceCode.getText(node.parent.callee));
+      const callee = node.parent.callee;
+      // React.createClass({})
+      if (callee.type === 'MemberExpression') {
+        return callee.object.name === pragma && callee.property.name === createClass;
+      }
+      // createClass({})
+      if (callee.type === 'Identifier') {
+        return callee.name === createClass;
+      }
+      return false;
     },
 
     /**
-     * Check if the node is a React ES6 component
+     * Check if a class is a React ES6 component
      *
      * @param {ASTNode} node The AST node being checked.
      * @returns {Boolean} True if the node is a React ES6 component, false if not
@@ -285,7 +294,14 @@ function componentRule(rule, context) {
       if (!node.superClass) {
         return false;
       }
-      return new RegExp(`^(${pragma}\\.)?(Pure)?Component$`).test(sourceCode.getText(node.superClass));
+      if (node.superClass.type === 'MemberExpression') {
+        return node.superClass.object.name === pragma
+          && /^(Pure)?Component$/.test(node.superClass.property.name);
+      }
+      if (node.superClass.type === 'Identifier') {
+        return /^(Pure)?Component$/.test(node.superClass.name);
+      }
+      return false;
     },
 
     /**


### PR DESCRIPTION
Benchmark on the [eslint repo](https://github.com/eslint/eslint) with `extends: plugin:react/recommended` and `time npx eslint .` (real time):

|  | before | after |
| --- | -- | -- |
| run 1 | 8.0s | 7.3s |
| run 2 | 7.8s | 7.4s |
| run 3 | 8.0s | 7.3s |

Benchmark with `TIMING=10 npx eslint .`:

```
Before:

Rule                           | Time (ms) | Relative
:------------------------------|----------:|--------:
react/no-deprecated            |   762.467 |    21.0%
react/no-direct-mutation-state |   648.951 |    17.9%
react/display-name             |   635.527 |    17.5%
react/no-string-refs           |   531.934 |    14.7%
react/prop-types               |   387.259 |    10.7%
react/require-render-return    |   382.931 |    10.6%
react/no-children-prop         |   165.876 |     4.6%
react/jsx-no-comment-textnodes |    49.452 |     1.4%
react/no-unescaped-entities    |    19.529 |     0.5%
react/jsx-key                  |    14.197 |     0.4%

After:

Rule                           | Time (ms) | Relative
:------------------------------|----------:|--------:
react/no-deprecated            |   531.083 |    21.5%
react/no-direct-mutation-state |   466.098 |    18.8%
react/display-name             |   427.566 |    17.3%
react/no-string-refs           |   313.779 |    12.7%
react/require-render-return    |   251.905 |    10.2%
react/prop-types               |   245.300 |     9.9%
react/no-children-prop         |   141.999 |     5.7%
react/jsx-no-comment-textnodes |    39.487 |     1.6%
react/no-unescaped-entities    |    17.461 |     0.7%
react/jsx-key                  |    12.571 |     0.5%
```
