### PR TITLE
[Docs] `no-array-index-key`: add template literal examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This change log adheres to standards from [Keep a CHANGELOG](https://keepachange
 * [`no-unknown-property`]: allow `onLoad` on `body` ([#3923][] @DerekStapleton)
 * [`no-unknown-property`]: allow `closedby` on `dialog` ([#3980][] @ljharb)
 
+### Changed
+* [Docs] [`no-array-index-key`]: add template literal examples ([#3978][] @akahoshi1421)
+
+[#3978]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3978
 [#3980]: https://github.com/jsx-eslint/eslint-plugin-react/issues/3980
 [#3930]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3930
 [#3923]: https://github.com/jsx-eslint/eslint-plugin-react/pull/3923

--- a/docs/rules/no-array-index-key.md
+++ b/docs/rules/no-array-index-key.md
@@ -20,7 +20,15 @@ things.map((thing, index) => (
 ));
 
 things.map((thing, index) => (
+  <Hello key={`hello-${index}`} />
+));
+
+things.map((thing, index) => (
   React.cloneElement(thing, { key: index })
+));
+
+things.map((thing, index) => (
+  React.cloneElement(thing, { key: `hello-${index}` })
 ));
 
 things.forEach((thing, index) => {
@@ -76,7 +84,15 @@ things.map((thing) => (
 ));
 
 things.map((thing) => (
+  <Hello key={`hello-${thing.id}`} />
+));
+
+things.map((thing) => (
   React.cloneElement(thing, { key: thing.id })
+));
+
+things.map((thing) => (
+  React.cloneElement(thing, { key: `hello-${thing.id}` })
 ));
 
 things.forEach((thing) => {


### PR DESCRIPTION
Added examples for cases where array index is used inside template literals.                                                                                                               
                                                                                                                                                                                             
  The current documentation only shows examples like `key={index}`, but using index inside template literals such as `` key={`prefix-${index}`} `` is also subject to this rule. This change
makes it clear.