### PR TITLE
[no-constructed-context-values] Update isJsxContext check to allow for JSXIdentifier ending with Provider

### DIFF
--- a/lib/rules/jsx-no-constructed-context-values.js
+++ b/lib/rules/jsx-no-constructed-context-values.js
@@ -143,12 +143,15 @@ module.exports = {
     return {
       JSXOpeningElement(node) {
         const openingElementName = node.name;
-        if (openingElementName.type !== 'JSXMemberExpression') {
-          // Has no member
-          return;
-        }
 
-        const isJsxContext = openingElementName.property.name === 'Provider';
+        // Consider an element a context provider if the name is either:
+        // - identifier and ends with Provider (i.e. SomeContextProvider)
+        // - member expression and has Provider as a property (i.e. SomeContext.Provider)
+        const isJsxContext = (openingElementName.type === 'JSXMemberExpression'
+            && openingElementName.property.name === 'Provider')
+          || (openingElementName.type === 'JSXIdentifier'
+            && openingElementName.name.endsWith('Provider'));
+
         if (!isJsxContext) {
           // Member is not Provider
           return;

--- a/tests/lib/rules/jsx-no-constructed-context-values.js
+++ b/tests/lib/rules/jsx-no-constructed-context-values.js
@@ -34,6 +34,9 @@ ruleTester.run('react-no-constructed-context-values', rule, {
       code: '<Context.Provider value={props}></Context.Provider>',
     },
     {
+      code: '<ContextProvider value={props}></ContextProvider>',
+    },
+    {
       code: '<Context.Provider value={100}></Context.Provider>',
     },
     {
@@ -145,6 +148,20 @@ ruleTester.run('react-no-constructed-context-values', rule, {
     {
       // Invalid because object construction creates a new identity
       code: 'function Component() { const foo = {}; return (<Context.Provider value={foo}></Context.Provider>) }',
+      errors: [{
+        messageId: 'withIdentifierMsg',
+        data: {
+          variableName: 'foo',
+          type: 'object',
+          nodeLine: '1',
+          usageLine: '1',
+        },
+      }],
+    },
+    {
+      // Invalid because object construction creates a new identity
+      // Duplicate of above test but using an identifier as the context provider name
+      code: 'function Component() { const foo = {}; return (<ContextProvider value={foo}></ContextProvider>) }',
       errors: [{
         messageId: 'withIdentifierMsg',
         data: {


### PR DESCRIPTION
`jsx/no-constructed-context-values` currently only works for context providers that are used as `<Context.Provider value={..}>`

We have a lot of use cases where, instead of exporting the context directly, we explicitly export the provider as a named export.  The naming convention for this is typically `${NameOfContext}Provider`

The proposed change here is to update the `isJsxContext` check to take the above scenario into account and run the lint rule for these elements as well.  