### PR TITLE
(incomplete) new failing test, <a target="_blank noopener">

### DIFF
--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -198,6 +198,11 @@ ruleTester.run('jsx-no-target-blank', rule, {
       errors: defaultErrors,
     },
     {
+      code: '<a href="https://example.com/7a-run-on" target="_blank rel=noopener"></a>'
+      output: '<a target="_blank noopener" href="https://example.com/7a-run-on"></a>',
+      errors: [{ messageId: 'noTargetBlankIntendedIneffective' }],
+    },
+    {
       code: '<a target="_BLANK" href="https://example.com/8"></a>',
       output: '<a target="_BLANK" href="https://example.com/8" rel="noreferrer"></a>',
       errors: defaultErrors,

--- a/tests/lib/rules/jsx-no-target-blank.js
+++ b/tests/lib/rules/jsx-no-target-blank.js
@@ -198,7 +198,7 @@ ruleTester.run('jsx-no-target-blank', rule, {
       errors: defaultErrors,
     },
     {
-      code: '<a href="https://example.com/7a-run-on" target="_blank rel=noopener"></a>'
+      code: '<a href="https://example.com/7a-run-on" target="_blank rel=noopener"></a>',
       output: '<a target="_blank noopener" href="https://example.com/7a-run-on"></a>',
       errors: [{ messageId: 'noTargetBlankIntendedIneffective' }],
     },


### PR DESCRIPTION
I'm offering this pull request as a sort of feature request: that this lint rule could detect when correct code was clearly intended but it failed.

It is going to need some discussion before merging! What would you like to do?

(I confess that I have not run the new code, I don't currently have a dev environment for it and this PR is fallout from an internal code review. I'm trying to balance between what this project might need and what my work projects need ⚖️)

----

this test is derived from a real bug in a project,  
  in which the intention was to get it right  
  but the bug causes "two wrongs make a right"

this one failing test is intended to illustrate an entire class of possible failures  
  which are neither detected nor thoroughly represented

and although the apparent *intention* of the "bad" code is  
  `target="_blank"` the *effect* is not, so unless the browser DWIMs it  
  then the jsx-no-target-blank rule is technically not violated