### PR TITLE
Quality: Locale-sensitive lowercasing can break module detection

### DIFF
--- a/lib/util/isDestructuredFromPragmaImport.js
+++ b/lib/util/isDestructuredFromPragmaImport.js
@@ -58,7 +58,7 @@ module.exports = function isDestructuredFromPragmaImport(context, node, variable
           && requireExpression.callee
           && requireExpression.callee.name === 'require'
           && requireExpression.arguments[0]
-          && requireExpression.arguments[0].value === pragma.toLocaleLowerCase()
+          && requireExpression.arguments[0].value === pragma.toLowerCase()
         ) {
           return true;
         }
@@ -70,7 +70,7 @@ module.exports = function isDestructuredFromPragmaImport(context, node, variable
       if (
         latestDef.parent
         && latestDef.parent.type === 'ImportDeclaration'
-        && latestDef.parent.source.value === pragma.toLocaleLowerCase()
+        && latestDef.parent.source.value === pragma.toLowerCase()
       ) {
         return true;
       }


### PR DESCRIPTION
## Problem

The rule checks `require()`/`import` source names using `pragma.toLocaleLowerCase()`. Locale-sensitive casing can produce incorrect results in some locales (for example Turkish casing), causing false negatives/positives when resolving React pragma imports.

**Severity**: `medium`
**File**: `lib/util/isDestructuredFromPragmaImport.js`

## Solution

Replace `toLocaleLowerCase()` with `toLowerCase()` for stable, locale-independent module name normalization.

## Changes

- `lib/util/isDestructuredFromPragmaImport.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
