### PR TITLE
fixed the schema of jsx-no-constructed-context-values.js

### DIFF
--- a/lib/rules/jsx-no-constructed-context-values.js
+++ b/lib/rules/jsx-no-constructed-context-values.js
@@ -140,7 +140,7 @@ module.exports = {
       url: docsUrl('jsx-no-constructed-context-values'),
     },
     messages,
-    schema: undefined,
+    schema: [],
   },
 
   // eslint-disable-next-line arrow-body-style

--- a/lib/rules/jsx-no-constructed-context-values.js
+++ b/lib/rules/jsx-no-constructed-context-values.js
@@ -140,7 +140,7 @@ module.exports = {
       url: docsUrl('jsx-no-constructed-context-values'),
     },
     messages,
-    schema: false,
+    schema: undefined,
   },
 
   // eslint-disable-next-line arrow-body-style

--- a/tests/lib/rules/jsx-no-constructed-context-values.js
+++ b/tests/lib/rules/jsx-no-constructed-context-values.js
@@ -41,7 +41,6 @@ ruleTester.run('react-no-constructed-context-values', rule, {
     },
     {
       code: 'function Component() { const foo = useMemo(() => { return {} }, []); return (<Context.Provider value={foo}></Context.Provider>)}',
-      options: [{ allowArrowFunctions: true }],
     },
     {
       code: `


### PR DESCRIPTION
The schema for `jsx-no-constructed-context-values` did not seem to satisfy eslint's `Rule.RuleMetaData["schema"]` type, so I fixed it.

```ts
export namespace Rule {
    interface RuleMetaData {
...
        schema?: JSONSchema4 | JSONSchema4[] | undefined;
...
}
```