### PR TITLE
[Tests] fix CI install failures in `after_install` step

### DIFF
--- a/.github/workflows/eslint-8-.yml
+++ b/.github/workflows/eslint-8-.yml
@@ -92,6 +92,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: strip eslint-doc-generator to avoid peer conflicts
+        if: ${{ matrix.typescript-eslint >= 6 }}
+        run: echo "$(jq 'del(.devDependencies["eslint-doc-generator"])' package.json)" > package.json
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:

--- a/.github/workflows/node-minors.yml
+++ b/.github/workflows/node-minors.yml
@@ -95,6 +95,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: strip eslint-doc-generator to avoid peer conflicts
+        if: ${{ matrix.node-version < 6 || (matrix.node-version >= 16 && matrix.eslint >= 7) }}
+        run: echo "$(jq 'del(.devDependencies["eslint-doc-generator"])' package.json)" > package.json
       - uses: ljharb/actions/node/install@main
         name: 'nvm install ${{ matrix.node-version }} && npm install'
         with:


### PR DESCRIPTION
Strip `eslint-doc-generator` from `package.json` before install where it causes peer dependency conflicts. It is only used for doc generation, not for running tests.

On Node < 6, its transitive dependency `pretty-format@30.4.0` introduced `npm:` aliases unsupported by npm 5. On Node 16+ with strict peer resolution, its `eslint >= 8.57.1` peer dep conflicts with the `eslint@7` installed by `after_install`, causing npm's ERESOLVE diagnostic printer to intermittently crash.

Fixes #4007