### PR TITLE
`jsx-newline`: support for checking newline at the start and end of children

### DIFF
--- a/lib/rules/jsx-newline.js
+++ b/lib/rules/jsx-newline.js
@@ -46,6 +46,10 @@ module.exports = {
             default: false,
             type: 'boolean',
           },
+          checkStartEnd: {
+            default: false,
+            type: 'boolean',
+          },
         },
         additionalProperties: false,
         if: {


### PR DESCRIPTION
Fixes #3663