### PR TITLE
[New] create ignorePrivate option for no-multi-comp rule

### DIFF
--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -69,6 +69,10 @@ class HelloJohn extends React.Component {
 module.exports = HelloJohn;
 ```
 
+### `exportOnly`
+
+When `true` the rule will ignore components which are not exported, which allows you to define components as long as they are only used within a private scope.
+
 ## When Not To Use It
 
 If you prefer to declare multiple components per file you can disable this rule.

--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -115,7 +115,7 @@ function Hello(props) {
 function HelloAgain(props) {
   return <div>Hello again {props.name}</div>;
 }
-module.exports = {Hello, HelloAgain}
+module.exports = { Hello, HelloAgain };
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -69,7 +69,7 @@ class HelloJohn extends React.Component {
 module.exports = HelloJohn;
 ```
 
-### `ignorePrivate`
+### `ignoreInternal`
 
 When `true` the rule will ignore components which are not exported, which allows you to define components that are consumed only within the same file.
 This ensures there is only one entry point for a React component without limiting the structural content of the file.

--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -73,6 +73,51 @@ module.exports = HelloJohn;
 
 When `true` the rule will ignore components which are not exported, which allows you to define components as long as they are only used within a private scope.
 
+Examples of **correct** code for this rule:
+
+```jsx
+export function Hello(props) {
+  return <div>Hello {props.name}</div>;
+}
+function HelloAgain(props) {
+  return <div>Hello again {props.name}</div>;
+}
+```
+
+```jsx
+function Hello(props) {
+  return <div>Hello {props.name}</div>;
+}
+class HelloJohn extends React.Component {
+  render() {
+    return <Hello name="John" />;
+  }
+}
+module.exports = HelloJohn;
+```
+
+Examples of **incorrect** code for this rule:
+
+```jsx
+export function Hello(props) {
+  return <div>Hello {props.name}</div>;
+}
+export function HelloAgain(props) {
+  return <div>Hello again {props.name}</div>;
+}
+```
+
+```jsx
+function Hello(props) {
+  return <div>Hello {props.name}</div>;
+}
+function HelloAgain(props) {
+  return <div>Hello again {props.name}</div>;
+}
+module.exports = {Hello, HelloAgain}
+```
+
+
 ## When Not To Use It
 
 If you prefer to declare multiple components per file you can disable this rule.

--- a/docs/rules/no-multi-comp.md
+++ b/docs/rules/no-multi-comp.md
@@ -69,9 +69,10 @@ class HelloJohn extends React.Component {
 module.exports = HelloJohn;
 ```
 
-### `exportOnly`
+### `ignorePrivate`
 
-When `true` the rule will ignore components which are not exported, which allows you to define components as long as they are only used within a private scope.
+When `true` the rule will ignore components which are not exported, which allows you to define components that are consumed only within the same file.
+This ensures there is only one entry point for a React component without limiting the structural content of the file.
 
 Examples of **correct** code for this rule:
 
@@ -116,7 +117,6 @@ function HelloAgain(props) {
 }
 module.exports = {Hello, HelloAgain}
 ```
-
 
 ## When Not To Use It
 

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -17,6 +17,7 @@ const report = require('../util/report');
 
 const messages = {
   onlyOneComponent: 'Declare only one React component per file',
+  onlyOneExportedComponent: 'Declare only one exported React component per file',
 };
 
 /** @type {import('eslint').Rule.RuleModule} */
@@ -38,6 +39,10 @@ module.exports = {
           default: false,
           type: 'boolean',
         },
+        exportOnly: {
+          default: false,
+          type: 'boolean',
+        },
       },
       additionalProperties: false,
     }],
@@ -46,6 +51,43 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     const configuration = context.options[0] || {};
     const ignoreStateless = configuration.ignoreStateless || false;
