### PR TITLE
Update minimatch to safe version

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "estraverse": "^5.3.0",
     "hasown": "^2.0.2",
     "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-    "minimatch": "^3.1.2",
+    "minimatch": "^3.1.4",
     "object.entries": "^1.1.9",
     "object.fromentries": "^2.0.8",
     "object.values": "^1.2.1",


### PR DESCRIPTION
As outlined [here](https://github.com/jsx-eslint/eslint-plugin-react/issues/3987), the previously used version of minimatch has a ReDoS vulnerability. This has been patched in v3.1.4.

Other unpatched versions of minimatch are used in a number of dev dependencies, but not in production. `npm run posttest` passes with 0 vulnerabilites after upgrading to minimatch 3.1.4.