### PR TITLE
Update types and RuleContext deprecations

### DIFF
--- a/lib/rules/jsx-filename-extension.js
+++ b/lib/rules/jsx-filename-extension.js
@@ -61,7 +61,7 @@ module.exports = {
   },
 
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename;
 
     let jsxNode;
 

--- a/lib/util/version.js
+++ b/lib/util/version.js
@@ -28,7 +28,7 @@ function resetDetectedVersion() {
 
 function resolveBasedir(contextOrFilename) {
   if (contextOrFilename) {
-    const filename = typeof contextOrFilename === 'string' ? contextOrFilename : contextOrFilename.getFilename();
+    const filename = typeof contextOrFilename === 'string' ? contextOrFilename : contextOrFilename.filename;
     const dirname = path.dirname(filename);
     try {
       if (fs.statSync(filename).isFile()) {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@babel/plugin-syntax-do-expressions": "^7.27.1",
     "@babel/plugin-syntax-function-bind": "^7.27.1",
     "@babel/preset-react": "^7.27.1",
-    "@types/eslint": "=7.2.10",
+    "@types/eslint": "=8.56.12",
     "@types/estree": "0.0.52",
     "@types/node": "^4.9.5",
     "@typescript-eslint/parser": "^2.34.0 || ^3.10.1 || ^4 || ^5 || ^6.20 || ^7.14.1 || 8.4 - 8.17",


### PR DESCRIPTION
## Summary

On `RuleContext` objects, use the `filename` property instead of the deprecated `getFilename()` method. That method was marked as deprecated in ESLint v8 and is removed in ESLint v10.

## Motivation

I'm preparing a company project for ESLint v10, and I get an error that `eslint-plugin-react` uses a method that doesn't exist on the `RuleContext` object.

(Hello, this is my first PR on this repo. I hope to be helpful and respectful.)