+    const exportOnly = configuration.exportOnly || false;
+
+    const exportedComponents = new Set(); // Track exported components
+    const validIdentifiers = ['ArrowFunctionExpression', 'Identifier', 'FunctionExpression'];
+
+    /**
+     * Given an export declaration, find the export name.
+     * @param {Object} node
+     * @returns {string}
+     */
+    function getExportedComponentName(node) {
+      if (node.declaration.type === 'ClassDeclaration') {
+        return node.declaration.id.name;
+      }
+      for (const declarator of node.declaration.declarations || []) {
+        const type = declarator.init.type;
+        if (validIdentifiers.find(type)) {
+          return declarator.id.name;
+        }
+      }
+    }
+
+    /**
+     * Given a React component, find the exported name.
+     * @param {Object} component
+     * @returns {string}
+     */
+    function findComponentIdentifierFromComponent(component) {
+      let name;
+      if (component.node.parent) {
+        name = component.node.parent.id.name;
+      }
+      if (!name) {
+        name = component.node.id.name;
+      }
+      return name;
+    }
 
     /**
      * Checks if the component is ignored
@@ -61,7 +103,16 @@ module.exports = {
       );
     }
 
-    return {
+    /**
+     * Checks if the component is exported, if exportOnly is set
+     * @param {Object} component The component being checked.
+     * @returns {boolean} True if the component is exported or exportOnly is false
+     */
+    function isExported(component) {
+      return !exportOnly && exportedComponents.has(findComponentIdentifierFromComponent(component));
+    }
+
+    const rule = {
       'Program:exit'() {
         if (components.length() <= 1) {
           return;
@@ -69,13 +120,29 @@ module.exports = {
 
         values(components.list())
           .filter((component) => !isIgnored(component))
+          .filter((component) => isExported(component))
           .slice(1)
           .forEach((component) => {
-            report(context, messages.onlyOneComponent, 'onlyOneComponent', {
-              node: component.node,
-            });
+            report(context,
+              exportOnly ? messages.onlyOneExportedComponent : messages.onlyOneComponent,
+              exportOnly ? 'onlyOneExportedComponent' : 'onlyOneComponent',
+              {
+                node: component.node,
+              });
           });
       },
     };
+
+    if (exportOnly) {
+      rule.ExportNamedDeclaration = (node) => {
+        exportedComponents.add(getExportedComponentName(node));
+      };
+
+      rule.ExportDefaultDeclaration = (node) => {
+        exportedComponents.add(getExportedComponentName(node));
+      };
+    }
+
+    return rule;
   }),
 };

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -109,7 +109,7 @@ module.exports = {
      * @returns {boolean} True if the component is exported or exportOnly is false
      */
     function isExported(component) {
-      return !exportOnly && exportedComponents.has(findComponentIdentifierFromComponent(component));
+      return !exportOnly || exportedComponents.has(findComponentIdentifierFromComponent(component));
     }
 
     const rule = {

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -65,6 +65,9 @@ module.exports = {
       if (node.declaration.type === 'ClassDeclaration') {
         return node.declaration.id.name;
       }
+      if (node.declaration.type === 'Identifier') {
+        return node.declaration.name;
+      }
       if (node.declaration.declarations) {
         const declarator = node.declaration.declarations.find((declaration) => validIdentifiers.has(declaration.init.type));
         if (declarator) {
@@ -109,7 +112,7 @@ module.exports = {
      * @returns {boolean} True if the component is exported or exportOnly is false
      */
     function isPrivate(component) {
-      return ignoreInternal && exportedComponents.has(findComponentIdentifierFromComponent(component));
+      return ignoreInternal && !exportedComponents.has(findComponentIdentifierFromComponent(component));
     }
 
     const rule = {

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -65,9 +65,9 @@ module.exports = {
       if (node.declaration.type === 'ClassDeclaration') {
         return node.declaration.id.name;
       }
-      for (const declarator of node.declaration.declarations || []) {
-        const type = declarator.init.type;
-        if (validIdentifiers.has(type)) {
+      if (node.declaration.declarations) {
+        const declarator = node.declaration.declarations.find((declarator) => validIdentifiers.has(declarator.init.type));
+        if (declarator) {
           return declarator.id.name;
         }
       }

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -39,7 +39,7 @@ module.exports = {
           default: false,
           type: 'boolean',
         },
-        ignorePrivate: {
+        ignoreInternal: {
           default: false,
           type: 'boolean',
         },
@@ -51,7 +51,7 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     const configuration = context.options[0] || {};
     const ignoreStateless = configuration.ignoreStateless || false;
-    const ignorePrivate = configuration.ignorePrivate || false;
+    const ignoreInternal = configuration.ignoreInternal || false;
 
     const exportedComponents = new Set(); // Track exported components
     const validIdentifiers = new Set(['ArrowFunctionExpression', 'Identifier', 'FunctionExpression']);
@@ -109,7 +109,7 @@ module.exports = {
      * @returns {boolean} True if the component is exported or exportOnly is false
      */
     function isPrivate(component) {
-      return ignorePrivate && exportedComponents.has(findComponentIdentifierFromComponent(component));
+      return ignoreInternal && exportedComponents.has(findComponentIdentifierFromComponent(component));
     }
 
     const rule = {
@@ -123,8 +123,8 @@ module.exports = {
           .slice(1)
           .forEach((component) => {
             report(context,
-              ignorePrivate ? messages.onlyOneExportedComponent : messages.onlyOneComponent,
-              ignorePrivate ? 'onlyOneExportedComponent' : 'onlyOneComponent',
+              ignoreInternal ? messages.onlyOneExportedComponent : messages.onlyOneComponent,
+              ignoreInternal ? 'onlyOneExportedComponent' : 'onlyOneComponent',
               {
                 node: component.node,
               });
@@ -132,14 +132,15 @@ module.exports = {
       },
     };
 
-    if (ignorePrivate) {
-      rule.ExportNamedDeclaration = (node) => {
-        exportedComponents.add(getExportedComponentName(node));
-      };
-
-      rule.ExportDefaultDeclaration = (node) => {
-        exportedComponents.add(getExportedComponentName(node));
-      };
+    if (ignoreInternal) {
+      Object.assign(rule, {
+        ExportNamedDeclaration(node) {
+          exportedComponents.add(getExportedComponentName(node));
+        },
+        ExportDefaultDeclaration(node) {
+          exportedComponents.add(getExportedComponentName(node));
+        },
+      });
     }
 
     return rule;

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -39,7 +39,7 @@ module.exports = {
           default: false,
           type: 'boolean',
         },
-        exportOnly: {
+        ignorePrivate: {
           default: false,
           type: 'boolean',
         },
@@ -51,7 +51,7 @@ module.exports = {
   create: Components.detect((context, components, utils) => {
     const configuration = context.options[0] || {};
     const ignoreStateless = configuration.ignoreStateless || false;
-    const exportOnly = configuration.exportOnly || false;
+    const ignorePrivate = configuration.ignorePrivate || false;
 
     const exportedComponents = new Set(); // Track exported components
     const validIdentifiers = new Set(['ArrowFunctionExpression', 'Identifier', 'FunctionExpression']);
@@ -108,8 +108,8 @@ module.exports = {
      * @param {Object} component The component being checked.
      * @returns {boolean} True if the component is exported or exportOnly is false
      */
-    function isExported(component) {
-      return !exportOnly || exportedComponents.has(findComponentIdentifierFromComponent(component));
+    function isPrivate(component) {
+      return ignorePrivate && exportedComponents.has(findComponentIdentifierFromComponent(component));
     }
 
     const rule = {
@@ -120,12 +120,12 @@ module.exports = {
 
         values(components.list())
           .filter((component) => !isIgnored(component))
-          .filter((component) => isExported(component))
+          .filter((component) => !isPrivate(component))
           .slice(1)
           .forEach((component) => {
             report(context,
-              exportOnly ? messages.onlyOneExportedComponent : messages.onlyOneComponent,
-              exportOnly ? 'onlyOneExportedComponent' : 'onlyOneComponent',
+              ignorePrivate ? messages.onlyOneExportedComponent : messages.onlyOneComponent,
+              ignorePrivate ? 'onlyOneExportedComponent' : 'onlyOneComponent',
               {
                 node: component.node,
               });
@@ -133,7 +133,7 @@ module.exports = {
       },
     };
 
-    if (exportOnly) {
+    if (ignorePrivate) {
       rule.ExportNamedDeclaration = (node) => {
         exportedComponents.add(getExportedComponentName(node));
       };

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -66,7 +66,7 @@ module.exports = {
         return node.declaration.id.name;
       }
       if (node.declaration.declarations) {
-        const declarator = node.declaration.declarations.find((declarator) => validIdentifiers.has(declarator.init.type));
+        const declarator = node.declaration.declarations.find((declaration) => validIdentifiers.has(declaration.init.type));
         if (declarator) {
           return declarator.id.name;
         }
@@ -119,7 +119,6 @@ module.exports = {
         }
 
         values(components.list())
-          .filter((component) => !isIgnored(component))
           .filter((component) => !isIgnored(component) && !isPrivate(component))
           .slice(1)
           .forEach((component) => {

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -54,7 +54,7 @@ module.exports = {
     const exportOnly = configuration.exportOnly || false;
 
     const exportedComponents = new Set(); // Track exported components
-    const validIdentifiers = ['ArrowFunctionExpression', 'Identifier', 'FunctionExpression'];
+    const validIdentifiers = new Set(['ArrowFunctionExpression', 'Identifier', 'FunctionExpression']);
 
     /**
      * Given an export declaration, find the export name.
@@ -67,7 +67,7 @@ module.exports = {
       }
       for (const declarator of node.declaration.declarations || []) {
         const type = declarator.init.type;
-        if (validIdentifiers.find(type)) {
+        if (validIdentifiers.has(type)) {
           return declarator.id.name;
         }
       }
@@ -80,7 +80,7 @@ module.exports = {
      */
     function findComponentIdentifierFromComponent(component) {
       let name;
-      if (component.node.parent) {
+      if (component.node.parent.id) {
         name = component.node.parent.id.name;
       }
       if (!name) {

--- a/lib/rules/no-multi-comp.js
+++ b/lib/rules/no-multi-comp.js
@@ -120,7 +120,7 @@ module.exports = {
 
         values(components.list())
           .filter((component) => !isIgnored(component))
-          .filter((component) => !isPrivate(component))
+          .filter((component) => !isIgnored(component) && !isPrivate(component))
           .slice(1)
           .forEach((component) => {
             report(context,

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -265,6 +265,69 @@ ruleTester.run('no-multi-comp', rule, {
         export default MenuList
       `,
     },
+    {
+      code: `
+        const componentOne = () => <></>;
+        const componentTwo = () => <></>;
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        export const componentOne = () => <></>;
+        const componentTwo = () => <></>;
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        const componentOne = () => <></>;
+        const componentTwo = () => <></>;
+        module.exports = { componentOne };
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        const componentOne = () => <></>;
+        const componentTwo = () => <></>;
+        export default componentOne;
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        function componentOne() { return <></> };
+        const componentTwo = () => <></>;
+        export default componentOne;
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        function componentOne() { return <></> };
+        function componentTwo() { return <></> };
+        export default componentOne;
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        import React, {Component} from "react";
+        export class componentOne extends Component() { render() { return <></>; }};
+        function componentTwo() { return <></> };
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        import React, {Component} from "react";
+        class componentOne extends Component() { render() { return <></>; }};
+        function componentTwo() { return <></> };
+        export default componentOne;
+      `,
+      options: [{ exportOnly: true }],
+    },
   ]),
 
   invalid: parsers.all([
@@ -611,6 +674,69 @@ ruleTester.run('no-multi-comp', rule, {
         },
       },
       errors: [{ messageId: 'onlyOneComponent' }],
+    },
+    {
+      code: `
+        export const componentOne = () => <></>;
+        export const componentTwo = () => <></>;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        const componentOne = () => <></>;
+        const componentTwo = () => <></>;
+        module.exports = { componentOne, componentTwo };
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        const componentOne = () => <></>;
+        export const componentTwo = () => <></>;
+        export default componentOne;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        export function componentOne() { return <></> };
+        export const componentTwo = () => <></>;
+        export default componentTwo;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        function componentOne() { return <></> };
+        export function componentTwo() { return <></> };
+        export default componentOne;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React, {Component} from "react";
+        export class componentOne extends Component() { render() { return <></>; }};
+        export function componentTwo() { return <></> };
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React, {Component} from "react";
+        class componentOne extends Component() { render() { return <></>; }};
+        export function componentTwo() { return <></> };
+        export default componentOne;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
   ]),
 });

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -267,64 +267,145 @@ ruleTester.run('no-multi-comp', rule, {
     },
     {
       code: `
-        const componentOne = () => <></>;
-        const componentTwo = () => <></>;
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
       `,
       options: [{ exportOnly: true }],
     },
     {
       code: `
-        export const componentOne = () => <></>;
-        const componentTwo = () => <></>;
+        export const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
       `,
       options: [{ exportOnly: true }],
     },
     {
       code: `
-        const componentOne = () => <></>;
-        const componentTwo = () => <></>;
-        module.exports = { componentOne };
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        module.exports = { ComponentOne };
       `,
       options: [{ exportOnly: true }],
     },
     {
       code: `
-        const componentOne = () => <></>;
-        const componentTwo = () => <></>;
-        export default componentOne;
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        export default ComponentOne;
       `,
       options: [{ exportOnly: true }],
     },
     {
       code: `
-        function componentOne() { return <></> };
-        const componentTwo = () => <></>;
-        export default componentOne;
+        function ComponentOne() { return <></> };
+        const ComponentTwo = () => <></>;
+        export default ComponentOne;
       `,
       options: [{ exportOnly: true }],
     },
     {
       code: `
-        function componentOne() { return <></> };
-        function componentTwo() { return <></> };
-        export default componentOne;
-      `,
-      options: [{ exportOnly: true }],
-    },
-    {
-      code: `
-        import React, {Component} from "react";
-        export class componentOne extends Component() { render() { return <></>; }};
-        function componentTwo() { return <></> };
+        function ComponentOne() { return <></> };
+        function ComponentTwo() { return <></> };
+        export default ComponentOne;
       `,
       options: [{ exportOnly: true }],
     },
     {
       code: `
         import React, {Component} from "react";
-        class componentOne extends Component() { render() { return <></>; }};
-        function componentTwo() { return <></> };
-        export default componentOne;
+        export class ComponentOne extends Component() { render() { return <></>; }};
+        function ComponentTwo() { return <></> };
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        import React, {Component} from "react";
+        class ComponentOne extends Component() { render() { return <></>; }};
+        function ComponentTwo() { return <></> };
+        export default ComponentOne;
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        export { ComponentOne };
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        export function ComponentOne() { return <></>; }
+        function ComponentTwo() { return <></>; }
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        module.exports = ComponentOne;
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        export default function() { return <ComponentOne />; }
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        function ComponentOne() { return <></>; }
+        const ComponentTwo = () => <></>;
+        export { ComponentOne as default };
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        import React from 'react';
+        export default class ComponentOne extends React.Component {
+          render() { return <></>; }
+        }
+        class ComponentTwo extends React.Component {
+          render() { return <></>; }
+        }
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        import React from 'react';
+        class ComponentOne extends React.Component {
+          render() { return <></>; }
+        }
+        class ComponentTwo extends React.Component {
+          render() { return <></>; }
+        }
+        export { ComponentOne };
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        import React, { memo } from 'react';
+        const ComponentOne = memo(() => <></>);
+        const ComponentTwo = () => <></>;
+        export default ComponentOne;
+      `,
+      options: [{ exportOnly: true }],
+    },
+    {
+      code: `
+        import React from "react";
+        export default function Component(props) { return <div>{props.children}</div>; }
+        function ComponentTwo(props) { return <div>{props.children}</div>; }
       `,
       options: [{ exportOnly: true }],
     },
@@ -677,53 +758,44 @@ ruleTester.run('no-multi-comp', rule, {
     },
     {
       code: `
-        export const componentOne = () => <></>;
-        export const componentTwo = () => <></>;
+        export const ComponentOne = () => <></>;
+        export const ComponentTwo = () => <></>;
       `,
       options: [{ exportOnly: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
       code: `
-        const componentOne = () => <></>;
-        const componentTwo = () => <></>;
-        module.exports = { componentOne, componentTwo };
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        module.exports = { ComponentOne, ComponentTwo };
       `,
       options: [{ exportOnly: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
       code: `
-        const componentOne = () => <></>;
-        export const componentTwo = () => <></>;
-        export default componentOne;
+        const ComponentOne = () => <></>;
+        export const ComponentTwo = () => <></>;
+        export default ComponentOne;
       `,
       options: [{ exportOnly: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
       code: `
-        export function componentOne() { return <></> };
-        export const componentTwo = () => <></>;
-        export default componentTwo;
+        export function ComponentOne() { return <></> };
+        export const ComponentTwo = () => <></>;
+        export default ComponentTwo;
       `,
       options: [{ exportOnly: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
       code: `
-        function componentOne() { return <></> };
-        export function componentTwo() { return <></> };
-        export default componentOne;
-      `,
-      options: [{ exportOnly: true }],
-      errors: [{ messageId: 'onlyOneExportedComponent' }],
-    },
-    {
-      code: `
-        import React, {Component} from "react";
-        export class componentOne extends Component() { render() { return <></>; }};
-        export function componentTwo() { return <></> };
+        function ComponentOne() { return <></> };
+        export function ComponentTwo() { return <></> };
+        export default ComponentOne;
       `,
       options: [{ exportOnly: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
@@ -731,9 +803,127 @@ ruleTester.run('no-multi-comp', rule, {
     {
       code: `
         import React, {Component} from "react";
-        class componentOne extends Component() { render() { return <></>; }};
-        export function componentTwo() { return <></> };
-        export default componentOne;
+        export class ComponentOne extends Component() { render() { return <></>; }};
+        export function ComponentTwo() { return <></> };
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React, {Component} from "react";
+        class ComponentOne extends Component() { render() { return <></>; }};
+        export function ComponentTwo() { return <></> };
+        export default ComponentOne;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React, {Component} from "react";
+        class ComponentOne extends Component() { render() { return <></>; }};
+        function ComponentTwo() { return <></> };
+        export default ComponentOne;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        export { ComponentOne };
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        export function ComponentOne() { return <></>; }
+        function ComponentTwo() { return <></>; }
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        module.exports = ComponentOne;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        const ComponentOne = () => <></>;
+        const ComponentTwo = () => <></>;
+        export default function() { return <ComponentOne />; }
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        function ComponentOne() { return <></>; }
+        const ComponentTwo = () => <></>;
+        export { ComponentOne as default };
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React from 'react';
+        export default class ComponentOne extends React.Component {
+          render() { return <></>; }
+        }
+        class ComponentTwo extends React.Component {
+          render() { return <></>; }
+        }
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React from 'react';
+        class ComponentOne extends React.Component {
+          render() { return <></>; }
+        }
+        class ComponentTwo extends React.Component {
+          render() { return <></>; }
+        }
+        export { ComponentOne };
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React, { memo } from 'react';
+        const ComponentOne = memo(() => <></>);
+        const ComponentTwo = () => <></>;
+        export default ComponentOne;
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React from "react";
+        export default function Component(props) { return <div>{props.children}</div>; }
+        export function ComponentTwo(props) { return <div>{props.children}</div>; }
+      `,
+      options: [{ exportOnly: true }],
+      errors: [{ messageId: 'onlyOneExportedComponent' }],
+    },
+    {
+      code: `
+        import React from "react";
+        export function componentOne(props) { return <div>{props.children}</div>; }
+        export function ComponentOne(props) { return <div>{props.children}</div>; }
       `,
       options: [{ exportOnly: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -270,14 +270,14 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentOne = () => <></>;
         const ComponentTwo = () => <></>;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
         export const ComponentOne = () => <></>;
         const ComponentTwo = () => <></>;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -285,7 +285,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         module.exports = { ComponentOne };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -293,7 +293,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -301,7 +301,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -309,7 +309,7 @@ ruleTester.run('no-multi-comp', rule, {
         function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -317,7 +317,7 @@ ruleTester.run('no-multi-comp', rule, {
         export class ComponentOne extends Component() { render() { return <></>; }};
         function ComponentTwo() { return <></> };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -326,7 +326,7 @@ ruleTester.run('no-multi-comp', rule, {
         function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -334,14 +334,14 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export { ComponentOne };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
         export function ComponentOne() { return <></>; }
         function ComponentTwo() { return <></>; }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -349,7 +349,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         module.exports = ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -357,7 +357,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default function() { return <ComponentOne />; }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -365,7 +365,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export { ComponentOne as default };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -377,7 +377,7 @@ ruleTester.run('no-multi-comp', rule, {
           render() { return <></>; }
         }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -390,7 +390,7 @@ ruleTester.run('no-multi-comp', rule, {
         }
         export { ComponentOne };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -399,7 +399,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
     {
       code: `
@@ -407,7 +407,7 @@ ruleTester.run('no-multi-comp', rule, {
         export default function Component(props) { return <div>{props.children}</div>; }
         function ComponentTwo(props) { return <div>{props.children}</div>; }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
     },
   ]),
 
@@ -761,7 +761,7 @@ ruleTester.run('no-multi-comp', rule, {
         export const ComponentOne = () => <></>;
         export const ComponentTwo = () => <></>;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -770,7 +770,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         module.exports = { ComponentOne, ComponentTwo };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -779,7 +779,7 @@ ruleTester.run('no-multi-comp', rule, {
         export const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -788,7 +788,7 @@ ruleTester.run('no-multi-comp', rule, {
         export const ComponentTwo = () => <></>;
         export default ComponentTwo;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -797,7 +797,7 @@ ruleTester.run('no-multi-comp', rule, {
         export function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -806,7 +806,7 @@ ruleTester.run('no-multi-comp', rule, {
         export class ComponentOne extends Component() { render() { return <></>; }};
         export function ComponentTwo() { return <></> };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -816,7 +816,7 @@ ruleTester.run('no-multi-comp', rule, {
         export function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -826,7 +826,7 @@ ruleTester.run('no-multi-comp', rule, {
         function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -835,7 +835,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export { ComponentOne };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -843,7 +843,7 @@ ruleTester.run('no-multi-comp', rule, {
         export function ComponentOne() { return <></>; }
         function ComponentTwo() { return <></>; }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -852,7 +852,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         module.exports = ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -861,7 +861,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default function() { return <ComponentOne />; }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -870,7 +870,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export { ComponentOne as default };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -883,7 +883,7 @@ ruleTester.run('no-multi-comp', rule, {
           render() { return <></>; }
         }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -897,7 +897,7 @@ ruleTester.run('no-multi-comp', rule, {
         }
         export { ComponentOne };
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -907,7 +907,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -916,7 +916,7 @@ ruleTester.run('no-multi-comp', rule, {
         export default function Component(props) { return <div>{props.children}</div>; }
         export function ComponentTwo(props) { return <div>{props.children}</div>; }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -925,7 +925,7 @@ ruleTester.run('no-multi-comp', rule, {
         export function componentOne(props) { return <div>{props.children}</div>; }
         export function ComponentOne(props) { return <div>{props.children}</div>; }
       `,
-      options: [{ exportOnly: true }],
+      options: [{ ignorePrivate: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
   ]),

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -92,7 +92,7 @@ const EXPORT_TYPES_VALID = [
   (compOne, compOneName, compTwo, compTwoName) => `
     ${compOne(compOneName)}
     ${compTwo(compTwoName)}
-    export ${compOneName}`, //  export, post declaration
+    export { ${compOneName} }`, //  export, post declaration
   (compOne, compOneName, compTwo, compTwoName) => `
     ${compOne(compOneName)}
     ${compTwo(compTwoName)}
@@ -134,12 +134,16 @@ const EXPORT_TYPES_INVALID = [
     ${compOne(compOneName)}
     ${compTwo(compTwoName)}
     export default ${compOneName}
-    export ${compTwoName}`, // default export, post declaration
+    export { ${compTwoName} }`, // default export, post declaration
   (compOne, compOneName, compTwo, compTwoName) => `
     ${compOne(compOneName)}
     ${compTwo(compTwoName)}
-    export ${compOneName}
-    export ${compTwoName}`, //  export, post declaration
+    export { ${compOneName} }
+    export { ${compTwoName} }`, //  export, post declaration
+  (compOne, compOneName, compTwo, compTwoName) => `
+    ${compOne(compOneName)}
+    ${compTwo(compTwoName)}
+    export { ${compOneName}, ${compTwoName} }`, //  export, post declaration
   (compOne, compOneName, compTwo, compTwoName) => `
     ${compOne(compOneName)}
     ${compTwo(compTwoName)}

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -82,7 +82,7 @@ const EXPORT_TYPES_VALID = [
   (compOne, compOneName, compTwo, compTwoName, exportRename) => `
     ${compOne(compOneName)}
     ${compTwo(compTwoName)}
-    module.exports = { ${compOneName} as ${exportRename} }`, // module export with rename, post declaration
+    module.exports = { ${exportRename} : ${compOneName} }`, // module export with rename, post declaration
   // nb: module export at declaration time will be handled separately
   // POST DECLARATION EXPORTS
   (compOne, compOneName, compTwo, compTwoName) => `
@@ -100,7 +100,7 @@ const EXPORT_TYPES_VALID = [
   (compOne, compOneName, compTwo, compTwoName, exportRename) => `
     ${compOne(compOneName)}
     ${compTwo(compTwoName)}
-    module.exports = { ${compOneName} as ${exportRename} }`, // module export with rename, post declaration
+    module.exports = { ${exportRename} : ${compOneName} }`, // module export with rename, post declaration
   (compOne, compOneName, compTwo, compTwoName) => `
     ${compOne(compOneName)}
     ${compTwo(compTwoName)}

--- a/tests/lib/rules/no-multi-comp.js
+++ b/tests/lib/rules/no-multi-comp.js
@@ -270,14 +270,14 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentOne = () => <></>;
         const ComponentTwo = () => <></>;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
         export const ComponentOne = () => <></>;
         const ComponentTwo = () => <></>;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -285,7 +285,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         module.exports = { ComponentOne };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -293,7 +293,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -301,7 +301,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -309,7 +309,7 @@ ruleTester.run('no-multi-comp', rule, {
         function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -317,7 +317,7 @@ ruleTester.run('no-multi-comp', rule, {
         export class ComponentOne extends Component() { render() { return <></>; }};
         function ComponentTwo() { return <></> };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -326,7 +326,7 @@ ruleTester.run('no-multi-comp', rule, {
         function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -334,14 +334,14 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export { ComponentOne };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
         export function ComponentOne() { return <></>; }
         function ComponentTwo() { return <></>; }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -349,7 +349,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         module.exports = ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -357,7 +357,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default function() { return <ComponentOne />; }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -365,7 +365,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export { ComponentOne as default };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -377,7 +377,7 @@ ruleTester.run('no-multi-comp', rule, {
           render() { return <></>; }
         }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -390,7 +390,7 @@ ruleTester.run('no-multi-comp', rule, {
         }
         export { ComponentOne };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -399,7 +399,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
     {
       code: `
@@ -407,7 +407,7 @@ ruleTester.run('no-multi-comp', rule, {
         export default function Component(props) { return <div>{props.children}</div>; }
         function ComponentTwo(props) { return <div>{props.children}</div>; }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
     },
   ]),
 
@@ -761,7 +761,7 @@ ruleTester.run('no-multi-comp', rule, {
         export const ComponentOne = () => <></>;
         export const ComponentTwo = () => <></>;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -770,7 +770,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         module.exports = { ComponentOne, ComponentTwo };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -779,7 +779,7 @@ ruleTester.run('no-multi-comp', rule, {
         export const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -788,7 +788,7 @@ ruleTester.run('no-multi-comp', rule, {
         export const ComponentTwo = () => <></>;
         export default ComponentTwo;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -797,7 +797,7 @@ ruleTester.run('no-multi-comp', rule, {
         export function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -806,7 +806,7 @@ ruleTester.run('no-multi-comp', rule, {
         export class ComponentOne extends Component() { render() { return <></>; }};
         export function ComponentTwo() { return <></> };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -816,7 +816,7 @@ ruleTester.run('no-multi-comp', rule, {
         export function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -826,7 +826,7 @@ ruleTester.run('no-multi-comp', rule, {
         function ComponentTwo() { return <></> };
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -835,7 +835,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export { ComponentOne };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -843,7 +843,7 @@ ruleTester.run('no-multi-comp', rule, {
         export function ComponentOne() { return <></>; }
         function ComponentTwo() { return <></>; }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -852,7 +852,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         module.exports = ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -861,7 +861,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default function() { return <ComponentOne />; }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -870,7 +870,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export { ComponentOne as default };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -883,7 +883,7 @@ ruleTester.run('no-multi-comp', rule, {
           render() { return <></>; }
         }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -897,7 +897,7 @@ ruleTester.run('no-multi-comp', rule, {
         }
         export { ComponentOne };
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -907,7 +907,7 @@ ruleTester.run('no-multi-comp', rule, {
         const ComponentTwo = () => <></>;
         export default ComponentOne;
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -916,7 +916,7 @@ ruleTester.run('no-multi-comp', rule, {
         export default function Component(props) { return <div>{props.children}</div>; }
         export function ComponentTwo(props) { return <div>{props.children}</div>; }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
     {
@@ -925,7 +925,7 @@ ruleTester.run('no-multi-comp', rule, {
         export function componentOne(props) { return <div>{props.children}</div>; }
         export function ComponentOne(props) { return <div>{props.children}</div>; }
       `,
-      options: [{ ignorePrivate: true }],
+      options: [{ ignoreInternal: true }],
       errors: [{ messageId: 'onlyOneExportedComponent' }],
     },
   ]),


### PR DESCRIPTION
Adds a new option to no-multi-comp which ignores components that are not exported.

Currently WIP:
- Thorough testing, find edge cases. `npm test` wasn't working locally so I'm hoping to rely on CI for this.
- Comparisons between exports and React components probably needs more work. Maybe there's a pre-existing lib function for this. Maybe this functionality should be moved into lib.