### PR TITLE
[Fix] bump `minimatch` so `npm audit --production` is happy

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "estraverse": "^5.3.0",
     "hasown": "^2.0.2",
     "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-    "minimatch": "^3.1.2",
+    "minimatch": "^3.1.5",
     "object.entries": "^1.1.9",
     "object.fromentries": "^2.0.8",
     "object.values": "^1.2.1",


### PR DESCRIPTION
https://github.com/jsx-eslint/eslint-plugin-react/pull/3979 appears to be blocked on [the posttest CI failing `npm audit`](https://github.com/jsx-eslint/eslint-plugin-react/actions/runs/22256080582/job/64387128028?pr=3979) due to recent ReDoSes in minimatch.

<details><summary>Screenshot of failing CI in case it gets cleaned by GHA</summary>
<img width="1067" height="465" alt="Screenshot 2026-03-04 at 10 54 23" src="https://github.com/user-attachments/assets/8aee5db7-7fe0-47bd-8bf8-bbe89e7322c8" />
</details> 

This adjusts the minimum bound of minimatch to 3.1.5.

Diff: https://github.com/isaacs/minimatch/compare/v3.1.2..v3.1.5