### PR TITLE
Fix jsx-sort-props autofix with trailing line comments

### DIFF
--- a/lib/rules/jsx-sort-props.js
+++ b/lib/rules/jsx-sort-props.js
@@ -220,7 +220,7 @@ function getGroupsOfSortableAttributes(attributes, context) {
             } else if (firstComment.type === 'Block') {
               attributeMap.set(attribute, { end: firstComment.range[1], hasComment: true });
             } else {
-              attributeMap.set(attribute, { end: firstComment.range[1], hasComment: false });
+              attributeMap.set(attribute, { end: firstComment.range[1], hasComment: false, hasTrailingLineComment: true });
             }
             addtoSortableAttributeGroups(attribute);
           }
@@ -274,6 +274,16 @@ function generateFixerFunction(node, context, reservedList) {
   const sortedAttributeGroups = sortableAttributeGroups
     .slice(0)
     .map((group) => toSorted(group, (a, b) => contextCompare(a, b, options)));
+  const hasUnsafeTrailingLineCommentFix = sortableAttributeGroups.some(
+    (sortableGroup, groupIndex) => sortableGroup.some((attribute, attributeIndex) => {
+      const sortedAttribute = sortedAttributeGroups[groupIndex][attributeIndex];
+      const attr = attributeMap.get(sortedAttribute);
+      return attr && attr.hasTrailingLineComment && attribute.loc.end.line === node.loc.end.line;
+    })
+  );
+  if (hasUnsafeTrailingLineCommentFix) {
+    return null;
+  }
 
   return function fixFunction(fixer) {
     const fixers = [];
@@ -364,10 +374,15 @@ function reportNodeAttribute(nodeAttribute, errorType, node, context, reservedLi
 
   reportedNodeAttributes.set(nodeAttribute, errors);
 
-  report(context, messages[errorType], errorType, {
+  const fix = generateFixerFunction(node, context, reservedList);
+  const reportConfig = {
     node: nodeAttribute.name,
-    fix: generateFixerFunction(node, context, reservedList),
-  });
+  };
+  if (fix) {
+    reportConfig.fix = fix;
+  }
+
+  report(context, messages[errorType], errorType, reportConfig);
 }
 
 /** @type {import('eslint').Rule.RuleModule} */

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -1131,7 +1131,31 @@ ruleTester.run('jsx-sort-props', rule, {
       code: `
         <div
           onClick={() => console.log()} // Comment
-          className="flex">
+          className="flex"
+        >
+          <span>Problematic Component</span>
+        </div>
+      `,
+      output: `
+        <div
+          className="flex"
+          onClick={() => console.log()} // Comment
+        >
+          <span>Problematic Component</span>
+        </div>
+      `,
+      errors: [
+        {
+          messageId: 'sortPropsByAlpha',
+          line: 4,
+        },
+      ],
+    } : [],
+    semver.satisfies(eslintPkg.version, '> 3') ? {
+      code: `
+        <div
+          onClick={() => console.log()} // Comment
+          id="root">
           <span>Problematic Component</span>
         </div>
       `,

--- a/tests/lib/rules/jsx-sort-props.js
+++ b/tests/lib/rules/jsx-sort-props.js
@@ -1127,6 +1127,22 @@ ruleTester.run('jsx-sort-props', rule, {
         },
       ],
     } : [],
+    semver.satisfies(eslintPkg.version, '> 3') ? {
+      code: `
+        <div
+          onClick={() => console.log()} // Comment
+          className="flex">
+          <span>Problematic Component</span>
+        </div>
+      `,
+      output: null,
+      errors: [
+        {
+          messageId: 'sortPropsByAlpha',
+          line: 4,
+        },
+      ],
+    } : [],
     {
       code: `
         <Page


### PR DESCRIPTION
## Summary

Fixes an unsafe autofix in `jsx-sort-props` when a JSX prop has a trailing line comment.

## What changed

- Added a regression test for a prop followed by an inline `//` comment.
- Kept the lint report, but skipped autofix when sorting that prop would produce invalid JSX.

## Why

Issue #3936 reports that sorting a prop with a trailing line comment can move JSX syntax after the comment, producing invalid output.

## Testing

- `./node_modules/.bin/mocha tests/lib/rules/jsx-sort-props.js --grep "Comment"`
- `./node_modules/.bin/mocha tests/lib/rules/jsx-sort-props.js`
- `npm run lint`
- `npm run unit-test`
- `npm test`

Fixes #3936