### PR TITLE
Update minimatch version to 10.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "estraverse": "^5.3.0",
     "hasown": "^2.0.2",
     "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-    "minimatch": "^3.1.2",
+    "minimatch": "10.2.4",
     "object.entries": "^1.1.9",
     "object.fromentries": "^2.0.8",
     "object.values": "^1.2.1",


### PR DESCRIPTION
According to CVE-2026-27904, minimatch older versions (maybe at build time), minimatch has a high vulnerability and the recent builds and versions are still behind

reference link: https://github.com/advisories/GHSA-23c5-xmqv-rm74