### PR TITLE
fix(jsx-curly-brace-presence): do not flag empty string literals in JSX children

### DIFF
--- a/lib/rules/jsx-curly-brace-presence.js
+++ b/lib/rules/jsx-curly-brace-presence.js
@@ -369,6 +369,17 @@ module.exports = {
         return false;
       }
 
+      // Don't flag empty string literals in JSX children — removing them changes
+      // the JSX tree and can affect whitespace rendering (autofixes must be safe).
+      if (
+        jsxUtil.isJSX(parent)
+        && node.expression
+        && node.expression.type === 'Literal'
+        && node.expression.value === ''
+      ) {
+        return false;
+      }
+
       return areRuleConditionsSatisfied(parent, config, OPTION_NEVER);
     }
 

--- a/tests/lib/rules/jsx-curly-brace-presence.js
+++ b/tests/lib/rules/jsx-curly-brace-presence.js
@@ -76,6 +76,33 @@ ruleTester.run('jsx-curly-brace-presence', rule, {
       code: '<App>{\'        \'}</App>',
       options: [{ children: 'always' }],
     },
+    /*
+     * Empty string expressions in JSX children must not be flagged:
+     * removing {""} changes the JSX tree and can affect whitespace rendering.
+     * Autofixes must not introduce semantic changes.
+     */
+    {
+      code: '<App>{""}</App>',
+    },
+    {
+      code: "<App>{''}</App>",
+    },
+    {
+      code: '<App>{""}</App>',
+      options: [{ children: 'never' }],
+    },
+    {
+      code: "<App>{''}</App>",
+      options: [{ children: 'never' }],
+    },
+    {
+      code: '<App>foo{""}</App>',
+      options: [{ children: 'never' }],
+    },
+    {
+      code: '<App>{""}foo</App>',
+      options: [{ children: 'never' }],
+    },
     {
       code: '<App {...props}>foo</App>',
       options: [{ props: 'always' }],


### PR DESCRIPTION
When `{""}` or `{''}` appears in JSX children and the `children` option is set to `never`, the rule reports it as an unnecessary curly brace and auto-fixes it by removing the expression entirely. This changes the JSX tree — an empty string literal in children is a distinct node from no node — and autofixes should never introduce semantic changes.

This fix adds a guard in `shouldCheckForUnnecessaryCurly` to skip empty string literals when their parent is a JSX element (children context). The behavior for props is unchanged: `bar={""}` is still flagged and correctly auto-fixed to `bar=""`, since both forms pass an identical empty string to the prop.

Fixes #3995