### PR TITLE
[Fix] catch JSX fragments with propElementValues

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -405,13 +405,19 @@ module.exports = {
         }
       },
 
+      'JSXAttribute > JSXExpressionContainer > JSXFragment'(node) {
+        if (userConfig.propElementValues === OPTION_NEVER) {
+          reportUnnecessaryCurly(node.parent);
+        }
+      },
+
       JSXExpressionContainer(node) {
         if (shouldCheckForUnnecessaryCurly(node, userConfig)) {
           lintUnnecessaryCurly(node);
         }
       },
 
-      'JSXAttribute > JSXElement, Literal, JSXText'(node) {
+      'JSXAttribute > JSXElement, JSXAttribute > JSXFragment, Literal, JSXText'(node) {
         if (shouldCheckForMissingCurly(node, userConfig)) {
           reportMissingCurly(node);
         }

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -933,10 +933,24 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       errors: [{ messageId: 'missingCurly' }],
     },
     {
+      code: `<App horror=<><div /></> />`,
+      options: [{ props: 'always', children: 'always', propElementValues: 'always' }],
+      features: ['no-ts'],
+      output: `<App horror={<><div /></>} />`,
+      errors: [{ messageId: 'missingCurly' }],
+    },
+    {
       code: `<App horror={<div />} />`,
       options: [{ props: 'never', children: 'never', propElementValues: 'never' }],
       features: ['no-ts'],
       output: `<App horror=<div /> />`,
+      errors: [{ messageId: 'unnecessaryCurly' }],
+    },
+    {
+      code: `<App horror={<><div /></>} />`,
+      options: [{ props: 'never', children: 'never', propElementValues: 'never' }],
+      features: ['no-ts'],
+      output: `<App horror=<><div /></> />`,
       errors: [{ messageId: 'unnecessaryCurly' }],
     },
     {


### PR DESCRIPTION
Bug report: #3951 

This proposed fix treats JSX fragments like JSX elements when handling the `propElementValues` option:
* It checks for unnecessary curly brackets in JSX fragments just like it does in JSX elements
* It considers JSX fragment when checking and reporting missing curly brackets

Let me know what you think, happy to update the code with any suggestions you have! 
