### PR TITLE
[Improvement] Issue Template Proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees: []
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues and my issue is unique
+        required: true
+      - label: My issue appears in the command-line and not only in the text editor
+        required: true
+  - type: textarea
+    id: Code
+    attributes:
+      label: Description Overview
+      description: A clear and concise description of bug w/ examples
+      placeholder: |
+        Brief description here
+
+        Show example of your code (as text format), add images/videos/gifs to help explain example
+        and/or Link of repo to where issue is occurring
+
+        What is happening? / What is the error?
+
+        What command(s) did you run to reproduce issue?
+      value: |
+        <!--Brief description-->
+
+
+        <!--Show example of your code (as text format), add images/videos/gifs to help explain example-->
+        <!--and/or Link of repo to where issue is occurring-->
+
+
+        <!--What is happening? / What is the error?-->
+
+
+        <!--What command(s) did you run to reproduce issue?-->
+
+    validations:
+      required: true
+  - type: textarea
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: |
+        Brief description here
+
+        Show example of code (as text format), add images/videos/gifs to help explain expected behavior
+      value: |
+        <!--Brief description-->
+
+
+        <!--Show example of code (as text format), add images/videos/gifs to help explain expected behavior-->
+    validations:
+      required: true
+  - type: input
+    id: eslint-plugin-react-version
+    attributes:
+      label: `eslint-plugin-react` version
+      placeholder: v7.31.11
+    validations:
+      required: true
+  - type: input
+    id: eslint-version
+    attributes:
+      label: `eslint` version
+      placeholder: v8.28.0
+    validations:
+      required: true
+  - type: input
+    id: node-version
+    attributes:
+      label: `node` version
+      placeholder: v8.19.2
+    validations:
+      required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,13 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 ### Changed
 * [Docs] [`jsx-no-leaked-render`]: Remove mentions of empty strings for React 18 ([#3468][] @karlhorky)
 * [Docs] update `eslint-doc-generator` to v1.0.0 ([#3499][] @bmish)
+* [meta] add issue template ([#3483][] @ROSSROSALES)
 
 [#3499]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3499
 [#3494]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3494
 [#3493]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3493
 [#3488]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3488
+[#3483]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3483
 [#3474]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3474
 [#3471]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3471
 [#3468]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3468


### PR DESCRIPTION
## Issue Template for Bugs

This Proposal is to improve the overall quality of how issues are presented and solved.
Issues presented with a standardized method should:
- improve understanding of problem
  - description and example
- reduce number of unnecessary clarifying questions to ask
  - "why do this?" or "can you show me an example?" or "Have you read X?"
- makes users creating an issue think if it's an issue that has not already been solved, or if this problem has been asked / answered before
  - Users presenting an issue can rethink their issue and possibly solve their problem by going through a checklist/process of submitting an issue through a template.

### Discussion/Thoughts
When creating this template, it is important for the user to have incentive to submit an issue.
With that in mind, we want to make sure the template:

- [x] not overwhelming with too much info to fill in
- [x] is simple to understand
- [x] taken inspiration from other used issue templates
- [x] enough information is filled so that contributors aiming to solve issue would have to ask minimal questions

### Goal / Conclusion
Issues that are presented by users are issues that users have tried to debug before submitting it.
First time / New contributors / Veteran contributors have a better background to tackle the issue.
Improve community contribution and participation through reducing barrier to entry for contributors and reducing maintainer time for minor matters (ie. asking redundant questions across issues to users in different time zones, waiting days for a reply)


There is always room for improvement, please let me know if I am missing any information that may be required or removed.
Thank you!