### PR TITLE
Add note about not needing jsx-no-undef with TS / typescript-eslint

### DIFF
--- a/docs/rules/jsx-no-undef.md
+++ b/docs/rules/jsx-no-undef.md
@@ -58,4 +58,8 @@ module.exports = Hello;
 
 ## When Not To Use It
 
-If you are not using JSX, or if you're using [`typescript-eslint` with `no-undef`](https://typescript-eslint.io/play/#ts=5.7.2&fileType=.tsx&code=DwCQpgNhD2AEB2BDAtmAvAIgFLQBbw1gHoA%2BAbgCgg&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQHYHsBaWXAE0QDN0pFpp9pJwwBfEFoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false), then you can disable this rule.
+It's recommended to avoid this rule if your project:
+
+1. does not use JSX
+2. uses TypeScript, which [automatically enables better checks than ESLint `no-undef` rules](https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors)
+3. uses [`typescript-eslint` with `no-undef`](https://typescript-eslint.io/play/#ts=5.7.2&fileType=.tsx&code=DwCQpgNhD2AEB2BDAtmAvAIgFLQBbw1gHoA%2BAbgCgg&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQHYHsBaWXAE0QDN0pFpp9pJwwBfEFoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false)

--- a/docs/rules/jsx-no-undef.md
+++ b/docs/rules/jsx-no-undef.md
@@ -58,4 +58,4 @@ module.exports = Hello;
 
 ## When Not To Use It
 
-If you are not using JSX then you can disable this rule.
+If you are not using JSX, or if you're using [`typescript-eslint` with `no-undef`](https://typescript-eslint.io/play/#ts=5.7.2&fileType=.jsx&code=DwCQpgNhD2AEB2BDAtmAvAIgFLQBbw1gHoA%2BAbiA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQHYHsBaWXAE0QDN0pFpp9pJwwBfEFoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false), then you can disable this rule.

--- a/docs/rules/jsx-no-undef.md
+++ b/docs/rules/jsx-no-undef.md
@@ -58,4 +58,4 @@ module.exports = Hello;
 
 ## When Not To Use It
 
-If you are not using JSX, or if you're using [`typescript-eslint` with `no-undef`](https://typescript-eslint.io/play/#ts=5.7.2&fileType=.jsx&code=DwCQpgNhD2AEB2BDAtmAvAIgFLQBbw1gHoA%2BAbiA&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQHYHsBaWXAE0QDN0pFpp9pJwwBfEFoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false), then you can disable this rule.
+If you are not using JSX, or if you're using [`typescript-eslint` with `no-undef`](https://typescript-eslint.io/play/#ts=5.7.2&fileType=.tsx&code=DwCQpgNhD2AEB2BDAtmAvAIgFLQBbw1gHoA%2BAbgCgg&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQHYHsBaWXAE0QDN0pFpp9pJwwBfEFoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false), then you can disable this rule.


### PR DESCRIPTION
Hi @ljharb, hope everything is going well! 👋

Quick PR to add an additional 2 cases of when to not use `react/jsx-no-undef`

1. when using TypeScript, since it has [better checks than ESLint `no-undef` rules](https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors)
2. the `@typescript-eslint/parser` parser allows for usage of ESLint's built-in `no-undef` without `react/jsx-no-undef`:
   - https://typescript-eslint.io/play/#ts=5.7.2&fileType=.tsx&code=DwCQpgNhD2AEB2BDAtmAvAIgFLQBbw1gHoA%2BAbgCgg&eslintrc=N4KABGBEBOCuA2BTAzpAXGUEKQHYHsBaWXAE0QDN0pFpp9pJwwBfEFoA&tsconfig=N4KABGBEDGD2C2AHAlgGwKYCcDyiAuysAdgM6QBcYoEEkJemy0eAcgK6qoDCAFutAGsylBm3TgwAXxCSgA&tokens=false

   <img width="2878" height="524" alt="Screenshot 2025-08-03 at 13 56 31" src="https://github.com/user-attachments/assets/39760185-65f9-451d-9835-a0e454dae0d9" />

   This applies to:

   1. `.tsx` files (as demonstrated in the typescript-eslint Playground link)
   2. `.jsx` or `.js` files - also without `"allowJs": true` or `"checkJs": true` in `tsconfig.json`.