### PR TITLE
[New]: `jsx-no-literals`: add restrictedAttributes option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`jsx-handler-names`]: support namespaced component names ([#3943][] @takuji)
 * [`jsx-no-leaked-render`]: add `ignoreAttributes` option ([#3441][] @aleclarson)
 * [`jsx-sort-props`]: add `sortFirst` option ([#3965][] @loderunner)
+* [`jsx-no-literals`]: add `restrictedAttributes` option ([#3950][] @ushiboy)
 
 ### Fixed
 * [`no-unknown-property`]: allow `onLoad` on `body` ([#3923][] @DerekStapleton)
@@ -26,6 +27,7 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 [#3958]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3958
 [#3980]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3980
 [#3965]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3965
+[#3950]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3950
 [#3943]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3943
 [#3942]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3942
 [#3930]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3930

--- a/docs/rules/jsx-no-literals.md
+++ b/docs/rules/jsx-no-literals.md
@@ -36,6 +36,7 @@ The supported options are:
 - `allowedStrings` - An array of unique string values that would otherwise warn, but will be ignored.
 - `ignoreProps` (default: `false`) - When `true` the rule ignores literals used in props, wrapped or unwrapped.
 - `noAttributeStrings` (default: `false`) - Enforces no string literals used in attributes when set to `true`.
+- `restrictedAttributes` - An array of unique attribute names where string literals should be restricted. Only the specified attributes will be checked for string literals when this option is used. **Note**: When `noAttributeStrings` is `true`, this option is ignored at the root level.
 - `elementOverrides` - An object where the keys are the element names and the values are objects with the same options as above. This allows you to specify different options for different elements.
 
 ### `elementOverrides`

--- a/lib/rules/jsx-no-literals.js
+++ b/lib/rules/jsx-no-literals.js
@@ -51,6 +51,8 @@ const messages = {
   noStringsInJSXInElement: 'Strings not allowed in JSX files: "{{text}}" in {{element}}',
   literalNotInJSXExpression: 'Missing JSX expression container around literal string: "{{text}}"',
   literalNotInJSXExpressionInElement: 'Missing JSX expression container around literal string: "{{text}}" in {{element}}',
+  restrictedAttributeString: 'Restricted attribute string: "{{text}}" in {{attribute}}',
+  restrictedAttributeStringInElement: 'Restricted attribute string: "{{text}}" in {{attribute}} of {{element}}',
 };
 
 /** @type {Exclude<RuleModule['meta']['schema'], unknown[] | false>['properties']} */
@@ -71,6 +73,13 @@ const commonPropertiesSchema = {
   noAttributeStrings: {
     type: 'boolean',
   },
+  restrictedAttributes: {
+    type: 'array',
+    uniqueItems: true,
+    items: {
+      type: 'string',
+    },
+  },
 };
 
 // eslint-disable-next-line valid-jsdoc
@@ -88,6 +97,9 @@ function normalizeElementConfig(config) {
       : new Set(),
     ignoreProps: !!config.ignoreProps,
     noAttributeStrings: !!config.noAttributeStrings,
+    restrictedAttributes: config.restrictedAttributes
+      ? new Set(map(iterFrom(config.restrictedAttributes), trimIfString))
+      : new Set(),
   };
 }
 
@@ -478,6 +490,26 @@ module.exports = {
 
         if (isLiteralString || isStringLiteral) {
           const resolvedConfig = getOverrideConfig(node) || config;
+          const restrictedAttributes = resolvedConfig.restrictedAttributes;
+
+          if (restrictedAttributes.size > 0 && node.name && node.name.type === 'JSXIdentifier') {
+            const attributeName = node.name.name;
+
+            if (restrictedAttributes.has(attributeName)) {
+              if (!resolvedConfig.allowedStrings.has(String(trimIfString(node.value.value)))) {
+                const messageId = resolvedConfig.type === 'override' ? 'restrictedAttributeStringInElement' : 'restrictedAttributeString';
+                report(context, messages[messageId], messageId, {
+                  node,
+                  data: {
+                    text: getText(context, node.value).trim(),
+                    attribute: attributeName,
+                    element: resolvedConfig.type === 'override' && 'name' in resolvedConfig ? resolvedConfig.name : undefined,
+                  },
+                });
+              }
+              return;
+            }
+          }
 
           if (
             resolvedConfig.noStrings

--- a/tests/lib/rules/jsx-no-literals.js
+++ b/tests/lib/rules/jsx-no-literals.js
@@ -298,6 +298,35 @@ ruleTester.run('jsx-no-literals', rule, {
     },
     {
       code: `
+        <img src="image.jpg" alt="text" />
+      `,
+      options: [{ restrictedAttributes: ['className', 'id'] }],
+    },
+    {
+      code: `
+        <div className="allowed" />
+      `,
+      options: [{ restrictedAttributes: ['className'], allowedStrings: ['allowed'] }],
+    },
+    {
+      code: `
+        <div className="test" title="hello" />
+      `,
+      options: [{
+        noStrings: true,
+        ignoreProps: true,
+        restrictedAttributes: ['className'],
+        allowedStrings: ['test'],
+      }],
+    },
+    {
+      code: `
+        <div className="test" id="foo" />
+      `,
+      options: [{ restrictedAttributes: [] }],
+    },
+    {
+      code: `
         <T>foo</T>
       `,
       options: [{ elementOverrides: { T: { allowElement: true } } }],
@@ -475,6 +504,45 @@ ruleTester.run('jsx-no-literals', rule, {
         <div>{'foo'}</div>
       `,
       options: [{ elementOverrides: { div: { allowElement: true } } }],
+    },
+    {
+      code: `
+        <div>
+          <Input type="text" />
+          <Button className="primary" />
+          <Image src="photo.jpg" />
+        </div>
+      `,
+      options: [{
+        elementOverrides: {
+          Input: { restrictedAttributes: ['placeholder'] },
+          Button: { restrictedAttributes: ['type'] },
+        },
+      }],
+    },
+    {
+      code: `
+        <div title="container">
+          <Button className="btn" />
+        </div>
+      `,
+      options: [{
+        restrictedAttributes: ['className'],
+        elementOverrides: {
+          Button: { restrictedAttributes: ['disabled'] },
+        },
+      }],
+    },
+    {
+      code: `
+        <Button className="btn" />
+      `,
+      options: [{
+        noAttributeStrings: true,
+        elementOverrides: {
+          Button: { restrictedAttributes: ['type'] },
+        },
+      }],
     },
   ]),
 
@@ -847,6 +915,68 @@ ruleTester.run('jsx-no-literals', rule, {
     },
     {
       code: `
+        <div className="test" />
+      `,
+      options: [{ restrictedAttributes: ['className'] }],
+      errors: [{
+        messageId: 'restrictedAttributeString',
+        data: { text: '"test"', attribute: 'className' },
+      }],
+    },
+    {
+      code: `
+        <div className="test" id="foo" title="bar" />
+      `,
+      options: [{ restrictedAttributes: ['className', 'id'] }],
+      errors: [
+        { messageId: 'restrictedAttributeString', data: { text: '"test"', attribute: 'className' } },
+        { messageId: 'restrictedAttributeString', data: { text: '"foo"', attribute: 'id' } },
+      ],
+    },
+    {
+      code: `
+        <div src="image.jpg" />
+      `,
+      options: [{
+        noAttributeStrings: true,
+        restrictedAttributes: ['className'],
+      }],
+      errors: [{ messageId: 'noStringsInAttributes', data: { text: '"image.jpg"' } }],
+    },
+    {
+      code: `
+        <div title="text">test</div>
+      `,
+      options: [{
+        restrictedAttributes: ['title'],
+        noStrings: true,
+      }],
+      errors: [
+        { messageId: 'restrictedAttributeString', data: { text: '"text"', attribute: 'title' } },
+        { messageId: 'noStringsInJSX', data: { text: 'test' } },
+      ],
+    },
+    {
+      code: `
+        <div className="test" title="hello" />
+      `,
+      options: [{ noStrings: true, ignoreProps: false, restrictedAttributes: ['className'] }],
+      errors: [
+        { messageId: 'restrictedAttributeString', data: { text: '"test"', attribute: 'className' } },
+        { messageId: 'invalidPropValue', data: { text: 'title="hello"' } },
+      ],
+    },
+    {
+      code: `
+        <div className="test" title="hello" />
+      `,
+      options: [{ noStrings: true, ignoreProps: true, restrictedAttributes: ['className'] }],
+      errors: [
+        { messageId: 'restrictedAttributeString', data: { text: '"test"', attribute: 'className' } },
+      ],
+    },
+    {
+      code: `
         <div>
           <div>foo</div>
           <T>bar</T>
@@ -1168,6 +1298,76 @@ ruleTester.run('jsx-no-literals', rule, {
       `,
       options: [{ elementOverrides: { div: { allowElement: true } } }],
       errors: [{ messageId: 'literalNotInJSXExpression', data: { text: 'foo' } }],
+    },
+    {
+      code: `
+        <div>
+          <div type="text" />
+          <Button type="submit" />
+        </div>
+      `,
+      options: [{
+        elementOverrides: {
+          Button: { restrictedAttributes: ['type'] },
+        },
+      }],
+      errors: [
+        { messageId: 'restrictedAttributeStringInElement', data: { text: '"submit"', attribute: 'type', element: 'Button' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <Input placeholder="Enter text" type="password" />
+          <Button type="submit" disabled="true" />
+        </div>
+      `,
+      options: [{
+        elementOverrides: {
+          Input: { restrictedAttributes: ['placeholder'] },
+          Button: { restrictedAttributes: ['disabled'] },
+        },
+      }],
+      errors: [
+        { messageId: 'restrictedAttributeStringInElement', data: { text: '"Enter text"', attribute: 'placeholder', element: 'Input' } },
+        { messageId: 'restrictedAttributeStringInElement', data: { text: '"true"', attribute: 'disabled', element: 'Button' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div className="wrapper" id="main" />
+          <Button className="btn" id="submit-btn" />
+        </div>
+      `,
+      options: [{
+        restrictedAttributes: ['className'],
+        elementOverrides: {
+          Button: { restrictedAttributes: ['id'] },
+        },
+      }],
+      errors: [
+        { messageId: 'restrictedAttributeString', data: { text: '"wrapper"', attribute: 'className' } },
+        { messageId: 'restrictedAttributeStringInElement', data: { text: '"submit-btn"', attribute: 'id', element: 'Button' } },
+      ],
+    },
+    {
+      code: `
+        <div>
+          <div foo1="bar1" />
+          <T foo2="bar2" />
+        </div>
+      `,
+      options: [{
+        noAttributeStrings: true,
+        elementOverrides: {
+          T: { restrictedAttributes: ['foo2'] },
+        },
+      }],
+      errors: [
+        { messageId: 'noStringsInAttributes', data: { text: '"bar1"' } },
+        { messageId: 'restrictedAttributeStringInElement', data: { text: '"bar2"', attribute: 'foo2', element: 'T' } },
+      ],
     },
   ]),
 });

--- a/types/rules/jsx-no-literals.d.ts
+++ b/types/rules/jsx-no-literals.d.ts
@@ -3,6 +3,7 @@ type RawElementConfig = {
   allowedStrings?: string[];
   ignoreProps?: boolean;
   noAttributeStrings?: boolean;
+  restrictedAttributes?: string[];
 };
 
 type RawOverrideConfig = {
@@ -25,6 +26,7 @@ interface ElementConfigProperties {
   allowedStrings: Set<string>;
   ignoreProps: boolean;
   noAttributeStrings: boolean;
+  restrictedAttributes: Set<string>;
 }
 
 interface OverrideConfigProperties {


### PR DESCRIPTION
## Add `restrictedAttributes` option to `jsx-no-literals` rule

### Summary
This PR introduces a new `restrictedAttributes` option for the `jsx-no-literals` rule. With this option, you can enforce translation (i18n) only for certain attributes, while other attributes can still use string literals freely.  

> Note: If `noAttributeStrings: true` is also set, the root-level `restrictedAttributes` will be ignored.

This implementation addresses the main requirements discussed in issue #3003, though it takes a slightly different approach from some of the ideas mentioned there.

### Usage Examples

#### Basic usage – restrict specific attributes globally
```js
{
  "react/jsx-no-literals": [
    "error", 
    { 
      "restrictedAttributes": ["title", "alt", "aria-label", "placeholder"] 
    }
  ]
}
```

```jsx
// ❌ Error: Restricted attribute string: "Click me" in title
<button title="Click me">Save</button>

// ✅ OK: className is not in restrictedAttributes
<button className="primary">Save</button>
```

#### Component-specific restrictions
```js
{
  "react/jsx-no-literals": [
    "error",
    {
      "elementOverrides": {
        "Input": { "restrictedAttributes": ["placeholder", "aria-label"] },
        "Button": { "restrictedAttributes": ["title", "aria-label"] }
      }
    }
  ]
}
```

```jsx
// ❌ Error: Restricted attribute string: "Enter name" in placeholder of Input
<Input placeholder="Enter name" />

// ✅ OK: type is not restricted for Button component
<Button type="submit">Submit</Button>
```