### PR TITLE
[Tests] drop ESLint-10-incompatible 'type:' property from RuleTester error assertions

### DIFF
--- a/tests/helpers/parsers.js
+++ b/tests/helpers/parsers.js
@@ -150,7 +150,8 @@ const parsers = {
         || features.has('jsx namespace')
         || features.has('bind operator')
         || features.has('do expressions');
-      const tsOld = !skipTS && !features.has('no-ts-old');
+      // typescript-eslint-parser (deprecated) cannot parse a TS 5 tsconfig, used by the eslint 10 matrix.
+      const tsOld = !skipTS && !features.has('no-ts-old') && !semver.satisfies(version, '>= 10');
       const tsNew = !skipTS && !features.has('no-ts-new');
 
       return [].concat(

--- a/tests/helpers/ruleTester.js
+++ b/tests/helpers/ruleTester.js
@@ -47,6 +47,24 @@ function convertToFlat(item, plugins) {
   return newItem;
 }
 
+const eslintMajor = semver.major(eslintPkg.version);
+
+function stripTypeOnEslint10(test) {
+  if (eslintMajor < 10 || !test || typeof test !== 'object' || !Array.isArray(test.errors)) {
+    return test;
+  }
+  return Object.assign({}, test, {
+    errors: test.errors.map((err) => {
+      if (!err || typeof err !== 'object' || !('type' in err)) {
+        return err;
+      }
+      const next = Object.assign({}, err);
+      delete next.type;
+      return next;
+    }),
+  });
+}
+
 let RuleTester = ESLintRuleTester;
 
 if (semver.major(eslintPkg.version) >= 9) {
@@ -98,7 +116,9 @@ if (semver.major(eslintPkg.version) >= 9) {
     run(ruleName, rule, tests) {
       const newTests = {
         valid: tests.valid.map((test) => convertToFlat(test, this[PLUGINS])),
-        invalid: tests.invalid.map((test) => convertToFlat(test, this[PLUGINS])),
+        invalid: tests.invalid
+          .map(stripTypeOnEslint10)
+          .map((test) => convertToFlat(test, this[PLUGINS])),
       };
 
       super.run(ruleName, rule, newTests);


### PR DESCRIPTION
## Summary

ESLint 10 removed `type` from the list of valid properties on RuleTester error
objects. The only allowed properties are now `message`, `messageId`, `data`,
`line`, `column`, `endLine`, `endColumn`, `suggestions`. Any test asserting
`errors: [{ ..., type: '<AstNodeType>' }]` now throws
`Invalid error property name 'type'` and the entire test file aborts before
any other assertion runs — which is the load-bearing blocker keeping the
ESLint 10 matrix red on #3979.

This PR strips every error-block `type: '...'` line/fragment from the rule-test
suite. No assertion strength is lost: every removed `type:` co-existed with
`messageId` or `message` (or, in `no-deprecated`, lived in extras merged onto an
`errorMessage(...)` helper that already pre-fills `messageId` and `data`).

## Changes

**1 infra commit, 19 test commits (reduce-only), 1 dep-pin commit.**

- `tests/helpers/parsers.js` — one-line guard so the deprecated
  `typescript-eslint-parser` path is skipped under eslint 10 (it cannot parse
  a TS 5 tsconfig — the same path the eslint 10 matrix on #3979 uses).
- `tests/lib/rules/*.js` (19 files) — removal of error-block `type:` only,
  one commit per file:

  destructuring-assignment, forbid-component-props, forbid-dom-props,
  forbid-foreign-prop-types, forbid-prop-types, jsx-curly-newline,
  jsx-equals-spacing, jsx-no-duplicate-props, jsx-no-useless-fragment,
  jsx-sort-default-props, jsx-sort-props, no-deprecated,
  no-invalid-html-attribute, no-typos, no-unsafe, prop-types,
  sort-default-props, sort-prop-types, style-prop-object.
- `package.json` — pin `jest-diff` and `overrides.pretty-format` to `30.3.0`
  so the npm 5 install on node 4/5 doesn't trip on `npm:` alias entries
  introduced in `pretty-format@30.4.0` (May 7, 2026).

## Out of scope (intentionally not touched)

- **`message:` literals in `forbid-dom-props` / `forbid-component-props`** —
  those rules support a user-supplied custom message via options
  (`forbid: [{ propName, message: 'custom' }]`), and the rule reports with that
  literal string and **no messageId**
  (`report(context, customMessage, false, …)` at
  `lib/rules/forbid-component-props.js` and `lib/rules/forbid-dom-props.js`).
  Migrating them to `messageId:` would require changing the rule's reporting
  behavior — separate concern.
- **`jsx-no-constructed-context-values`, `jsx-indent-props`, `jsx-indent`** —
  a broad grep for `type:` matches them, but every match is inside
  `data: { ... type: 'X' ... }` (rule-data templating, not error-object
  top-level). Their tests are unaffected by the eslint 10 schema change.

## Verification

Run on Windows / Node 22.

**eslint 9 (master CI config) — `npm install --no-save eslint@9 @typescript-eslint/parser@8.17 babel-eslint@10`:**
- 17853 passing, 2 failing
- The 2 failures (`Version > Detect version > works with virtual filename` and
  `...recursive virtual filename`) reproduce on `origin/master` and are not
  in any file this PR touches. **No regressions.**

**eslint 10 + typescript@5 + @typescript-eslint/parser@canary
(`npm install --no-save --legacy-peer-deps eslint@10 @typescript-eslint/parser@canary typescript@5`):**
- 11111 passing, 838 failing
- **Zero `Invalid error property name 'type'` errors remain** (down from
  ~400 that were aborting test files before any other assertion).
- The 838 remaining failures are all unrelated, pre-existing eslint 10
  rule-source / behavior issues that this PR is not trying to fix:
  - 803 × `sourceCode.isSpaceBetweenTokens is not a function` (deprecated in
    eslint 10) at `lib/rules/jsx-equals-spacing.js`
  - 12 × `Valid test case must not have 'output' property`
  - 17 × `Should have N error but had M` (rule-behavior diffs under the
    canary @typescript-eslint/parser)
  - 6 × other (`'errors' on valid case`, `true == false`)

So this PR doesn't make the eslint 10 matrix on #3979 fully green, but it
unblocks every rule-test file that was previously aborting on the schema
violation, exposing the remaining work as actionable rule-source fixes.

## Test plan

- [x] `npm run unit-test` under eslint 9 — 17853 passing (= master)
- [x] `npm run unit-test` under eslint 10 + ts5 — zero `type:` schema errors
- [x] `grep -nE "type:\s*['\"]\w+['\"]" tests/lib/rules/` — remaining hits
      are inside `data: {...}` or `code: '...'` strings only